### PR TITLE
Light Generation

### DIFF
--- a/steel-core/src/chunk/chunk_generator.rs
+++ b/steel-core/src/chunk/chunk_generator.rs
@@ -2,6 +2,27 @@
 
 use crate::chunk::chunk_access::ChunkAccess;
 use enum_dispatch::enum_dispatch;
+use std::sync::Arc;
+
+/// A guard that provides access to a chunk.
+/// This is a wrapper around arc_swap::Guard to provide a more ergonomic API.
+pub struct ChunkGuard(pub Arc<ChunkAccess>);
+
+impl std::ops::Deref for ChunkGuard {
+    type Target = ChunkAccess;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl ChunkGuard {
+    /// Creates a new ChunkGuard from an arc_swap Guard
+    pub fn new(guard: arc_swap::Guard<Option<Arc<ChunkAccess>>>) -> Self {
+        let chunk = guard.as_ref().expect("Chunk should be Some").clone();
+        Self(chunk)
+    }
+}
 
 /// A trait for generating chunks.
 #[enum_dispatch]

--- a/steel-core/src/chunk/chunk_generator.rs
+++ b/steel-core/src/chunk/chunk_generator.rs
@@ -5,7 +5,6 @@ use enum_dispatch::enum_dispatch;
 use std::sync::Arc;
 
 /// A guard that provides access to a chunk.
-/// This is a wrapper around arc_swap::Guard to provide a more ergonomic API.
 pub struct ChunkGuard(pub Arc<ChunkAccess>);
 
 impl std::ops::Deref for ChunkGuard {
@@ -17,7 +16,11 @@ impl std::ops::Deref for ChunkGuard {
 }
 
 impl ChunkGuard {
-    /// Creates a new ChunkGuard from an arc_swap Guard
+    /// Creates a new `ChunkGuard` from an `arc_swap` Guard
+    ///
+    /// # Panics
+    /// This panics if chunk is None.
+    #[must_use]
     pub fn new(guard: arc_swap::Guard<Option<Arc<ChunkAccess>>>) -> Self {
         let chunk = guard.as_ref().expect("Chunk should be Some").clone();
         Self(chunk)

--- a/steel-core/src/chunk/chunk_holder.rs
+++ b/steel-core/src/chunk/chunk_holder.rs
@@ -381,7 +381,8 @@ impl ChunkHolder {
         let min_section_y = -4; // -64 / 16
         let section_index = (section_y - min_section_y) as u32;
 
-        if section_index < 32 { // u32 has 32 bits (more than enough for 26 sections)
+        if section_index < 32 {
+            // u32 has 32 bits (more than enough for 26 sections)
             let bit_mask = 1u32 << section_index;
             let sections = if is_sky_light {
                 &self.sky_changed_sections
@@ -405,8 +406,13 @@ impl ChunkHolder {
     ///
     /// # Returns
     /// `true` if the section was newly marked (wasn't already marked), `false` otherwise
-    pub fn mark_light_storage_section_changed(&self, storage_index: u32, is_sky_light: bool) -> bool {
-        if storage_index < 32 { // u32 has 32 bits (more than enough for 26 sections)
+    pub fn mark_light_storage_section_changed(
+        &self,
+        storage_index: u32,
+        is_sky_light: bool,
+    ) -> bool {
+        if storage_index < 32 {
+            // u32 has 32 bits (more than enough for 26 sections)
             let bit_mask = 1u32 << storage_index;
             let sections = if is_sky_light {
                 &self.sky_changed_sections

--- a/steel-core/src/chunk/chunk_map.rs
+++ b/steel-core/src/chunk/chunk_map.rs
@@ -69,7 +69,7 @@ impl ChunkMap {
                     registry.blocks.get_default_state_id(vanilla_blocks::BEDROCK), // Bedrock
                     registry.blocks.get_default_state_id(vanilla_blocks::DIRT), // Dirt
                     registry.blocks.get_default_state_id(vanilla_blocks::GRASS_BLOCK), // Grass Block
-                    registry.blocks.get_default_state_id(vanilla_blocks::TORCH)
+                    registry.blocks.get_default_state_id(vanilla_blocks::TORCH),
                 ))),
                 light_engine: Arc::new(ThreadedLevelLightEngine::new(registry.blocks.clone())),
                 runtime_handle: chunk_runtime.handle().clone(),

--- a/steel-core/src/chunk/chunk_map.rs
+++ b/steel-core/src/chunk/chunk_map.rs
@@ -68,8 +68,10 @@ impl ChunkMap {
                 generator: Arc::new(ChunkGeneratorType::Flat(FlatChunkGenerator::new(
                     registry.blocks.get_default_state_id(vanilla_blocks::BEDROCK), // Bedrock
                     registry.blocks.get_default_state_id(vanilla_blocks::DIRT), // Dirt
-                    registry.blocks.get_default_state_id(vanilla_blocks::GRASS_BLOCK), // Grass Block
-                    registry.blocks.get_default_state_id(vanilla_blocks::TORCH),
+                    registry
+                        .blocks
+                        .get_default_state_id(vanilla_blocks::GRASS_BLOCK), // Grass Block
+                    registry.blocks.get_default_state_id(vanilla_blocks::TORCH), // Torch
                 ))),
                 light_engine: Arc::new(ThreadedLevelLightEngine::new(registry.blocks.clone())),
                 runtime_handle: chunk_runtime.handle().clone(),

--- a/steel-core/src/chunk/chunk_map.rs
+++ b/steel-core/src/chunk/chunk_map.rs
@@ -15,6 +15,7 @@ use crate::chunk::chunk_holder::ChunkHolder;
 use crate::chunk::chunk_ticket_manager::{
     ChunkTicketManager, LevelChange, MAX_VIEW_DISTANCE, is_full,
 };
+use crate::chunk::light_engine::ThreadedLevelLightEngine;
 use crate::chunk::player_chunk_view::PlayerChunkView;
 use crate::chunk::world_gen_context::ChunkGeneratorType;
 use crate::chunk::{
@@ -70,7 +71,7 @@ impl ChunkMap {
                     registry.blocks.get_default_state_id(vanilla_blocks::GRASS_BLOCK), // Grass Block
                     registry.blocks.get_default_state_id(vanilla_blocks::TORCH)
                 ))),
-                light_engine: Arc::new(crate::chunk::light_engine::ThreadedLevelLightEngine::new()),
+                light_engine: Arc::new(ThreadedLevelLightEngine::new(registry.blocks.clone())),
             }),
             thread_pool: Arc::new(ThreadPoolBuilder::new().build().unwrap()),
             chunk_runtime,

--- a/steel-core/src/chunk/chunk_map.rs
+++ b/steel-core/src/chunk/chunk_map.rs
@@ -66,7 +66,9 @@ impl ChunkMap {
             chunk_tickets: SyncMutex::new(ChunkTicketManager::new()),
             world_gen_context: Arc::new(WorldGenContext {
                 generator: Arc::new(ChunkGeneratorType::Flat(FlatChunkGenerator::new(
-                    registry.blocks.get_default_state_id(vanilla_blocks::BEDROCK), // Bedrock
+                    registry
+                        .blocks
+                        .get_default_state_id(vanilla_blocks::BEDROCK), // Bedrock
                     registry.blocks.get_default_state_id(vanilla_blocks::DIRT), // Dirt
                     registry
                         .blocks

--- a/steel-core/src/chunk/chunk_map.rs
+++ b/steel-core/src/chunk/chunk_map.rs
@@ -65,13 +65,10 @@ impl ChunkMap {
             chunk_tickets: SyncMutex::new(ChunkTicketManager::new()),
             world_gen_context: Arc::new(WorldGenContext {
                 generator: Arc::new(ChunkGeneratorType::Flat(FlatChunkGenerator::new(
-                    registry
-                        .blocks
-                        .get_default_state_id(vanilla_blocks::BEDROCK), // Bedrock
+                    registry.blocks.get_default_state_id(vanilla_blocks::BEDROCK), // Bedrock
                     registry.blocks.get_default_state_id(vanilla_blocks::DIRT), // Dirt
-                    registry
-                        .blocks
-                        .get_default_state_id(vanilla_blocks::GRASS_BLOCK), // Grass Block
+                    registry.blocks.get_default_state_id(vanilla_blocks::GRASS_BLOCK), // Grass Block
+                    registry.blocks.get_default_state_id(vanilla_blocks::TORCH)
                 ))),
                 light_engine: Arc::new(crate::chunk::light_engine::ThreadedLevelLightEngine::new()),
             }),

--- a/steel-core/src/chunk/chunk_map.rs
+++ b/steel-core/src/chunk/chunk_map.rs
@@ -73,6 +73,7 @@ impl ChunkMap {
                         .blocks
                         .get_default_state_id(vanilla_blocks::GRASS_BLOCK), // Grass Block
                 ))),
+                light_engine: Arc::new(crate::chunk::light_engine::ThreadedLevelLightEngine::new()),
             }),
             thread_pool: Arc::new(ThreadPoolBuilder::new().build().unwrap()),
             chunk_runtime,

--- a/steel-core/src/chunk/chunk_map.rs
+++ b/steel-core/src/chunk/chunk_map.rs
@@ -72,6 +72,7 @@ impl ChunkMap {
                     registry.blocks.get_default_state_id(vanilla_blocks::TORCH)
                 ))),
                 light_engine: Arc::new(ThreadedLevelLightEngine::new(registry.blocks.clone())),
+                runtime_handle: chunk_runtime.handle().clone(),
             }),
             thread_pool: Arc::new(ThreadPoolBuilder::new().build().unwrap()),
             chunk_runtime,

--- a/steel-core/src/chunk/chunk_status_tasks.rs
+++ b/steel-core/src/chunk/chunk_status_tasks.rs
@@ -151,12 +151,22 @@ impl ChunkStatusTasks {
         _cache: &Arc<StaticCache2D<Arc<ChunkHolder>>>,
         holder: Arc<ChunkHolder>,
     ) -> Result<(), anyhow::Error> {
+        let start_time = std::time::Instant::now();
+        let chunk_pos = holder.get_pos();
+
         let chunk = holder
             .try_chunk(ChunkStatus::Features)
             .expect("Chunk not found at status Features");
 
         let is_lighted = true;
         context.light_engine.initialize_light(chunk, is_lighted)?;
+
+        let duration = start_time.elapsed();
+        log::info!(
+            "initialize_light for chunk {:?} took {:?}",
+            chunk_pos,
+            duration
+        );
 
         Ok(())
     }
@@ -171,6 +181,9 @@ impl ChunkStatusTasks {
         cache: &Arc<StaticCache2D<Arc<ChunkHolder>>>,
         holder: Arc<ChunkHolder>,
     ) -> Result<(), anyhow::Error> {
+        let start_time = std::time::Instant::now();
+        let chunk_pos = holder.get_pos();
+
         let chunk = holder
             .try_chunk(ChunkStatus::InitializeLight)
             .expect("Chunk not found at status InitializeLight");
@@ -185,6 +198,13 @@ impl ChunkStatusTasks {
                 .light_engine
                 .light_chunk_with_cache(&mut guard, cache, is_lighted),
         )?;
+
+        let duration = start_time.elapsed();
+        log::info!(
+            "light for chunk {:?} took {:?}",
+            chunk_pos,
+            duration
+        );
 
         Ok(())
     }

--- a/steel-core/src/chunk/chunk_status_tasks.rs
+++ b/steel-core/src/chunk/chunk_status_tasks.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 
 use crate::chunk::{
+    ChunkSkyLightSources,
     chunk_access::{ChunkAccess, ChunkStatus},
     chunk_generation_task::StaticCache2D,
     chunk_generator::ChunkGenerator,
@@ -48,6 +49,7 @@ impl ChunkStatusTasks {
                     .collect(),
                 sky_light,
                 block_light,
+                sky_light_sources: ChunkSkyLightSources::default(),
             },
             holder.get_pos(),
         );

--- a/steel-core/src/chunk/chunk_status_tasks.rs
+++ b/steel-core/src/chunk/chunk_status_tasks.rs
@@ -198,7 +198,12 @@ impl ChunkStatusTasks {
 
         let is_lighted = true; // TODO: Implement isLighted(chunk) check
         let mut guard = ChunkGuard::new(chunk);
-        context.light_engine.light_chunk_with_cache(&mut guard, cache, is_lighted)?;
+
+        // Block on the async light propagation
+        // This is safe because the Tokio runtime has its own thread pool
+        context.runtime_handle.block_on(
+            context.light_engine.light_chunk_with_cache(&mut guard, cache, is_lighted)
+        )?;
 
         Ok(())
     }

--- a/steel-core/src/chunk/chunk_status_tasks.rs
+++ b/steel-core/src/chunk/chunk_status_tasks.rs
@@ -183,7 +183,7 @@ impl ChunkStatusTasks {
         context.runtime_handle.block_on(
             context
                 .light_engine
-                .light_chunk_with_cache(&mut guard, cache, is_lighted),
+                .light_chunk_with_cache(&mut guard, cache, &holder, is_lighted),
         )?;
 
         Ok(())

--- a/steel-core/src/chunk/chunk_status_tasks.rs
+++ b/steel-core/src/chunk/chunk_status_tasks.rs
@@ -151,7 +151,6 @@ impl ChunkStatusTasks {
         _cache: &Arc<StaticCache2D<Arc<ChunkHolder>>>,
         holder: Arc<ChunkHolder>,
     ) -> Result<(), anyhow::Error> {
-        let start_time = std::time::Instant::now();
         let chunk_pos = holder.get_pos();
 
         let chunk = holder
@@ -160,13 +159,6 @@ impl ChunkStatusTasks {
 
         let is_lighted = true;
         context.light_engine.initialize_light(chunk, is_lighted)?;
-
-        let duration = start_time.elapsed();
-        log::info!(
-            "initialize_light for chunk {:?} took {:?}",
-            chunk_pos,
-            duration
-        );
 
         Ok(())
     }
@@ -181,7 +173,6 @@ impl ChunkStatusTasks {
         cache: &Arc<StaticCache2D<Arc<ChunkHolder>>>,
         holder: Arc<ChunkHolder>,
     ) -> Result<(), anyhow::Error> {
-        let start_time = std::time::Instant::now();
         let chunk_pos = holder.get_pos();
 
         let chunk = holder
@@ -198,13 +189,6 @@ impl ChunkStatusTasks {
                 .light_engine
                 .light_chunk_with_cache(&mut guard, cache, is_lighted),
         )?;
-
-        let duration = start_time.elapsed();
-        log::info!(
-            "light for chunk {:?} took {:?}",
-            chunk_pos,
-            duration
-        );
 
         Ok(())
     }

--- a/steel-core/src/chunk/chunk_status_tasks.rs
+++ b/steel-core/src/chunk/chunk_status_tasks.rs
@@ -151,8 +151,6 @@ impl ChunkStatusTasks {
         _cache: &Arc<StaticCache2D<Arc<ChunkHolder>>>,
         holder: Arc<ChunkHolder>,
     ) -> Result<(), anyhow::Error> {
-        let chunk_pos = holder.get_pos();
-
         let chunk = holder
             .try_chunk(ChunkStatus::Features)
             .expect("Chunk not found at status Features");
@@ -173,8 +171,6 @@ impl ChunkStatusTasks {
         cache: &Arc<StaticCache2D<Arc<ChunkHolder>>>,
         holder: Arc<ChunkHolder>,
     ) -> Result<(), anyhow::Error> {
-        let chunk_pos = holder.get_pos();
-
         let chunk = holder
             .try_chunk(ChunkStatus::InitializeLight)
             .expect("Chunk not found at status InitializeLight");

--- a/steel-core/src/chunk/chunk_status_tasks.rs
+++ b/steel-core/src/chunk/chunk_status_tasks.rs
@@ -189,7 +189,7 @@ impl ChunkStatusTasks {
     pub fn light(
         context: Arc<WorldGenContext>,
         _step: &ChunkStep,
-        _cache: &Arc<StaticCache2D<Arc<ChunkHolder>>>,
+        cache: &Arc<StaticCache2D<Arc<ChunkHolder>>>,
         holder: Arc<ChunkHolder>,
     ) -> Result<(), anyhow::Error> {
         let chunk = holder
@@ -197,7 +197,8 @@ impl ChunkStatusTasks {
             .expect("Chunk not found at status InitializeLight");
 
         let is_lighted = true; // TODO: Implement isLighted(chunk) check
-        context.light_engine.light_chunk(chunk, is_lighted)?;
+        let mut guard = ChunkGuard::new(chunk);
+        context.light_engine.light_chunk_with_cache(&mut guard, cache, is_lighted)?;
 
         Ok(())
     }

--- a/steel-core/src/chunk/flat_chunk_generator.rs
+++ b/steel-core/src/chunk/flat_chunk_generator.rs
@@ -10,16 +10,19 @@ pub struct FlatChunkGenerator {
     pub dirt: BlockStateId,
     /// The block state id for grass blocks.
     pub grass: BlockStateId,
+    /// The block state id for torch.
+    pub torch: BlockStateId,
 }
 
 impl FlatChunkGenerator {
     /// Creates a new `FlatChunkGenerator`.
     #[must_use]
-    pub fn new(bedrock: BlockStateId, dirt: BlockStateId, grass: BlockStateId) -> Self {
+    pub fn new(bedrock: BlockStateId, dirt: BlockStateId, grass: BlockStateId, torch: BlockStateId) -> Self {
         Self {
             bedrock,
             dirt,
             grass,
+            torch,
         }
     }
 }
@@ -52,6 +55,8 @@ impl ChunkGenerator for FlatChunkGenerator {
                 chunk.set_relative_block(x, 3, z, self.grass);
             }
         }
+
+        chunk_guard.set_relative_block(0, 4, 0, self.torch);
     }
 
     fn build_surface(&self, _chunk: &ChunkAccess) {}

--- a/steel-core/src/chunk/flat_chunk_generator.rs
+++ b/steel-core/src/chunk/flat_chunk_generator.rs
@@ -17,7 +17,12 @@ pub struct FlatChunkGenerator {
 impl FlatChunkGenerator {
     /// Creates a new `FlatChunkGenerator`.
     #[must_use]
-    pub fn new(bedrock: BlockStateId, dirt: BlockStateId, grass: BlockStateId, torch: BlockStateId) -> Self {
+    pub fn new(
+        bedrock: BlockStateId,
+        dirt: BlockStateId,
+        grass: BlockStateId,
+        torch: BlockStateId,
+    ) -> Self {
         Self {
             bedrock,
             dirt,

--- a/steel-core/src/chunk/flat_chunk_generator.rs
+++ b/steel-core/src/chunk/flat_chunk_generator.rs
@@ -58,10 +58,14 @@ impl ChunkGenerator for FlatChunkGenerator {
 
                 // Grass block
                 chunk.set_relative_block(x, 3, z, self.grass);
+
+                if x != 0 && x != 15 && z != 0 && z != 15 {
+                    chunk.set_relative_block(x, 7, z, self.grass);
+                }
             }
         }
 
-        chunk.set_relative_block(0, 4, 0, self.torch);
+        chunk.set_relative_block(8, 4, 8, self.torch);
     }
 
     fn build_surface(&self, _chunk: &ChunkAccess) {}

--- a/steel-core/src/chunk/flat_chunk_generator.rs
+++ b/steel-core/src/chunk/flat_chunk_generator.rs
@@ -61,7 +61,7 @@ impl ChunkGenerator for FlatChunkGenerator {
             }
         }
 
-        chunk_guard.set_relative_block(0, 4, 0, self.torch);
+        chunk.set_relative_block(0, 4, 0, self.torch);
     }
 
     fn build_surface(&self, _chunk: &ChunkAccess) {}

--- a/steel-core/src/chunk/level_chunk.rs
+++ b/steel-core/src/chunk/level_chunk.rs
@@ -101,25 +101,27 @@ impl LevelChunk {
 
             if has_sky_change && i < self.sections.sky_light.len() {
                 // Check if section is empty (all 0s) or has data
-                if let LightStorage::Homogeneous(0) = self.sections.sky_light[i] {
+                let sky_storage = self.sections.sky_light[i].read();
+                if let LightStorage::Homogeneous(0) = *sky_storage {
                     // Section is empty - set in empty mask, don't send data
                     empty_sky_y_mask.set(i, true);
                 } else {
                     // Section has data - set in data mask and send array
                     sky_y_mask.set(i, true);
-                    sky_updates.push(self.sections.sky_light[i].to_packet_data());
+                    sky_updates.push(sky_storage.to_packet_data());
                 }
             }
 
             if has_block_change && i < self.sections.block_light.len() {
                 // Check if section is empty (all 0s) or has data
-                if let LightStorage::Homogeneous(0) = self.sections.block_light[i] {
+                let block_storage = self.sections.block_light[i].read();
+                if let LightStorage::Homogeneous(0) = *block_storage {
                     // Section is empty - set in empty mask, don't send data
                     empty_block_y_mask.set(i, true);
                 } else {
                     // Section has data - set in data mask and send array
                     block_y_mask.set(i, true);
-                    block_updates.push(self.sections.block_light[i].to_packet_data());
+                    block_updates.push(block_storage.to_packet_data());
                 }
             }
         }
@@ -160,8 +162,8 @@ impl LevelChunk {
             block_y_mask.set(i, true);
 
             // Get the packet data for this section (index i maps directly to storage)
-            sky_updates.push(self.sections.sky_light[i].to_packet_data());
-            block_updates.push(self.sections.block_light[i].to_packet_data());
+            sky_updates.push(self.sections.sky_light[i].read().to_packet_data());
+            block_updates.push(self.sections.block_light[i].read().to_packet_data());
         }
 
         LightUpdatePacketData {

--- a/steel-core/src/chunk/level_chunk.rs
+++ b/steel-core/src/chunk/level_chunk.rs
@@ -78,11 +78,19 @@ impl LevelChunk {
         let mut sky_updates = Vec::new();
         let mut block_updates = Vec::new();
 
-        for i in 0..section_count {
+        // Extract light data from stored sections
+        // Note: sky_light and block_light have section_count + 2 entries (padding above/below)
+        // Indices: 0 = bottom padding, 1..=section_count = actual sections, section_count+1 = top padding
+        // We skip the TOP padding (always Homogeneous(15)) but include bottom padding (can have light if bedrock broken)
+        // So we send indices 0 through section_count (inclusive), which is section_count+1 total sections
+        for i in 0..=section_count {
+            // Set masks to indicate we have light data for this section
             sky_y_mask.set(i, true);
             block_y_mask.set(i, true);
-            sky_updates.push(vec![0xFF; 2048]);
-            block_updates.push(vec![0xFF; 2048]);
+
+            // Get the packet data for this section (index i maps directly to storage)
+            sky_updates.push(self.sections.sky_light[i].to_packet_data());
+            block_updates.push(self.sections.block_light[i].to_packet_data());
         }
 
         LightUpdatePacketData {

--- a/steel-core/src/chunk/level_chunk.rs
+++ b/steel-core/src/chunk/level_chunk.rs
@@ -66,14 +66,78 @@ impl LevelChunk {
         }
     }
 
+    /// Extracts only the changed light sections for sending to the client.
+    ///
+    /// # Arguments
+    /// * `sky_changed` - Bit flags indicating which sky light sections changed
+    /// * `block_changed` - Bit flags indicating which block light sections changed
+    #[must_use]
+    pub fn extract_changed_light_data(&self, sky_changed: u32, block_changed: u32) -> LightUpdatePacketData {
+        use crate::chunk::light_storage::LightStorage;
+
+        let section_count = self.sections.sections.len();
+        // Note: light storage has section_count + 2 entries (padding above and below)
+        let light_section_count = section_count + 1; // We send section_count + 1 sections (skip top padding)
+
+        let mut sky_y_mask = BitSet(vec![0; light_section_count.div_ceil(64)].into_boxed_slice());
+        let mut block_y_mask = BitSet(vec![0; light_section_count.div_ceil(64)].into_boxed_slice());
+        let mut empty_sky_y_mask = BitSet(vec![0; light_section_count.div_ceil(64)].into_boxed_slice());
+        let mut empty_block_y_mask = BitSet(vec![0; light_section_count.div_ceil(64)].into_boxed_slice());
+
+        let mut sky_updates = Vec::new();
+        let mut block_updates = Vec::new();
+
+        // Only extract sections that changed
+        // Iterate through light storage indices (0 to section_count inclusive)
+        for i in 0..light_section_count {
+            let has_sky_change = (sky_changed & (1 << i)) != 0;
+            let has_block_change = (block_changed & (1 << i)) != 0;
+
+            if has_sky_change && i < self.sections.sky_light.len() {
+                // Check if section is empty (all 0s) or has data
+                if let LightStorage::Homogeneous(0) = self.sections.sky_light[i] {
+                    // Section is empty - set in empty mask, don't send data
+                    empty_sky_y_mask.set(i, true);
+                } else {
+                    // Section has data - set in data mask and send array
+                    sky_y_mask.set(i, true);
+                    sky_updates.push(self.sections.sky_light[i].to_packet_data());
+                }
+            }
+
+            if has_block_change && i < self.sections.block_light.len() {
+                // Check if section is empty (all 0s) or has data
+                if let LightStorage::Homogeneous(0) = self.sections.block_light[i] {
+                    // Section is empty - set in empty mask, don't send data
+                    empty_block_y_mask.set(i, true);
+                } else {
+                    // Section has data - set in data mask and send array
+                    block_y_mask.set(i, true);
+                    block_updates.push(self.sections.block_light[i].to_packet_data());
+                }
+            }
+        }
+
+        LightUpdatePacketData {
+            sky_y_mask,
+            block_y_mask,
+            empty_sky_y_mask,
+            empty_block_y_mask,
+            sky_updates,
+            block_updates,
+        }
+    }
+
     /// Extracts the light data for sending to the client.
     #[must_use]
     pub fn extract_light_data(&self) -> LightUpdatePacketData {
         let section_count = self.sections.sections.len();
-        let mut sky_y_mask = BitSet(vec![0; section_count.div_ceil(64)].into_boxed_slice());
-        let mut block_y_mask = BitSet(vec![0; section_count.div_ceil(64)].into_boxed_slice());
-        let empty_sky_y_mask = BitSet(vec![0; section_count.div_ceil(64)].into_boxed_slice());
-        let empty_block_y_mask = BitSet(vec![0; section_count.div_ceil(64)].into_boxed_slice());
+        // We send section_count + 1 sections (indices 0 through section_count inclusive)
+        let light_section_count = section_count + 1;
+        let mut sky_y_mask = BitSet(vec![0; light_section_count.div_ceil(64)].into_boxed_slice());
+        let mut block_y_mask = BitSet(vec![0; light_section_count.div_ceil(64)].into_boxed_slice());
+        let empty_sky_y_mask = BitSet(vec![0; light_section_count.div_ceil(64)].into_boxed_slice());
+        let empty_block_y_mask = BitSet(vec![0; light_section_count.div_ceil(64)].into_boxed_slice());
 
         let mut sky_updates = Vec::new();
         let mut block_updates = Vec::new();

--- a/steel-core/src/chunk/level_chunk.rs
+++ b/steel-core/src/chunk/level_chunk.rs
@@ -72,7 +72,11 @@ impl LevelChunk {
     /// * `sky_changed` - Bit flags indicating which sky light sections changed
     /// * `block_changed` - Bit flags indicating which block light sections changed
     #[must_use]
-    pub fn extract_changed_light_data(&self, sky_changed: u32, block_changed: u32) -> LightUpdatePacketData {
+    pub fn extract_changed_light_data(
+        &self,
+        sky_changed: u32,
+        block_changed: u32,
+    ) -> LightUpdatePacketData {
         use crate::chunk::light_storage::LightStorage;
 
         let section_count = self.sections.sections.len();
@@ -81,8 +85,10 @@ impl LevelChunk {
 
         let mut sky_y_mask = BitSet(vec![0; light_section_count.div_ceil(64)].into_boxed_slice());
         let mut block_y_mask = BitSet(vec![0; light_section_count.div_ceil(64)].into_boxed_slice());
-        let mut empty_sky_y_mask = BitSet(vec![0; light_section_count.div_ceil(64)].into_boxed_slice());
-        let mut empty_block_y_mask = BitSet(vec![0; light_section_count.div_ceil(64)].into_boxed_slice());
+        let mut empty_sky_y_mask =
+            BitSet(vec![0; light_section_count.div_ceil(64)].into_boxed_slice());
+        let mut empty_block_y_mask =
+            BitSet(vec![0; light_section_count.div_ceil(64)].into_boxed_slice());
 
         let mut sky_updates = Vec::new();
         let mut block_updates = Vec::new();
@@ -137,7 +143,8 @@ impl LevelChunk {
         let mut sky_y_mask = BitSet(vec![0; light_section_count.div_ceil(64)].into_boxed_slice());
         let mut block_y_mask = BitSet(vec![0; light_section_count.div_ceil(64)].into_boxed_slice());
         let empty_sky_y_mask = BitSet(vec![0; light_section_count.div_ceil(64)].into_boxed_slice());
-        let empty_block_y_mask = BitSet(vec![0; light_section_count.div_ceil(64)].into_boxed_slice());
+        let empty_block_y_mask =
+            BitSet(vec![0; light_section_count.div_ceil(64)].into_boxed_slice());
 
         let mut sky_updates = Vec::new();
         let mut block_updates = Vec::new();

--- a/steel-core/src/chunk/light_engine/base.rs
+++ b/steel-core/src/chunk/light_engine/base.rs
@@ -47,7 +47,8 @@ pub trait CenterChunkLightAccess {
     fn get_light(&self, pos: BlockPos) -> Option<u8>;
 
     /// Sets the light level at the given position, or returns false if outside center chunk.
-    fn set_light(&mut self, pos: BlockPos, level: u8) -> bool;
+    /// Uses interior mutability for light storage.
+    fn set_light(&self, pos: BlockPos, level: u8) -> bool;
 
     /// Gets the block state at the given position, or None if outside center chunk.
     fn get_block_state(&self, pos: BlockPos) -> Option<BlockStateId>;
@@ -156,7 +157,7 @@ impl LightEngine {
     ///
     /// # Arguments
     /// * `chunk_access` - Provides synchronous access to center chunk only
-    pub fn run_center_chunk_updates<T: CenterChunkLightAccess>(&mut self, chunk_access: &mut T) {
+    pub fn run_center_chunk_updates<T: CenterChunkLightAccess>(&mut self, chunk_access: &T) {
         self.propagate_decreases_center(chunk_access);
         self.propagate_increases_center(chunk_access);
     }
@@ -308,7 +309,7 @@ impl LightEngine {
     ///
     /// When encountering positions outside the center chunk, records them as boundary crossings
     /// instead of propagating across chunk boundaries.
-    fn propagate_decreases_center<T: CenterChunkLightAccess>(&mut self, chunk_access: &mut T) {
+    fn propagate_decreases_center<T: CenterChunkLightAccess>(&mut self, chunk_access: &T) {
         const ALL_DIRECTIONS: [Direction; 6] = [
             Direction::Down,
             Direction::Up,
@@ -372,7 +373,7 @@ impl LightEngine {
     ///
     /// When encountering positions outside the center chunk, records them as boundary crossings
     /// instead of propagating across chunk boundaries.
-    fn propagate_increases_center<T: CenterChunkLightAccess>(&mut self, chunk_access: &mut T) {
+    fn propagate_increases_center<T: CenterChunkLightAccess>(&mut self, chunk_access: &T) {
         const ALL_DIRECTIONS: [Direction; 6] = [
             Direction::Down,
             Direction::Up,

--- a/steel-core/src/chunk/light_engine/base.rs
+++ b/steel-core/src/chunk/light_engine/base.rs
@@ -17,7 +17,7 @@ pub trait LightChunkAccess {
     async fn get_light(&self, pos: BlockPos) -> u8;
 
     /// Sets the light level at the given world block position.
-    async fn set_light(&mut self, pos: BlockPos, level: u8) -> ();
+    async fn set_light(&mut self, pos: BlockPos, level: u8);
 
     /// Gets the block state at the given world block position.
     async fn get_block_state(&self, pos: BlockPos) -> BlockStateId;

--- a/steel-core/src/chunk/light_engine/base.rs
+++ b/steel-core/src/chunk/light_engine/base.rs
@@ -1,0 +1,117 @@
+//! Base light engine for flood-fill light propagation.
+//!
+//! This is a scaffold for the future light propagation implementation.
+//! The actual propagation logic (`propagate_increases`, `propagate_decreases`) will be
+//! implemented later.
+
+use steel_utils::BlockPos;
+
+use super::{light_queue::LightQueue, queue_entry::QueueEntry};
+
+/// Base light engine that handles light propagation using a flood-fill algorithm.
+///
+/// This structure maintains two FIFO queues for light propagation:
+/// - `increase_queue`: Processes light additions/increases
+/// - `decrease_queue`: Processes light removals/decreases
+///
+/// The light engine follows this execution order:
+/// 1. Process all decrease operations first (remove old light)
+/// 2. Process all increase operations second (add new light)
+///
+/// This ordering ensures correct light values at boundaries.
+#[derive(Debug)]
+pub struct LightEngine {
+    /// Queue for light increase operations.
+    increase_queue: LightQueue,
+    /// Queue for light decrease operations.
+    decrease_queue: LightQueue,
+}
+
+impl LightEngine {
+    /// Creates a new light engine with empty queues.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            increase_queue: LightQueue::new(),
+            decrease_queue: LightQueue::new(),
+        }
+    }
+
+    /// Enqueues a light increase at the given position.
+    pub fn enqueue_increase(&mut self, pos: BlockPos, entry: QueueEntry) {
+        self.increase_queue.enqueue(pos, entry);
+    }
+
+    /// Enqueues a light decrease at the given position.
+    pub fn enqueue_decrease(&mut self, pos: BlockPos, entry: QueueEntry) {
+        self.decrease_queue.enqueue(pos, entry);
+    }
+
+    /// Runs all queued light updates.
+    ///
+    /// This method:
+    /// 1. Processes all decreases first (`propagate_decreases`)
+    /// 2. Processes all increases second (`propagate_increases`)
+    ///
+    /// # Note
+    /// This is currently a stub. The actual propagation logic will be implemented later.
+    pub fn run_light_updates(&mut self) {
+        // TODO: Implement actual light propagation
+        // For now, just clear the queues to prevent unbounded growth
+        self.propagate_decreases();
+        self.propagate_increases();
+    }
+
+    /// Processes all light decrease operations.
+    ///
+    /// # Note
+    /// This is currently a stub. The actual implementation will:
+    /// - Dequeue each entry from `decrease_queue`
+    /// - Remove light from the position
+    /// - Propagate the decrease to neighbors
+    /// - Re-add light sources that still exist
+    fn propagate_decreases(&mut self) {
+        // TODO: Implement decrease propagation algorithm
+        // Stub: just clear the queue
+        self.decrease_queue.clear();
+    }
+
+    /// Processes all light increase operations.
+    ///
+    /// # Note
+    /// This is currently a stub. The actual implementation will:
+    /// - Dequeue each entry from `increase_queue`
+    /// - Set light at the position (if from emission)
+    /// - Propagate light to neighbors
+    /// - Check shape occlusion
+    /// - Reduce light by opacity
+    fn propagate_increases(&mut self) {
+        // TODO: Implement increase propagation algorithm
+        // Stub: just clear the queue
+        self.increase_queue.clear();
+    }
+
+    /// Checks if there are any pending light updates.
+    #[must_use]
+    pub fn has_work(&self) -> bool {
+        !self.increase_queue.is_empty() || !self.decrease_queue.is_empty()
+    }
+
+    /// Returns the number of queued increase operations.
+    #[must_use]
+    pub fn increase_queue_size(&self) -> usize {
+        self.increase_queue.len()
+    }
+
+    /// Returns the number of queued decrease operations.
+    #[must_use]
+    pub fn decrease_queue_size(&self) -> usize {
+        self.decrease_queue.len()
+    }
+}
+
+impl Default for LightEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/steel-core/src/chunk/light_engine/base.rs
+++ b/steel-core/src/chunk/light_engine/base.rs
@@ -1,12 +1,29 @@
 //! Base light engine for flood-fill light propagation.
 //!
-//! This is a scaffold for the future light propagation implementation.
-//! The actual propagation logic (`propagate_increases`, `propagate_decreases`) will be
-//! implemented later.
+//! Implements the core light propagation algorithm based on vanilla Minecraft's approach.
+//! Uses a flood-fill algorithm with two priority queues for increases and decreases.
 
-use steel_utils::BlockPos;
+use steel_registry::vanilla_blocks;
+use steel_utils::{BlockPos, BlockStateId};
 
-use super::{light_queue::LightQueue, queue_entry::QueueEntry};
+use super::{direction::Direction, light_queue::LightQueue, queue_entry::QueueEntry};
+
+/// Trait providing access to chunk light and block data for the light engine.
+///
+/// This abstracts away the complexity of chunk storage and cross-chunk access.
+pub trait LightChunkAccess {
+    /// Gets the light level at the given world block position.
+    fn get_light(&self, pos: BlockPos) -> u8;
+
+    /// Sets the light level at the given world block position.
+    fn set_light(&mut self, pos: BlockPos, level: u8);
+
+    /// Gets the block state at the given world block position.
+    fn get_block_state(&self, pos: BlockPos) -> BlockStateId;
+
+    /// Checks if the block at the given position has an empty collision shape.
+    fn is_empty_shape(&self, pos: BlockPos) -> bool;
+}
 
 /// Base light engine that handles light propagation using a flood-fill algorithm.
 ///
@@ -19,12 +36,44 @@ use super::{light_queue::LightQueue, queue_entry::QueueEntry};
 /// 2. Process all increase operations second (add new light)
 ///
 /// This ordering ensures correct light values at boundaries.
+///
+/// # Note on Architecture
+///
+/// This is a simplified implementation that currently only supports within-chunk propagation.
+/// Cross-chunk propagation will be added once the chunk access architecture is finalized.
 #[derive(Debug)]
 pub struct LightEngine {
     /// Queue for light increase operations.
     increase_queue: LightQueue,
     /// Queue for light decrease operations.
     decrease_queue: LightQueue,
+}
+
+/// Checks if two block shapes occlude light between them in the given direction.
+///
+/// This is a STUB implementation that always returns `false` (light passes through).
+/// The full implementation would check `VoxelShape` face occlusion.
+///
+/// # Arguments
+/// * `_from_state` - The block state light is coming from
+/// * `_to_state` - The block state light is going to
+/// * `_direction` - The direction of light propagation
+///
+/// # Returns
+/// `true` if shapes occlude and light cannot pass, `false` otherwise.
+///
+/// # Note
+/// This stub implementation allows all light to pass through.
+/// TODO: Implement proper VoxelShape face occlusion using `Shapes::faceShapeOccludes`.
+fn shape_occludes(_from_state: BlockStateId, _to_state: BlockStateId, _direction: Direction) -> bool {
+    // STUB: Always allow light to pass
+    // The real implementation would:
+    // 1. Get VoxelShapes for both blocks
+    // 2. Get the face shapes in the given direction
+    // 3. Check if faces occlude each other using Shapes::faceShapeOccludes
+    //
+    // For example, stairs and slabs should allow light through gaps
+    false
 }
 
 impl LightEngine {
@@ -47,48 +96,144 @@ impl LightEngine {
         self.decrease_queue.enqueue(pos, entry);
     }
 
-    /// Runs all queued light updates.
+    /// Runs all queued light updates with access to chunk data.
     ///
     /// This method:
     /// 1. Processes all decreases first (`propagate_decreases`)
     /// 2. Processes all increases second (`propagate_increases`)
     ///
-    /// # Note
-    /// This is currently a stub. The actual propagation logic will be implemented later.
+    /// # Arguments
+    /// * `chunk_access` - Provides access to light storage and block states
+    pub fn run_light_updates_with_access<T: LightChunkAccess>(&mut self, chunk_access: &mut T) {
+        self.propagate_decreases(chunk_access);
+        self.propagate_increases(chunk_access);
+    }
+
+    /// Runs all queued light updates (stub version without chunk access).
+    ///
+    /// This is a compatibility method that just clears queues.
+    /// Use `run_light_updates_with_access` for actual light propagation.
     pub fn run_light_updates(&mut self) {
-        // TODO: Implement actual light propagation
-        // For now, just clear the queues to prevent unbounded growth
-        self.propagate_decreases();
-        self.propagate_increases();
+        // Stub: Just clear queues
+        self.decrease_queue.clear();
+        self.increase_queue.clear();
     }
 
     /// Processes all light decrease operations.
     ///
-    /// # Note
-    /// This is currently a stub. The actual implementation will:
-    /// - Dequeue each entry from `decrease_queue`
-    /// - Remove light from the position
-    /// - Propagate the decrease to neighbors
-    /// - Re-add light sources that still exist
-    fn propagate_decreases(&mut self) {
-        // TODO: Implement decrease propagation algorithm
-        // Stub: just clear the queue
-        self.decrease_queue.clear();
+    /// This implements the vanilla flood-fill algorithm for removing light:
+    /// 1. Dequeue each (pos, entry) from decrease_queue
+    /// 2. For each neighbor in the direction flags:
+    ///    - If neighbor's light <= entry.level - 1: propagate decrease
+    ///    - Otherwise: re-queue neighbor for increase (it's a light source)
+    fn propagate_decreases<T: LightChunkAccess>(&mut self, chunk_access: &mut T) {
+        const ALL_DIRECTIONS: [Direction; 6] = [
+            Direction::Down,
+            Direction::Up,
+            Direction::North,
+            Direction::South,
+            Direction::West,
+            Direction::East,
+        ];
+
+        while let Some((pos, entry)) = self.decrease_queue.dequeue() {
+            let from_level = entry.level();
+
+            for direction in ALL_DIRECTIONS {
+                if !entry.should_propagate(direction) {
+                    continue;
+                }
+
+                let neighbor_pos = direction.relative(pos);
+                let neighbor_light = chunk_access.get_light(neighbor_pos);
+
+                if neighbor_light == 0 {
+                    continue; // Already dark
+                }
+
+                if neighbor_light <= from_level.saturating_sub(1) {
+                    // This neighbor's light came from us, remove it
+                    chunk_access.set_light(neighbor_pos, 0);
+                    self.enqueue_decrease(
+                        neighbor_pos,
+                        QueueEntry::decrease_all_directions(neighbor_light),
+                    );
+                } else {
+                    // This neighbor has its own light source, re-light it
+                    self.enqueue_increase(
+                        neighbor_pos,
+                        QueueEntry::increase_skip_one_direction(
+                            neighbor_light,
+                            chunk_access.is_empty_shape(neighbor_pos),
+                            direction.opposite(),
+                        ),
+                    );
+                }
+            }
+        }
     }
 
     /// Processes all light increase operations.
     ///
-    /// # Note
-    /// This is currently a stub. The actual implementation will:
-    /// - Dequeue each entry from `increase_queue`
-    /// - Set light at the position (if from emission)
-    /// - Propagate light to neighbors
-    /// - Check shape occlusion
-    /// - Reduce light by opacity
-    fn propagate_increases(&mut self) {
-        // TODO: Implement increase propagation algorithm
-        // Stub: just clear the queue
-        self.increase_queue.clear();
+    /// This implements the vanilla flood-fill algorithm for adding light:
+    /// 1. Dequeue each (pos, entry) from increase_queue
+    /// 2. For each neighbor in the direction flags:
+    ///    - Calculate new_light = current_light - max(1, opacity)
+    ///    - If new_light > neighbor's light && !shape_occludes:
+    ///      - Set neighbor's light to new_light
+    ///      - Enqueue neighbor for propagation
+    fn propagate_increases<T: LightChunkAccess>(&mut self, chunk_access: &mut T) {
+        const ALL_DIRECTIONS: [Direction; 6] = [
+            Direction::Down,
+            Direction::Up,
+            Direction::North,
+            Direction::South,
+            Direction::West,
+            Direction::East,
+        ];
+
+        while let Some((pos, entry)) = self.increase_queue.dequeue() {
+            let current_light = chunk_access.get_light(pos);
+
+            // Only propagate if light level matches (prevents duplicate processing)
+            if current_light != entry.level() {
+                continue;
+            }
+
+            for direction in ALL_DIRECTIONS {
+                if !entry.should_propagate(direction) {
+                    continue;
+                }
+
+                let neighbor_pos = direction.relative(pos);
+                let neighbor_block = chunk_access.get_block_state(neighbor_pos);
+
+                // Check shape occlusion between blocks
+                let pos_block = chunk_access.get_block_state(pos);
+                if shape_occludes(pos_block, neighbor_block, direction) {
+                    continue;
+                }
+
+                // Calculate light reduction (minimum 1, or block's opacity)
+                let opacity = vanilla_blocks::get_block_opacity(neighbor_block);
+                let reduction = opacity.max(1);
+
+                let new_light = current_light.saturating_sub(reduction);
+                let neighbor_light = chunk_access.get_light(neighbor_pos);
+
+                if new_light > neighbor_light {
+                    chunk_access.set_light(neighbor_pos, new_light);
+                    self.enqueue_increase(
+                        neighbor_pos,
+                        QueueEntry::increase_skip_one_direction(
+                            new_light,
+                            chunk_access.is_empty_shape(neighbor_pos),
+                            direction.opposite(),
+                        ),
+                    );
+                }
+            }
+        }
     }
 
     /// Checks if there are any pending light updates.

--- a/steel-core/src/chunk/light_engine/chunk_cache.rs
+++ b/steel-core/src/chunk/light_engine/chunk_cache.rs
@@ -1,0 +1,156 @@
+//! 2-element LRU cache for chunk access during light propagation.
+
+use std::sync::Arc;
+use steel_utils::{ChunkPos, math::Vector2};
+
+use crate::chunk::chunk_holder::ChunkHolder;
+
+/// 2-element LRU cache for recently accessed chunks.
+///
+/// This cache stores the two most recently accessed chunks to avoid
+/// repeated lock acquisitions during light propagation. The cache uses
+/// a simple LRU eviction policy: when both slots are full, the least
+/// recently used entry is evicted.
+pub struct ChunkCache {
+    /// Cache size (always 2 for vanilla compatibility).
+    cache_size: usize,
+
+    /// Cached chunk positions (invalid when ChunkPos(-1, -1)).
+    last_chunk_pos: [ChunkPos; 2],
+
+    /// Cached chunk holders.
+    last_chunk_holder: [Option<Arc<ChunkHolder>>; 2],
+
+    /// Access counters for LRU tracking (higher = more recent).
+    access_counter: [u64; 2],
+
+    /// Global access counter.
+    global_counter: u64,
+}
+
+impl ChunkCache {
+    /// Creates a new empty chunk cache.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            cache_size: 2,
+            last_chunk_pos: [
+                ChunkPos(Vector2::new(-1, -1)),
+                ChunkPos(Vector2::new(-1, -1)),
+            ],
+            last_chunk_holder: [None, None],
+            access_counter: [0, 0],
+            global_counter: 0,
+        }
+    }
+
+    /// Attempts to get a chunk from the cache.
+    ///
+    /// Returns `Some(holder)` if found in cache, `None` otherwise.
+    pub fn get(&mut self, pos: ChunkPos) -> Option<Arc<ChunkHolder>> {
+        for i in 0..self.cache_size {
+            if self.last_chunk_pos[i] == pos {
+                // Cache hit - update access time
+                self.global_counter += 1;
+                self.access_counter[i] = self.global_counter;
+
+                return self.last_chunk_holder[i].clone();
+            }
+        }
+
+        // Cache miss
+        None
+    }
+
+    /// Inserts a chunk into the cache, evicting LRU entry if needed.
+    pub fn insert(&mut self, pos: ChunkPos, holder: Arc<ChunkHolder>) {
+        // Check if already in cache (update in place)
+        for i in 0..self.cache_size {
+            if self.last_chunk_pos[i] == pos {
+                self.global_counter += 1;
+                self.access_counter[i] = self.global_counter;
+                self.last_chunk_holder[i] = Some(holder);
+                return;
+            }
+        }
+
+        // Find LRU slot (lowest access counter)
+        let mut lru_idx = 0;
+        let mut lru_count = self.access_counter[0];
+
+        for i in 1..self.cache_size {
+            if self.access_counter[i] < lru_count {
+                lru_count = self.access_counter[i];
+                lru_idx = i;
+            }
+        }
+
+        // Evict LRU and insert new entry
+        self.global_counter += 1;
+        self.last_chunk_pos[lru_idx] = pos;
+        self.last_chunk_holder[lru_idx] = Some(holder);
+        self.access_counter[lru_idx] = self.global_counter;
+    }
+
+    /// Clears the cache.
+    pub fn clear(&mut self) {
+        for i in 0..self.cache_size {
+            self.last_chunk_pos[i] = ChunkPos(Vector2::new(-1, -1));
+            self.last_chunk_holder[i] = None;
+            self.access_counter[i] = 0;
+        }
+        self.global_counter = 0;
+    }
+
+    /// Disables the cache (clears it).
+    pub fn disable(&mut self) {
+        self.clear();
+    }
+}
+
+impl Default for ChunkCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cache_hit() {
+        let mut cache = ChunkCache::new();
+        let pos = ChunkPos(Vector2::new(0, 0));
+
+        // Initial state - cache miss
+        assert!(cache.get(pos).is_none());
+    }
+
+    #[test]
+    fn test_lru_eviction() {
+        let cache = ChunkCache::new();
+
+        let _pos1 = ChunkPos(Vector2::new(0, 0));
+        let _pos2 = ChunkPos(Vector2::new(1, 0));
+        let _pos3 = ChunkPos(Vector2::new(2, 0));
+
+        // Verify cache size is 2
+        assert_eq!(cache.cache_size, 2);
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut cache = ChunkCache::new();
+
+        cache.clear();
+
+        // All positions should be invalid after clear
+        for i in 0..2 {
+            assert_eq!(cache.last_chunk_pos[i], ChunkPos(Vector2::new(-1, -1)));
+            assert!(cache.last_chunk_holder[i].is_none());
+            assert_eq!(cache.access_counter[i], 0);
+        }
+        assert_eq!(cache.global_counter, 0);
+    }
+}

--- a/steel-core/src/chunk/light_engine/direction.rs
+++ b/steel-core/src/chunk/light_engine/direction.rs
@@ -1,0 +1,104 @@
+//! Cardinal direction enum for light propagation.
+
+use steel_utils::BlockPos;
+
+/// Six cardinal directions for light propagation.
+///
+/// The ordinal values (0-5) match Minecraft's Java implementation and are critical
+/// for `QueueEntry` bit manipulation (direction flags use bits 4-9).
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Direction {
+    /// Downward (-Y direction) - ordinal 0, uses bit 4 in `QueueEntry`
+    Down = 0,
+    /// Upward (+Y direction) - ordinal 1, uses bit 5 in `QueueEntry`
+    Up = 1,
+    /// North (-Z direction) - ordinal 2, uses bit 6 in `QueueEntry`
+    North = 2,
+    /// South (+Z direction) - ordinal 3, uses bit 7 in `QueueEntry`
+    South = 3,
+    /// West (-X direction) - ordinal 4, uses bit 8 in `QueueEntry`
+    West = 4,
+    /// East (+X direction) - ordinal 5, uses bit 9 in `QueueEntry`
+    East = 5,
+}
+
+impl Direction {
+    /// All six directions in array form for iteration.
+    pub const ALL: [Direction; 6] = [
+        Direction::Down,
+        Direction::Up,
+        Direction::North,
+        Direction::South,
+        Direction::West,
+        Direction::East,
+    ];
+
+    /// Returns the opposite direction.
+    #[must_use]
+    pub const fn opposite(self) -> Self {
+        match self {
+            Self::Down => Self::Up,
+            Self::Up => Self::Down,
+            Self::North => Self::South,
+            Self::South => Self::North,
+            Self::West => Self::East,
+            Self::East => Self::West,
+        }
+    }
+
+    /// Gets the offset in the given direction.
+    ///
+    /// Returns (dx, dy, dz) for this direction.
+    #[must_use]
+    pub const fn offset(self) -> (i32, i32, i32) {
+        match self {
+            Self::Down => (0, -1, 0),
+            Self::Up => (0, 1, 0),
+            Self::North => (0, 0, -1),
+            Self::South => (0, 0, 1),
+            Self::West => (-1, 0, 0),
+            Self::East => (1, 0, 0),
+        }
+    }
+
+    /// Returns a new `BlockPos` relative to the given position in this direction.
+    #[must_use]
+    pub fn relative(self, pos: BlockPos) -> BlockPos {
+        use steel_utils::math::Vector3;
+        let (dx, dy, dz) = self.offset();
+        BlockPos(Vector3::new(pos.0.x + dx, pos.0.y + dy, pos.0.z + dz))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ordinals() {
+        assert_eq!(Direction::Down as u8, 0);
+        assert_eq!(Direction::Up as u8, 1);
+        assert_eq!(Direction::North as u8, 2);
+        assert_eq!(Direction::South as u8, 3);
+        assert_eq!(Direction::West as u8, 4);
+        assert_eq!(Direction::East as u8, 5);
+    }
+
+    #[test]
+    fn test_opposite() {
+        assert_eq!(Direction::Down.opposite(), Direction::Up);
+        assert_eq!(Direction::North.opposite(), Direction::South);
+        assert_eq!(Direction::West.opposite(), Direction::East);
+    }
+
+    #[test]
+    fn test_offset() {
+        assert_eq!(Direction::Down.offset(), (0, -1, 0));
+        assert_eq!(Direction::Up.offset(), (0, 1, 0));
+        assert_eq!(Direction::North.offset(), (0, 0, -1));
+        assert_eq!(Direction::South.offset(), (0, 0, 1));
+        assert_eq!(Direction::West.offset(), (-1, 0, 0));
+        assert_eq!(Direction::East.offset(), (1, 0, 0));
+    }
+}

--- a/steel-core/src/chunk/light_engine/light_queue.rs
+++ b/steel-core/src/chunk/light_engine/light_queue.rs
@@ -103,8 +103,14 @@ mod tests {
     #[test]
     fn test_clear() {
         let mut queue = LightQueue::new();
-        queue.enqueue(BlockPos(Vector3::new(0, 0, 0)), QueueEntry::decrease_all_directions(10));
-        queue.enqueue(BlockPos(Vector3::new(1, 1, 1)), QueueEntry::decrease_all_directions(5));
+        queue.enqueue(
+            BlockPos(Vector3::new(0, 0, 0)),
+            QueueEntry::decrease_all_directions(10),
+        );
+        queue.enqueue(
+            BlockPos(Vector3::new(1, 1, 1)),
+            QueueEntry::decrease_all_directions(5),
+        );
 
         assert_eq!(queue.len(), 2);
         queue.clear();

--- a/steel-core/src/chunk/light_engine/light_queue.rs
+++ b/steel-core/src/chunk/light_engine/light_queue.rs
@@ -1,0 +1,114 @@
+//! FIFO queue for light propagation entries.
+
+use std::collections::VecDeque;
+
+use steel_utils::BlockPos;
+
+use super::queue_entry::QueueEntry;
+
+/// A FIFO queue for light propagation.
+///
+/// Stores pairs of (`BlockPos`, `QueueEntry`) for processing light changes.
+/// The queue processes entries in order to ensure correct light propagation.
+#[derive(Debug)]
+pub struct LightQueue {
+    queue: VecDeque<(BlockPos, QueueEntry)>,
+}
+
+impl LightQueue {
+    /// Creates a new empty light queue.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            queue: VecDeque::new(),
+        }
+    }
+
+    /// Creates a new light queue with the specified capacity.
+    #[must_use]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            queue: VecDeque::with_capacity(capacity),
+        }
+    }
+
+    /// Enqueues a position and queue entry for processing.
+    pub fn enqueue(&mut self, pos: BlockPos, entry: QueueEntry) {
+        self.queue.push_back((pos, entry));
+    }
+
+    /// Dequeues the next position and queue entry.
+    ///
+    /// Returns `None` if the queue is empty.
+    pub fn dequeue(&mut self) -> Option<(BlockPos, QueueEntry)> {
+        self.queue.pop_front()
+    }
+
+    /// Checks if the queue is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.queue.is_empty()
+    }
+
+    /// Returns the number of entries in the queue.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.queue.len()
+    }
+
+    /// Clears all entries from the queue.
+    pub fn clear(&mut self) {
+        self.queue.clear();
+    }
+}
+
+impl Default for LightQueue {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use steel_utils::math::Vector3;
+
+    #[test]
+    #[allow(clippy::unwrap_used)] // Tests are allowed to panic
+    fn test_enqueue_dequeue() {
+        let mut queue = LightQueue::new();
+        let pos1 = BlockPos(Vector3::new(10, 64, 20));
+        let pos2 = BlockPos(Vector3::new(11, 64, 20));
+        let entry1 = QueueEntry::decrease_all_directions(5);
+        let entry2 = QueueEntry::increase_from_emission(14, true);
+
+        queue.enqueue(pos1, entry1);
+        queue.enqueue(pos2, entry2);
+
+        assert_eq!(queue.len(), 2);
+        assert!(!queue.is_empty());
+
+        let (dequeued_pos1, dequeued_entry1) = queue.dequeue().unwrap();
+        assert_eq!(dequeued_pos1, pos1);
+        assert_eq!(dequeued_entry1, entry1);
+
+        let (dequeued_pos2, dequeued_entry2) = queue.dequeue().unwrap();
+        assert_eq!(dequeued_pos2, pos2);
+        assert_eq!(dequeued_entry2, entry2);
+
+        assert!(queue.is_empty());
+        assert_eq!(queue.len(), 0);
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut queue = LightQueue::new();
+        queue.enqueue(BlockPos(Vector3::new(0, 0, 0)), QueueEntry::decrease_all_directions(10));
+        queue.enqueue(BlockPos(Vector3::new(1, 1, 1)), QueueEntry::decrease_all_directions(5));
+
+        assert_eq!(queue.len(), 2);
+        queue.clear();
+        assert_eq!(queue.len(), 0);
+        assert!(queue.is_empty());
+    }
+}

--- a/steel-core/src/chunk/light_engine/light_queue.rs
+++ b/steel-core/src/chunk/light_engine/light_queue.rs
@@ -16,11 +16,14 @@ pub struct LightQueue {
 }
 
 impl LightQueue {
-    /// Creates a new empty light queue.
+    /// Creates a new empty light queue with pre-allocated capacity.
+    ///
+    /// Pre-allocates space for 4096 entries based on typical light propagation workloads,
+    /// which significantly reduces reallocation overhead during flood-fill.
     #[must_use]
     pub fn new() -> Self {
         Self {
-            queue: VecDeque::new(),
+            queue: VecDeque::with_capacity(4096),
         }
     }
 

--- a/steel-core/src/chunk/light_engine/mod.rs
+++ b/steel-core/src/chunk/light_engine/mod.rs
@@ -28,14 +28,18 @@
 //! - Implementing `propagate_light_sources` for both types
 
 mod base;
+mod chunk_cache;
 pub mod direction;
 pub mod light_queue;
 pub mod queue_entry;
+mod sky_light_engine;
 pub mod threaded_level_light_engine;
 
 // Re-export main types for convenience
 pub use base::{BoundaryCrossing, CenterChunkLightAccess, LightChunkAccess, LightEngine};
+pub use chunk_cache::ChunkCache;
 pub use direction::Direction;
 pub use light_queue::LightQueue;
 pub use queue_entry::QueueEntry;
+pub use sky_light_engine::SkyLightEngine;
 pub use threaded_level_light_engine::{TaskType, ThreadedLevelLightEngine};

--- a/steel-core/src/chunk/light_engine/mod.rs
+++ b/steel-core/src/chunk/light_engine/mod.rs
@@ -1,0 +1,38 @@
+//! Light engine for chunk lighting.
+//!
+//! This module implements Minecraft's light propagation system using a flood-fill
+//! algorithm with two FIFO queues for increases and decreases.
+//!
+//! # Architecture
+//!
+//! - `Direction`: Cardinal directions for light propagation
+//! - `QueueEntry`: Bit-packed u64 encoding light level and propagation metadata
+//! - `LightQueue`: FIFO queue for (BlockPos, QueueEntry) pairs
+//! - `LightEngine`: Base flood-fill light propagation engine
+//! - `ThreadedLevelLightEngine`: Multi-threaded task-based light engine
+//!
+//! # Current Status
+//!
+//! This is a **scaffold implementation**. The core structures are in place, but
+//! the actual light propagation logic is stubbed out. Future work includes:
+//!
+//! - Implementing `propagate_increases` and `propagate_decreases` in `LightEngine`
+//! - Adding section status tracking (`update_section_status`)
+//! - Implementing `set_light_enabled` and `retain_data` flags
+//! - Adding chunk neighbor access for cross-chunk propagation
+//! - Implementing shape occlusion checking
+//! - Adding block light and sky light specific engines
+//! - Implementing `propagate_light_sources` for both types
+
+mod base;
+pub mod direction;
+pub mod light_queue;
+pub mod queue_entry;
+pub mod threaded_level_light_engine;
+
+// Re-export main types for convenience
+pub use base::LightEngine;
+pub use direction::Direction;
+pub use light_queue::LightQueue;
+pub use queue_entry::QueueEntry;
+pub use threaded_level_light_engine::{TaskType, ThreadedLevelLightEngine};

--- a/steel-core/src/chunk/light_engine/mod.rs
+++ b/steel-core/src/chunk/light_engine/mod.rs
@@ -34,7 +34,7 @@ pub mod queue_entry;
 pub mod threaded_level_light_engine;
 
 // Re-export main types for convenience
-pub use base::{LightChunkAccess, LightEngine};
+pub use base::{BoundaryCrossing, CenterChunkLightAccess, LightChunkAccess, LightEngine};
 pub use direction::Direction;
 pub use light_queue::LightQueue;
 pub use queue_entry::QueueEntry;

--- a/steel-core/src/chunk/light_engine/mod.rs
+++ b/steel-core/src/chunk/light_engine/mod.rs
@@ -9,18 +9,21 @@
 //! - `QueueEntry`: Bit-packed u64 encoding light level and propagation metadata
 //! - `LightQueue`: FIFO queue for (BlockPos, QueueEntry) pairs
 //! - `LightEngine`: Base flood-fill light propagation engine
+//! - `LightChunkAccess`: Trait for accessing chunk light and block data
 //! - `ThreadedLevelLightEngine`: Multi-threaded task-based light engine
 //!
-//! # Current Status
+//! # Implementation Status
 //!
-//! This is a **scaffold implementation**. The core structures are in place, but
-//! the actual light propagation logic is stubbed out. Future work includes:
+//! **Completed:**
+//! - ✅ Core flood-fill propagation algorithm (`propagate_increases`, `propagate_decreases`)
+//! - ✅ Light property getters (luminance, opacity)
+//! - ✅ Shape occlusion stub (uses `can_occlude` as approximation)
 //!
-//! - Implementing `propagate_increases` and `propagate_decreases` in `LightEngine`
+//! **TODO:**
 //! - Adding section status tracking (`update_section_status`)
 //! - Implementing `set_light_enabled` and `retain_data` flags
-//! - Adding chunk neighbor access for cross-chunk propagation
-//! - Implementing shape occlusion checking
+//! - Adding full chunk neighbor access for cross-chunk propagation
+//! - Implementing proper VoxelShape face occlusion checking
 //! - Adding block light and sky light specific engines
 //! - Implementing `propagate_light_sources` for both types
 
@@ -31,7 +34,7 @@ pub mod queue_entry;
 pub mod threaded_level_light_engine;
 
 // Re-export main types for convenience
-pub use base::LightEngine;
+pub use base::{LightChunkAccess, LightEngine};
 pub use direction::Direction;
 pub use light_queue::LightQueue;
 pub use queue_entry::QueueEntry;

--- a/steel-core/src/chunk/light_engine/mod.rs
+++ b/steel-core/src/chunk/light_engine/mod.rs
@@ -1,31 +1,4 @@
-//! Light engine for chunk lighting.
-//!
-//! This module implements Minecraft's light propagation system using a flood-fill
-//! algorithm with two FIFO queues for increases and decreases.
-//!
-//! # Architecture
-//!
-//! - `Direction`: Cardinal directions for light propagation
-//! - `QueueEntry`: Bit-packed u64 encoding light level and propagation metadata
-//! - `LightQueue`: FIFO queue for (BlockPos, QueueEntry) pairs
-//! - `LightEngine`: Base flood-fill light propagation engine
-//! - `LightChunkAccess`: Trait for accessing chunk light and block data
-//! - `ThreadedLevelLightEngine`: Multi-threaded task-based light engine
-//!
-//! # Implementation Status
-//!
-//! **Completed:**
-//! - ✅ Core flood-fill propagation algorithm (`propagate_increases`, `propagate_decreases`)
-//! - ✅ Light property getters (luminance, opacity)
-//! - ✅ Shape occlusion stub (uses `can_occlude` as approximation)
-//!
-//! **TODO:**
-//! - Adding section status tracking (`update_section_status`)
-//! - Implementing `set_light_enabled` and `retain_data` flags
-//! - Adding full chunk neighbor access for cross-chunk propagation
-//! - Implementing proper VoxelShape face occlusion checking
-//! - Adding block light and sky light specific engines
-//! - Implementing `propagate_light_sources` for both types
+//! Minecraft-compatible light propagation system using flood-fill algorithm.
 
 mod base;
 mod chunk_cache;
@@ -42,4 +15,4 @@ pub use direction::Direction;
 pub use light_queue::LightQueue;
 pub use queue_entry::QueueEntry;
 pub use sky_light_engine::SkyLightEngine;
-pub use threaded_level_light_engine::{TaskType, ThreadedLevelLightEngine};
+pub use threaded_level_light_engine::ThreadedLevelLightEngine;

--- a/steel-core/src/chunk/light_engine/queue_entry.rs
+++ b/steel-core/src/chunk/light_engine/queue_entry.rs
@@ -1,0 +1,246 @@
+//! `QueueEntry` bit-packing system for light propagation.
+//!
+//! The `QueueEntry` packs all propagation metadata into a single u64:
+//! - Bits 0-3: Light level (0-15)
+//! - Bits 4-9: Direction flags (6 directions)
+//! - Bit 10: Empty shape flag
+//! - Bit 11: Increase from emission flag
+//!
+//! Using u64 (instead of u16) for native word size performance on 64-bit CPUs.
+
+use super::direction::Direction;
+
+/// A queue entry that encodes light propagation information in a bit-packed u64.
+///
+/// Bit layout:
+/// ```text
+/// Bit Position:  63.....................12  11  10  9  8  7  6  5  4  3  2  1  0
+///                |         Unused        | F | F | D D D D D D | L L L L |
+///                                         | | |               |         |
+///                                         | | |               |         +-> Light Level (4 bits)
+///                                         | | |               +----------> Direction Flags (6 bits)
+///                                         | | +----------------------------> Empty Shape Flag
+///                                         | +-------------------------------> Increase From Emission Flag
+///                                         +---------------------------------> (Unused)
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueueEntry(u64);
+
+impl QueueEntry {
+    /// Mask for light level (bits 0-3)
+    const LEVEL_MASK: u64 = 0x0F;
+
+    /// Mask for all direction flags (bits 4-9)
+    const DIRECTIONS_MASK: u64 = 0x3F0;
+
+    /// Flag for empty collision shape (bit 10)
+    const EMPTY_SHAPE_FLAG: u64 = 0x400;
+
+    /// Flag for increase from light emission (bit 11)
+    const EMISSION_FLAG: u64 = 0x800;
+
+    /// Gets the light level from this queue entry (0-15).
+    #[must_use]
+    #[inline]
+    pub fn level(self) -> u8 {
+        (self.0 & Self::LEVEL_MASK) as u8
+    }
+
+    /// Checks if light should propagate in the given direction.
+    #[must_use]
+    #[inline]
+    pub fn should_propagate(self, dir: Direction) -> bool {
+        let bit = 1u64 << (dir as u8 + 4);
+        (self.0 & bit) != 0
+    }
+
+    /// Checks if this entry is from a block with an empty collision shape.
+    #[must_use]
+    #[inline]
+    pub fn is_from_empty_shape(self) -> bool {
+        (self.0 & Self::EMPTY_SHAPE_FLAG) != 0
+    }
+
+    /// Checks if this entry represents light increase from an emitting block.
+    #[must_use]
+    #[inline]
+    pub fn is_from_emission(self) -> bool {
+        (self.0 & Self::EMISSION_FLAG) != 0
+    }
+
+    /// Sets the light level in the entry, preserving other flags.
+    #[must_use]
+    #[inline]
+    fn with_level(self, level: u8) -> Self {
+        debug_assert!(level <= 15, "Light level must be 0-15");
+        // Clear level bits and set new level
+        Self((self.0 & !Self::LEVEL_MASK) | (u64::from(level) & Self::LEVEL_MASK))
+    }
+
+    /// Adds a direction flag to the entry.
+    #[must_use]
+    #[inline]
+    fn with_direction(self, dir: Direction) -> Self {
+        Self(self.0 | (1u64 << (dir as u8 + 4)))
+    }
+
+    /// Removes a direction flag from the entry.
+    #[must_use]
+    #[inline]
+    fn without_direction(self, dir: Direction) -> Self {
+        Self(self.0 & !(1u64 << (dir as u8 + 4)))
+    }
+
+    /// Creates a queue entry for decreasing light in all directions.
+    #[must_use]
+    pub fn decrease_all_directions(level: u8) -> Self {
+        debug_assert!(level <= 15, "Light level must be 0-15");
+        Self(Self::DIRECTIONS_MASK).with_level(level)
+    }
+
+    /// Creates a queue entry for decreasing light in all directions except one.
+    #[must_use]
+    pub fn decrease_skip_one_direction(level: u8, skip_dir: Direction) -> Self {
+        debug_assert!(level <= 15, "Light level must be 0-15");
+        Self(Self::DIRECTIONS_MASK)
+            .without_direction(skip_dir)
+            .with_level(level)
+    }
+
+    /// Creates a queue entry for increasing light from an emitting block.
+    #[must_use]
+    pub fn increase_from_emission(level: u8, from_empty_shape: bool) -> Self {
+        debug_assert!(level <= 15, "Light level must be 0-15");
+        let mut entry = Self::DIRECTIONS_MASK | Self::EMISSION_FLAG;
+        if from_empty_shape {
+            entry |= Self::EMPTY_SHAPE_FLAG;
+        }
+        Self(entry).with_level(level)
+    }
+
+    /// Creates a queue entry for increasing light in all directions except one.
+    #[must_use]
+    pub fn increase_skip_one_direction(level: u8, from_empty_shape: bool, skip_dir: Direction) -> Self {
+        debug_assert!(level <= 15, "Light level must be 0-15");
+        let mut entry = Self::DIRECTIONS_MASK;
+        if from_empty_shape {
+            entry |= Self::EMPTY_SHAPE_FLAG;
+        }
+        Self(entry)
+            .without_direction(skip_dir)
+            .with_level(level)
+    }
+
+    /// Creates a queue entry for increasing light in only one direction.
+    #[must_use]
+    pub fn increase_only_one_direction(level: u8, from_empty_shape: bool, dir: Direction) -> Self {
+        debug_assert!(level <= 15, "Light level must be 0-15");
+        let mut entry = 0u64;
+        if from_empty_shape {
+            entry |= Self::EMPTY_SHAPE_FLAG;
+        }
+        Self(entry)
+            .with_direction(dir)
+            .with_level(level)
+    }
+
+    /// Creates a queue entry for sky light propagation with selective directions.
+    ///
+    /// Sky light always propagates at level 15.
+    #[must_use]
+    #[allow(clippy::fn_params_excessive_bools)] // Matches vanilla signature
+    pub fn increase_sky_source_in_directions(
+        down: bool,
+        north: bool,
+        south: bool,
+        west: bool,
+        east: bool,
+    ) -> Self {
+        let mut entry = Self(0).with_level(15);
+        if down {
+            entry = entry.with_direction(Direction::Down);
+        }
+        if north {
+            entry = entry.with_direction(Direction::North);
+        }
+        if south {
+            entry = entry.with_direction(Direction::South);
+        }
+        if west {
+            entry = entry.with_direction(Direction::West);
+        }
+        if east {
+            entry = entry.with_direction(Direction::East);
+        }
+        entry
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_level_extraction() {
+        let entry = QueueEntry::decrease_all_directions(12);
+        assert_eq!(entry.level(), 12);
+    }
+
+    #[test]
+    fn test_direction_flags() {
+        let entry = QueueEntry::decrease_all_directions(5);
+        assert!(entry.should_propagate(Direction::Down));
+        assert!(entry.should_propagate(Direction::Up));
+        assert!(entry.should_propagate(Direction::North));
+        assert!(entry.should_propagate(Direction::South));
+        assert!(entry.should_propagate(Direction::West));
+        assert!(entry.should_propagate(Direction::East));
+    }
+
+    #[test]
+    fn test_skip_one_direction() {
+        let entry = QueueEntry::decrease_skip_one_direction(8, Direction::Up);
+        assert!(entry.should_propagate(Direction::Down));
+        assert!(!entry.should_propagate(Direction::Up));
+        assert!(entry.should_propagate(Direction::North));
+        assert_eq!(entry.level(), 8);
+    }
+
+    #[test]
+    fn test_emission_flag() {
+        let entry = QueueEntry::increase_from_emission(14, true);
+        assert_eq!(entry.level(), 14);
+        assert!(entry.is_from_emission());
+        assert!(entry.is_from_empty_shape());
+    }
+
+    #[test]
+    fn test_only_one_direction() {
+        let entry = QueueEntry::increase_only_one_direction(7, false, Direction::East);
+        assert_eq!(entry.level(), 7);
+        assert!(!entry.should_propagate(Direction::Down));
+        assert!(!entry.should_propagate(Direction::Up));
+        assert!(!entry.should_propagate(Direction::North));
+        assert!(!entry.should_propagate(Direction::South));
+        assert!(!entry.should_propagate(Direction::West));
+        assert!(entry.should_propagate(Direction::East));
+    }
+
+    #[test]
+    fn test_sky_source_directions() {
+        let entry = QueueEntry::increase_sky_source_in_directions(
+            true,  // down
+            true,  // north
+            false, // south
+            false, // west
+            true,  // east
+        );
+        assert_eq!(entry.level(), 15);
+        assert!(entry.should_propagate(Direction::Down));
+        assert!(entry.should_propagate(Direction::North));
+        assert!(!entry.should_propagate(Direction::South));
+        assert!(!entry.should_propagate(Direction::West));
+        assert!(entry.should_propagate(Direction::East));
+        assert!(!entry.should_propagate(Direction::Up));
+    }
+}

--- a/steel-core/src/chunk/light_engine/queue_entry.rs
+++ b/steel-core/src/chunk/light_engine/queue_entry.rs
@@ -120,15 +120,17 @@ impl QueueEntry {
 
     /// Creates a queue entry for increasing light in all directions except one.
     #[must_use]
-    pub fn increase_skip_one_direction(level: u8, from_empty_shape: bool, skip_dir: Direction) -> Self {
+    pub fn increase_skip_one_direction(
+        level: u8,
+        from_empty_shape: bool,
+        skip_dir: Direction,
+    ) -> Self {
         debug_assert!(level <= 15, "Light level must be 0-15");
         let mut entry = Self::DIRECTIONS_MASK;
         if from_empty_shape {
             entry |= Self::EMPTY_SHAPE_FLAG;
         }
-        Self(entry)
-            .without_direction(skip_dir)
-            .with_level(level)
+        Self(entry).without_direction(skip_dir).with_level(level)
     }
 
     /// Creates a queue entry for increasing light in only one direction.
@@ -139,9 +141,7 @@ impl QueueEntry {
         if from_empty_shape {
             entry |= Self::EMPTY_SHAPE_FLAG;
         }
-        Self(entry)
-            .with_direction(dir)
-            .with_level(level)
+        Self(entry).with_direction(dir).with_level(level)
     }
 
     /// Creates a queue entry for sky light propagation with selective directions.

--- a/steel-core/src/chunk/light_engine/sky_light_engine.rs
+++ b/steel-core/src/chunk/light_engine/sky_light_engine.rs
@@ -172,27 +172,18 @@ mod tests {
             .map(|_| ChunkSection::new_empty())
             .collect();
 
-        let mut sections = Sections {
-            sections: sections_vec.into_boxed_slice(),
-            sky_light: (0..(num_sections + 2))
-                .map(|_| LightStorage::new_empty())
-                .collect(),
-            block_light: (0..(num_sections + 2))
-                .map(|_| LightStorage::new_empty())
-                .collect(),
-            sky_light_sources: Default::default(),
-        };
+        let sections = Sections::from_owned(sections_vec.into_boxed_slice());
 
         engine.propagate_from_empty_sections(
             ChunkPos(steel_utils::math::Vector2::new(0, 0)),
-            &mut sections,
+            &sections,
             -64,
         );
 
         // All sections should be filled with light 15
         for idx in 1..=num_sections {
             let light = sections.sky_light[idx].read().get(0, 0, 0);
-            assert_eq!(light, 15, "Section {} should have light 15", idx);
+            assert_eq!(light, 15, "Section {idx} should have light 15");
         }
     }
 }

--- a/steel-core/src/chunk/light_engine/sky_light_engine.rs
+++ b/steel-core/src/chunk/light_engine/sky_light_engine.rs
@@ -1,0 +1,194 @@
+//! Sky light engine with empty section propagation optimization.
+
+use crate::chunk::{
+    light_storage::LightStorage,
+    paletted_container::{BlockPalette, PalettedContainer},
+    section::Sections,
+};
+use steel_utils::{BlockStateId, ChunkPos};
+
+/// Sky light engine with optimizations for vertical light propagation.
+pub struct SkyLightEngine {
+    // Base light engine could be added here if needed for more complex propagation
+}
+
+impl SkyLightEngine {
+    /// Creates a new sky light engine.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    /// Checks if a section is completely empty (all air blocks).
+    fn is_section_empty(section: &BlockPalette) -> bool {
+        match section {
+            PalettedContainer::Homogeneous(block_state) => *block_state == BlockStateId(0),
+            PalettedContainer::Heterogeneous(_) => false,
+        }
+    }
+
+    /// Propagates light from empty sections in a single operation.
+    ///
+    /// This is the core optimization: when encountering an empty section,
+    /// instead of propagating block-by-block, we skip to the bottom of all
+    /// consecutive empty sections below.
+    ///
+    /// # Panics
+    /// This function does not panic under normal circumstances.
+    pub fn propagate_from_empty_sections(
+        &mut self,
+        _chunk_pos: ChunkPos,
+        sections: &mut Sections,
+        _chunk_min_y: i32,
+    ) {
+        let num_sections = sections.sections.len();
+
+        // Start from top, find first non-empty section
+        let mut top_section = None;
+        for idx in (0..num_sections).rev() {
+            if !Self::is_section_empty(&sections.sections[idx].states) {
+                top_section = Some(idx);
+                break;
+            }
+        }
+
+        // If all sections are empty (all air), fill everything with light 15
+        if top_section.is_none() {
+            for idx in 1..=num_sections {
+                if idx < sections.sky_light.len() {
+                    sections.sky_light[idx] = LightStorage::new_filled(15);
+                }
+            }
+            return;
+        }
+
+        let top_section = top_section.expect("top_section should be Some at this point");
+
+        // Fill all sections above top_section with full sky light (15)
+        for idx in (top_section + 1)..num_sections {
+            let light_idx = idx + 1; // +1 for padding
+            if light_idx < sections.sky_light.len() {
+                sections.sky_light[light_idx] = LightStorage::new_filled(15);
+            }
+        }
+
+        // Track which columns are still active (still propagating light downward)
+        // 16x16 = 256 columns, indexed by z * 16 + x
+        let mut column_active = [true; 256];
+
+        // Process from top_section downward, tracking column state
+        for section_idx in (0..=top_section).rev() {
+            let section = &sections.sections[section_idx];
+
+            // Check if this entire section is empty
+            if Self::is_section_empty(&section.states) {
+                // Fast path: fill entire section with light 15
+                let light_idx = section_idx + 1; // +1 for padding
+                if light_idx < sections.sky_light.len() {
+                    sections.sky_light[light_idx] = LightStorage::new_filled(15);
+                }
+                // All columns remain active
+            } else {
+                // Process this section column by column
+                let light_idx = section_idx + 1; // +1 for padding
+
+                for z in 0..16 {
+                    for x in 0..16 {
+                        let col_idx = z * 16 + x;
+
+                        // Skip columns that have already hit solid blocks
+                        if !column_active[col_idx] {
+                            continue;
+                        }
+
+                        // Propagate downward in this column through this section
+                        for y in (0..16).rev() {
+                            let block_state = section.states.get(x, y, z);
+                            let is_air = block_state == BlockStateId(0);
+
+                            if is_air {
+                                sections.sky_light[light_idx].set(x, y, z, 15);
+                            } else {
+                                // Hit solid block, mark column as terminated
+                                sections.sky_light[light_idx].set(x, y, z, 0);
+                                column_active[col_idx] = false;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Propagates sky light and updates source tracking.
+    ///
+    /// This method propagates the sky light, then the caller should update sources separately.
+    pub fn propagate_with_sources(
+        &mut self,
+        chunk_pos: ChunkPos,
+        sections: &mut Sections,
+        chunk_min_y: i32,
+    ) {
+        // Use the optimized empty section propagation
+        self.propagate_from_empty_sections(chunk_pos, sections, chunk_min_y);
+
+        // Note: Caller should update sources after this call by calling:
+        // sections.sky_light_sources.update_from_chunk_sections(&sections.sections, chunk_min_y);
+    }
+}
+
+impl Default for SkyLightEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chunk::section::ChunkSection;
+
+    #[test]
+    fn test_is_section_empty() {
+        let empty = PalettedContainer::Homogeneous(BlockStateId(0));
+        assert!(SkyLightEngine::is_section_empty(&empty));
+
+        let non_empty = PalettedContainer::Homogeneous(BlockStateId(1));
+        assert!(!SkyLightEngine::is_section_empty(&non_empty));
+    }
+
+    #[test]
+    fn test_all_air_chunk() {
+        let mut engine = SkyLightEngine::new();
+
+        // Create a chunk with all air sections
+        let num_sections = 24; // -64 to 320 in 16-block sections
+        let sections_vec: Vec<ChunkSection> = (0..num_sections)
+            .map(|_| ChunkSection::new_empty())
+            .collect();
+
+        let mut sections = Sections {
+            sections: sections_vec.into_boxed_slice(),
+            sky_light: (0..(num_sections + 2))
+                .map(|_| LightStorage::new_empty())
+                .collect(),
+            block_light: (0..(num_sections + 2))
+                .map(|_| LightStorage::new_empty())
+                .collect(),
+            sky_light_sources: Default::default(),
+        };
+
+        engine.propagate_from_empty_sections(
+            ChunkPos(steel_utils::math::Vector2::new(0, 0)),
+            &mut sections,
+            -64,
+        );
+
+        // All sections should be filled with light 15
+        for idx in 1..=num_sections {
+            let light = sections.sky_light[idx].get(0, 0, 0);
+            assert_eq!(light, 15, "Section {} should have light 15", idx);
+        }
+    }
+}

--- a/steel-core/src/chunk/light_engine/sky_light_engine.rs
+++ b/steel-core/src/chunk/light_engine/sky_light_engine.rs
@@ -32,9 +32,6 @@ impl SkyLightEngine {
     /// This is the core optimization: when encountering an empty section,
     /// instead of propagating block-by-block, we skip to the bottom of all
     /// consecutive empty sections below.
-    ///
-    /// # Panics
-    /// This function does not panic under normal circumstances.
     pub fn propagate_from_empty_sections(
         &mut self,
         _chunk_pos: ChunkPos,
@@ -54,16 +51,14 @@ impl SkyLightEngine {
         }
 
         // If all sections are empty (all air), fill everything with light 15
-        if top_section.is_none() {
+        let Some(top_section) = top_section else {
             for idx in 1..=num_sections {
                 if idx < sections.sky_light.len() {
                     *sections.sky_light[idx].write() = LightStorage::new_filled(15);
                 }
             }
             return;
-        }
-
-        let top_section = top_section.expect("top_section should be Some at this point");
+        };
 
         // Fill all sections above top_section with full sky light (15)
         for idx in (top_section + 1)..num_sections {

--- a/steel-core/src/chunk/light_engine/threaded_level_light_engine.rs
+++ b/steel-core/src/chunk/light_engine/threaded_level_light_engine.rs
@@ -260,7 +260,7 @@ impl ThreadedLevelLightEngine {
                     let section = &sections.sections[actual_section_idx];
 
                     for y in (0..16).rev() {
-                        let block_state = section.states.get(x, y - 1, z);
+                        let block_state = section.states.get(x, y, z);
                         let is_air = block_state == BlockStateId(0);
 
                         if is_air {

--- a/steel-core/src/chunk/light_engine/threaded_level_light_engine.rs
+++ b/steel-core/src/chunk/light_engine/threaded_level_light_engine.rs
@@ -1,0 +1,292 @@
+//! Threaded light engine with task queue system.
+//!
+//! This extends the base `LightEngine` with asynchronous task scheduling and batched execution.
+//! Tasks are divided into `PRE_UPDATE` (setup) and `POST_UPDATE` (completion) phases.
+
+use std::sync::Arc;
+
+use parking_lot::{Mutex, RwLock as ParkingRwLock};
+use steel_utils::ChunkPos;
+
+use crate::chunk::{chunk_access::ChunkAccess, section::ChunkSection};
+
+use super::base::LightEngine;
+
+/// Task type for light engine operations.
+///
+/// Tasks are executed in a specific order to ensure correct light propagation:
+/// 1. All `PRE_UPDATE` tasks run first (setup, marking sections)
+/// 2. Light propagation runs (`run_light_updates`)
+/// 3. All `POST_UPDATE` tasks run last (completion, futures)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaskType {
+    /// Tasks executed before light propagation (setup phase).
+    PreUpdate,
+    /// Tasks executed after light propagation (completion phase).
+    PostUpdate,
+}
+
+/// A light engine task with its associated type.
+type LightTask = (TaskType, Box<dyn FnOnce() + Send>);
+
+/// Multi-threaded light engine that batches and schedules lighting operations.
+///
+/// This engine maintains:
+/// - A base `LightEngine` for light propagation
+/// - A task queue for `PRE_UPDATE` and `POST_UPDATE` operations
+/// - Section status tracking for which sections need lighting
+///
+/// # Architecture
+///
+/// The engine follows vanilla Minecraft's pattern:
+/// 1. Public methods (like `initialize_light`) create tasks
+/// 2. Tasks are queued and batched
+/// 3. When batch size is reached or forced, tasks execute:
+///    - `PRE_UPDATE` tasks (mark sections, queue changes)
+///    - Light propagation (`run_light_updates`)
+///    - `POST_UPDATE` tasks (set flags, complete futures)
+pub struct ThreadedLevelLightEngine {
+    /// The base light engine for propagation.
+    light_engine: Arc<Mutex<LightEngine>>,
+    /// Queued tasks waiting to be executed.
+    light_tasks: Arc<Mutex<Vec<LightTask>>>,
+}
+
+impl ThreadedLevelLightEngine {
+    /// Creates a new threaded light engine.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            light_engine: Arc::new(Mutex::new(LightEngine::new())),
+            light_tasks: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    /// Initializes lighting for a chunk.
+    ///
+    /// This method follows vanilla's approach:
+    /// 1. `PRE_UPDATE` task: Scans sections and marks non-empty ones
+    /// 2. `POST_UPDATE` task: Enables lighting and configures data retention
+    ///
+    /// **Important**: This does NOT set light values. It only:
+    /// - Identifies which sections need lighting
+    /// - Marks them for the light engine
+    /// - Enables lighting for the chunk
+    ///
+    /// Actual light propagation happens later in the LIGHT chunk status.
+    pub fn initialize_light(&self, chunk: &ParkingRwLock<Option<ChunkAccess>>, light_enabled: bool) -> Result<(), anyhow::Error> {
+        use crate::chunk::chunk_generator::ChunkGuard;
+
+        let chunk_guard = ChunkGuard::new(chunk);
+        let chunk_pos = match &*chunk_guard {
+            ChunkAccess::Proto(proto) => proto.pos,
+            ChunkAccess::Full(full) => full.pos,
+        };
+        drop(chunk_guard);
+
+        // PRE_UPDATE task: Mark non-empty sections for lighting
+        self.add_task(chunk_pos, TaskType::PreUpdate, {
+            // Note: We can't easily pass the chunk reference into the closure
+            // For now, this is a stub - will be implemented when section status tracking is added
+            move || {
+                // TODO: Access chunk and scan sections
+                // let chunk_guard = ChunkGuard::new(chunk);
+                // let sections = match &*chunk_guard { ... };
+
+                // TODO: Scan sections and mark non-empty ones
+                // for (i, section) in sections.sections.iter().enumerate() {
+                //     if !Self::is_section_empty(section) {
+                //         super.updateSectionStatus(SectionPos.of(chunkPos, section_y), false);
+                //     }
+                // }
+            }
+        });
+
+        // POST_UPDATE task: Enable lighting and configure data retention
+        self.add_task(chunk_pos, TaskType::PostUpdate, {
+            move || {
+                // TODO: Implement set_light_enabled and retain_data
+                // super.setLightEnabled(chunkPos, lightEnabled);
+                // super.retainData(chunkPos, false);
+                let _ = light_enabled;
+                let _ = chunk_pos;
+            }
+        });
+
+        Ok(())
+    }
+
+    /// Adds a task to the task queue.
+    fn add_task<F>(&self, _chunk_pos: ChunkPos, task_type: TaskType, task: F)
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        let mut tasks = self.light_tasks.lock();
+        tasks.push((task_type, Box::new(task)));
+
+        // TODO: Implement batch scheduling
+        // In vanilla, tasks accumulate until batch size reaches 1000 or tryScheduleUpdate() is called
+        // For now, we'll just queue them
+    }
+
+    /// Checks if a section is empty (all air blocks).
+    #[allow(dead_code)] // Stubbed for future use
+    fn is_section_empty(section: &ChunkSection) -> bool {
+        // A section is empty if it only contains air (BlockStateId 0)
+        match &section.states {
+            crate::chunk::paletted_container::PalettedContainer::Homogeneous(id) => {
+                id.0 == 0
+            }
+            crate::chunk::paletted_container::PalettedContainer::Heterogeneous(_) => {
+                // If it's heterogeneous, it has different block types, so not empty
+                false
+            }
+        }
+    }
+
+    /// Runs all queued light tasks and propagates light.
+    ///
+    /// Execution order:
+    /// 1. Execute all `PRE_UPDATE` tasks
+    /// 2. Run light propagation (`run_light_updates`)
+    /// 3. Execute all `POST_UPDATE` tasks
+    ///
+    /// # Note
+    /// This is currently a stub. In the full implementation, this would be called
+    /// by the chunk task dispatcher when the batch is ready.
+    pub fn run_update(&self) {
+        let mut tasks = self.light_tasks.lock();
+        let all_tasks = std::mem::take(&mut *tasks);
+        drop(tasks);
+
+        // Separate tasks by type
+        let (pre_update_tasks, post_update_tasks): (Vec<_>, Vec<_>) = all_tasks
+            .into_iter()
+            .partition(|(task_type, _)| *task_type == TaskType::PreUpdate);
+
+        // Execute PRE_UPDATE tasks
+        for (_, task) in pre_update_tasks {
+            task();
+        }
+
+        // Run light propagation
+        let mut engine = self.light_engine.lock();
+        engine.run_light_updates();
+        drop(engine);
+
+        // Execute POST_UPDATE tasks
+        for (_, task) in post_update_tasks {
+            task();
+        }
+    }
+
+    /// Propagates light throughout a chunk.
+    ///
+    /// This method should:
+    /// 1. Call `propagateLightSources()` for both block and sky light
+    /// 2. Call `run_light_updates()` to propagate all queued light
+    /// 3. Mark chunk as `light_correct`
+    ///
+    /// # Note
+    /// This is currently a TEMPORARY stub implementation that directly sets sky light.
+    /// The proper implementation will use the queue-based flood-fill algorithm.
+    pub fn light_chunk(&self, chunk: &ParkingRwLock<Option<ChunkAccess>>, _light_enabled: bool) -> Result<(), anyhow::Error> {
+        use crate::chunk::{chunk_generator::ChunkGuard, light_storage::LightStorage};
+        use steel_utils::BlockStateId;
+
+        // TEMPORARY: Direct sky light initialization
+        // TODO: Replace with proper light engine implementation:
+        // - propagate_sky_light_sources(chunk_pos)
+        // - propagate_block_light_sources(chunk_pos)
+        // - run_light_updates()
+
+        let mut chunk_guard = ChunkGuard::new(chunk);
+        let sections = match &mut *chunk_guard {
+            ChunkAccess::Proto(proto_chunk) => &mut proto_chunk.sections,
+            ChunkAccess::Full(level_chunk) => &mut level_chunk.sections,
+        };
+
+        let num_sections = sections.sections.len();
+
+        let mut current_section = 0;
+
+        // Scan from top to bottom to find sections that are all air
+        for index in (0..num_sections + 2).rev() {
+            if index == 0 {
+                sections.sky_light[index] = LightStorage::new_empty();
+            } else if index == num_sections + 1 {
+                sections.sky_light[index] = LightStorage::new_filled(15);
+            } else if let Some(section) = sections.sections.get(index - 1) {
+                let is_all_air = match &section.states {
+                    crate::chunk::paletted_container::PalettedContainer::Homogeneous(id) => {
+                        *id == BlockStateId(0)
+                    }
+                    crate::chunk::paletted_container::PalettedContainer::Heterogeneous(_) => false,
+                };
+
+                if is_all_air {
+                    sections.sky_light[index] = LightStorage::new_filled(15);
+                    current_section = index;
+                } else {
+                    break;
+                }
+            }
+        }
+
+        let start_section = if current_section > 0 {
+            current_section - 1
+        } else {
+            0
+        };
+
+        for x in 0..16 {
+            for z in 0..16 {
+                for section_idx in (0..=start_section).rev() {
+                    if section_idx == 0 {
+                        continue;
+                    }
+
+                    let actual_section_idx = section_idx - 1;
+                    if actual_section_idx >= num_sections {
+                        continue;
+                    }
+
+                    let section = &sections.sections[actual_section_idx];
+
+                    for y in (0..16).rev() {
+                        let block_state = section.states.get(x, y-1, z);
+                        let is_air = block_state == BlockStateId(0);
+
+                        if is_air {
+                            sections.sky_light[section_idx].set(x, y, z, 15);
+                        } else {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Checks if there are any pending tasks or light updates.
+    #[must_use]
+    pub fn has_work(&self) -> bool {
+        let tasks = self.light_tasks.lock();
+        let has_tasks = !tasks.is_empty();
+        drop(tasks);
+
+        let engine = self.light_engine.lock();
+        let has_light_work = engine.has_work();
+        drop(engine);
+
+        has_tasks || has_light_work
+    }
+}
+
+impl Default for ThreadedLevelLightEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/steel-core/src/chunk/light_engine/threaded_level_light_engine.rs
+++ b/steel-core/src/chunk/light_engine/threaded_level_light_engine.rs
@@ -74,7 +74,11 @@ impl ThreadedLevelLightEngine {
     /// - Enables lighting for the chunk
     ///
     /// Actual light propagation happens later in the LIGHT chunk status.
-    pub fn initialize_light(&self, chunk: &ParkingRwLock<Option<ChunkAccess>>, light_enabled: bool) -> Result<(), anyhow::Error> {
+    pub fn initialize_light(
+        &self,
+        chunk: &ParkingRwLock<Option<ChunkAccess>>,
+        light_enabled: bool,
+    ) -> Result<(), anyhow::Error> {
         use crate::chunk::chunk_generator::ChunkGuard;
 
         let chunk_guard = ChunkGuard::new(chunk);
@@ -134,9 +138,7 @@ impl ThreadedLevelLightEngine {
     fn is_section_empty(section: &ChunkSection) -> bool {
         // A section is empty if it only contains air (BlockStateId 0)
         match &section.states {
-            crate::chunk::paletted_container::PalettedContainer::Homogeneous(id) => {
-                id.0 == 0
-            }
+            crate::chunk::paletted_container::PalettedContainer::Homogeneous(id) => id.0 == 0,
             crate::chunk::paletted_container::PalettedContainer::Heterogeneous(_) => {
                 // If it's heterogeneous, it has different block types, so not empty
                 false
@@ -190,7 +192,11 @@ impl ThreadedLevelLightEngine {
     /// # Note
     /// This is currently a TEMPORARY stub implementation that directly sets sky light.
     /// The proper implementation will use the queue-based flood-fill algorithm.
-    pub fn light_chunk(&self, chunk: &ParkingRwLock<Option<ChunkAccess>>, _light_enabled: bool) -> Result<(), anyhow::Error> {
+    pub fn light_chunk(
+        &self,
+        chunk: &ParkingRwLock<Option<ChunkAccess>>,
+        _light_enabled: bool,
+    ) -> Result<(), anyhow::Error> {
         use crate::chunk::{chunk_generator::ChunkGuard, light_storage::LightStorage};
         use steel_utils::BlockStateId;
 
@@ -254,7 +260,7 @@ impl ThreadedLevelLightEngine {
                     let section = &sections.sections[actual_section_idx];
 
                     for y in (0..16).rev() {
-                        let block_state = section.states.get(x, y-1, z);
+                        let block_state = section.states.get(x, y - 1, z);
                         let is_air = block_state == BlockStateId(0);
 
                         if is_air {

--- a/steel-core/src/chunk/light_engine/threaded_level_light_engine.rs
+++ b/steel-core/src/chunk/light_engine/threaded_level_light_engine.rs
@@ -22,6 +22,15 @@ use super::{
     queue_entry::QueueEntry,
 };
 
+/// Type of light being propagated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LightType {
+    /// Block light (emitted by light-emitting blocks like torches).
+    Block,
+    /// Sky light (comes from the sky, propagates downward and horizontally).
+    Sky,
+}
+
 /// Synchronous center-chunk-only light access for lock-free propagation.
 ///
 /// Returns `None` when accessing positions outside the center chunk bounds,
@@ -35,6 +44,8 @@ struct CenterOnlyChunkAccess<'a> {
     chunk_min_y: i32,
     /// Block registry for block properties.
     block_registry: Arc<BlockRegistry>,
+    /// Type of light (block or sky).
+    light_type: LightType,
 }
 
 impl<'a> CenterOnlyChunkAccess<'a> {
@@ -43,16 +54,19 @@ impl<'a> CenterOnlyChunkAccess<'a> {
         sections: &'a Sections,
         chunk_min_y: i32,
         block_registry: Arc<BlockRegistry>,
+        light_type: LightType,
     ) -> Self {
         Self {
             chunk_pos,
             sections,
             chunk_min_y,
             block_registry,
+            light_type,
         }
     }
 
     /// Checks if a position is within the center chunk.
+    #[inline]
     fn is_in_center_chunk(&self, pos: BlockPos) -> bool {
         let chunk_x = pos.0.x >> 4;
         let chunk_z = pos.0.z >> 4;
@@ -60,13 +74,26 @@ impl<'a> CenterOnlyChunkAccess<'a> {
     }
 
     /// Converts world position to chunk-relative coordinates.
+    #[inline]
     fn to_relative_coords(&self, pos: BlockPos) -> Option<(usize, usize, usize)> {
         if !self.is_in_center_chunk(pos) {
             return None;
         }
 
-        let rel_x = (pos.0.x & 15) as usize;
+        // Check Y bounds - position must be within valid chunk height range
+        if pos.0.y < self.chunk_min_y {
+            return None; // Below chunk
+        }
+
         let rel_y = (pos.0.y - self.chunk_min_y) as usize;
+
+        // Check if the Y position has a corresponding section
+        let section_idx = rel_y / 16;
+        if section_idx >= self.sections.sections.len() {
+            return None; // Above chunk
+        }
+
+        let rel_x = (pos.0.x & 15) as usize;
         let rel_z = (pos.0.z & 15) as usize;
 
         Some((rel_x, rel_y, rel_z))
@@ -74,10 +101,12 @@ impl<'a> CenterOnlyChunkAccess<'a> {
 }
 
 impl CenterChunkLightAccess for CenterOnlyChunkAccess<'_> {
+    #[inline]
     fn center_chunk_pos(&self) -> ChunkPos {
         self.chunk_pos
     }
 
+    #[inline]
     fn get_light(&self, pos: BlockPos) -> Option<u8> {
         let (rel_x, rel_y, rel_z) = self.to_relative_coords(pos)?;
 
@@ -85,9 +114,14 @@ impl CenterChunkLightAccess for CenterOnlyChunkAccess<'_> {
         let section_y = rel_y % 16;
         let light_section_idx = section_idx + 1; // +1 for padding
 
-        if light_section_idx < self.sections.block_light.len() {
+        let light_array = match self.light_type {
+            LightType::Block => &self.sections.block_light,
+            LightType::Sky => &self.sections.sky_light,
+        };
+
+        if light_section_idx < light_array.len() {
             Some(
-                self.sections.block_light[light_section_idx]
+                light_array[light_section_idx]
                     .read()
                     .get(rel_x, section_y, rel_z),
             )
@@ -96,6 +130,7 @@ impl CenterChunkLightAccess for CenterOnlyChunkAccess<'_> {
         }
     }
 
+    #[inline]
     fn set_light(&self, pos: BlockPos, level: u8) -> bool {
         let Some((rel_x, rel_y, rel_z)) = self.to_relative_coords(pos) else {
             return false;
@@ -105,8 +140,13 @@ impl CenterChunkLightAccess for CenterOnlyChunkAccess<'_> {
         let section_y = rel_y % 16;
         let light_section_idx = section_idx + 1; // +1 for padding
 
-        if light_section_idx < self.sections.block_light.len() {
-            self.sections.block_light[light_section_idx]
+        let light_array = match self.light_type {
+            LightType::Block => &self.sections.block_light,
+            LightType::Sky => &self.sections.sky_light,
+        };
+
+        if light_section_idx < light_array.len() {
+            light_array[light_section_idx]
                 .write()
                 .set(rel_x, section_y, rel_z, level);
             true
@@ -115,11 +155,13 @@ impl CenterChunkLightAccess for CenterOnlyChunkAccess<'_> {
         }
     }
 
+    #[inline]
     fn get_block_state(&self, pos: BlockPos) -> Option<BlockStateId> {
         let (rel_x, rel_y, rel_z) = self.to_relative_coords(pos)?;
         self.sections.get_relative_block(rel_x, rel_y, rel_z)
     }
 
+    #[inline]
     fn is_empty_shape(&self, pos: BlockPos) -> Option<bool> {
         let block_state = self.get_block_state(pos)?;
 
@@ -129,46 +171,45 @@ impl CenterChunkLightAccess for CenterOnlyChunkAccess<'_> {
             Some(true)
         }
     }
+
+    #[inline]
+    fn get_neighbor_data(&self, pos: BlockPos) -> Option<(BlockStateId, u8)> {
+        // Single coordinate conversion for both block state and light
+        let (rel_x, rel_y, rel_z) = self.to_relative_coords(pos)?;
+
+        // Get block state - guaranteed valid since to_relative_coords succeeded
+        let block_state = self.sections.get_relative_block(rel_x, rel_y, rel_z)?;
+
+        // Get light level using the same relative coordinates
+        let section_idx = rel_y / 16;
+        let section_y = rel_y % 16;
+        let light_section_idx = section_idx + 1; // +1 for padding
+
+        let light_array = match self.light_type {
+            LightType::Block => &self.sections.block_light,
+            LightType::Sky => &self.sections.sky_light,
+        };
+
+        let light = if light_section_idx < light_array.len() {
+            light_array[light_section_idx]
+                .read()
+                .get(rel_x, section_y, rel_z)
+        } else {
+            0
+        };
+
+        Some((block_state, light))
+    }
 }
 
-/// Task type for light engine operations.
+/// Multi-threaded light engine for chunk lighting.
 ///
-/// Tasks are executed in a specific order to ensure correct light propagation:
-/// 1. All `PRE_UPDATE` tasks run first (setup, marking sections)
-/// 2. Light propagation runs (`run_light_updates`)
-/// 3. All `POST_UPDATE` tasks run last (completion, futures)
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TaskType {
-    /// Tasks executed before light propagation (setup phase).
-    PreUpdate,
-    /// Tasks executed after light propagation (completion phase).
-    PostUpdate,
-}
-
-/// A light engine task with its associated type.
-type LightTask = (TaskType, Box<dyn FnOnce() + Send>);
-
-/// Multi-threaded light engine that batches and schedules lighting operations.
-///
-/// This engine maintains:
-/// - A base `LightEngine` for light propagation
-/// - A task queue for `PRE_UPDATE` and `POST_UPDATE` operations
-/// - Section status tracking for which sections need lighting
-///
-/// # Architecture
-///
-/// The engine follows vanilla Minecraft's pattern:
-/// 1. Public methods (like `initialize_light`) create tasks
-/// 2. Tasks are queued and batched
-/// 3. When batch size is reached or forced, tasks execute:
-///    - `PRE_UPDATE` tasks (mark sections, queue changes)
-///    - Light propagation (`run_light_updates`)
-///    - `POST_UPDATE` tasks (set flags, complete futures)
+/// This engine provides:
+/// - Lock-free center-chunk propagation with boundary crossing collection
+/// - Iterative cross-chunk propagation with non-blocking lock acquisition
+/// - LRU chunk cache to reduce lock contention
+/// - Empty section optimization for sky light
 pub struct ThreadedLevelLightEngine {
-    /// The base light engine for propagation.
-    light_engine: Arc<SyncMutex<LightEngine>>,
-    /// Queued tasks waiting to be executed.
-    light_tasks: Arc<SyncMutex<Vec<LightTask>>>,
     /// Block registry for block properties.
     block_registry: Arc<BlockRegistry>,
     /// 2-element LRU cache for chunk access.
@@ -180,8 +221,6 @@ impl ThreadedLevelLightEngine {
     #[must_use]
     pub fn new(block_registry: Arc<BlockRegistry>) -> Self {
         Self {
-            light_engine: Arc::new(SyncMutex::new(LightEngine::new())),
-            light_tasks: Arc::new(SyncMutex::new(Vec::new())),
             block_registry,
             chunk_cache: Arc::new(SyncMutex::new(super::chunk_cache::ChunkCache::new())),
         }
@@ -201,82 +240,20 @@ impl ThreadedLevelLightEngine {
 
     /// Initializes lighting for a chunk.
     ///
-    /// This method follows vanilla's approach:
-    /// 1. `PRE_UPDATE` task: Scans sections and marks non-empty ones
-    /// 2. `POST_UPDATE` task: Enables lighting and configures data retention
+    /// This is a placeholder for vanilla's section status tracking system.
+    /// In vanilla, this method would:
+    /// 1. Scan sections and mark non-empty ones for lighting
+    /// 2. Enable lighting and configure data retention
     ///
-    /// **Important**: This does NOT set light values. It only:
-    /// - Identifies which sections need lighting
-    /// - Marks them for the light engine
-    /// - Enables lighting for the chunk
-    ///
-    /// Actual light propagation happens later in the LIGHT chunk status.
+    /// Currently, section status tracking is not implemented, so this method
+    /// is a no-op. Actual light propagation happens in `light_chunk_with_cache`.
     pub fn initialize_light(
         &self,
-        chunk: arc_swap::Guard<Option<std::sync::Arc<ChunkAccess>>>,
-        light_enabled: bool,
+        _chunk: arc_swap::Guard<Option<std::sync::Arc<ChunkAccess>>>,
+        _light_enabled: bool,
     ) -> Result<(), anyhow::Error> {
-        let chunk_guard = ChunkGuard::new(chunk);
-        let chunk_pos = match &*chunk_guard {
-            ChunkAccess::Proto(proto) => proto.pos,
-            ChunkAccess::Full(full) => full.pos,
-        };
-        drop(chunk_guard);
-
-        // PRE_UPDATE task: Mark non-empty sections for lighting
-        self.add_task(chunk_pos, TaskType::PreUpdate, move || {
-            // TODO: Implement section scanning when section status tracking is added
-        });
-
-        // POST_UPDATE task: Enable lighting and configure data retention
-        self.add_task(chunk_pos, TaskType::PostUpdate, move || {
-            // TODO: Implement when light enable/disable tracking is added
-            let _ = light_enabled;
-            let _ = chunk_pos;
-        });
-
+        // No-op until section status tracking is implemented
         Ok(())
-    }
-
-    /// Adds a task to the task queue.
-    fn add_task<F>(&self, _chunk_pos: ChunkPos, task_type: TaskType, task: F)
-    where
-        F: FnOnce() + Send + 'static,
-    {
-        let mut tasks = self.light_tasks.lock();
-        tasks.push((task_type, Box::new(task)));
-    }
-
-    /// Runs all queued light tasks and propagates light.
-    ///
-    /// Execution order:
-    /// 1. Execute all `PRE_UPDATE` tasks
-    /// 2. Run light propagation (`run_light_updates`)
-    /// 3. Execute all `POST_UPDATE` tasks
-    pub fn run_update(&self) {
-        let mut tasks = self.light_tasks.lock();
-        let all_tasks = std::mem::take(&mut *tasks);
-        drop(tasks);
-
-        // Separate tasks by type
-        let (pre_update_tasks, post_update_tasks): (Vec<_>, Vec<_>) = all_tasks
-            .into_iter()
-            .partition(|(task_type, _)| *task_type == TaskType::PreUpdate);
-
-        // Execute PRE_UPDATE tasks
-        for (_, task) in pre_update_tasks {
-            task();
-        }
-
-        // Run light propagation
-        let mut engine = self.light_engine.lock();
-        engine.run_light_updates();
-        drop(engine);
-
-        // Execute POST_UPDATE tasks
-        for (_, task) in post_update_tasks {
-            task();
-        }
     }
 
     /// Propagates light throughout a chunk with cross-chunk support.
@@ -290,7 +267,6 @@ impl ThreadedLevelLightEngine {
     /// Unlike `light_chunk`, this version uses a cache of neighboring chunks to enable
     /// light propagation across chunk boundaries.
     #[allow(clippy::too_many_lines)]
-    #[allow(clippy::unused_async)]
     pub async fn light_chunk_with_cache(
         &self,
         chunk_guard: &ChunkGuard,
@@ -320,6 +296,344 @@ impl ThreadedLevelLightEngine {
             .sky_light_sources
             .write()
             .update_from_chunk_sections(&sections.sections, chunk_min_y);
+
+        // ===== STEP 1.5: Sky light horizontal propagation =====
+        // After vertical fill, propagate sky light horizontally across chunk boundaries.
+        // Uses vanilla's selective enqueue strategy: only enqueue blocks at terrain boundaries.
+        //
+        // Vanilla optimization: Instead of enqueueing all lit blocks (thousands), only enqueue:
+        // 1. Blocks at lowestSourceY (terrain surface) - these propagate DOWN
+        // 2. Blocks below neighbor's lowestSourceY - these propagate HORIZONTALLY to neighbors
+        //
+        // This reduces enqueued blocks from ~4,096 to ~256-512 per chunk (8-16x speedup).
+
+        // Create a new light engine for sky light horizontal propagation
+        let mut sky_engine_horizontal = super::base::LightEngine::new();
+
+        // Compute enqueue positions in a separate scope to ensure lock is dropped early
+        let enqueue_positions = {
+            // Get sky light sources (heightmap) for selective enqueuing
+            let sky_sources = sections.sky_light_sources.read();
+
+            // Get neighbor chunks' sky light sources for boundary checking
+            // Store as (dx, dz, heightmap_array) to avoid lifetime issues
+            let mut neighbor_sources: Vec<(i32, i32, Box<[i32; 256]>)> = vec![];
+            for dx in -1..=1_i32 {
+                for dz in -1..=1_i32 {
+                    if dx == 0 && dz == 0 {
+                        continue; // Skip center chunk
+                    }
+                    let neighbor_chunk_pos = ChunkPos(steel_utils::math::Vector2::new(
+                        chunk_pos.0.x + dx,
+                        chunk_pos.0.y + dz,
+                    ));
+                    let neighbor_holder = cache.get(neighbor_chunk_pos.0.x, neighbor_chunk_pos.0.y);
+                    if let Some(neighbor_arc) = neighbor_holder
+                        .try_chunk(ChunkStatus::InitializeLight)
+                        .and_then(|guard| guard.as_ref().cloned())
+                    {
+                        let heightmap = match neighbor_arc.as_ref() {
+                            ChunkAccess::Proto(proto) => {
+                                let sources = proto.sections.sky_light_sources.read();
+                                // Clone the heightmap data (just 256 i32s, very cheap)
+                                let mut heights = Box::new([0i32; 256]);
+                                for i in 0..256 {
+                                    heights[i] = sources.get(i % 16, i / 16);
+                                }
+                                heights
+                            }
+                            ChunkAccess::Full(full) => {
+                                let sources = full.sections.sky_light_sources.read();
+                                // Clone the heightmap data (just 256 i32s, very cheap)
+                                let mut heights = Box::new([0i32; 256]);
+                                for i in 0..256 {
+                                    heights[i] = sources.get(i % 16, i / 16);
+                                }
+                                heights
+                            }
+                        };
+                        neighbor_sources.push((dx, dz, heightmap));
+                    }
+                }
+            }
+
+            // Helper to get neighbor's lowestSourceY at chunk boundaries
+            let get_neighbor_height = |x: usize, z: usize, dx: i32, dz: i32| -> i32 {
+                for (ndx, ndz, heights) in &neighbor_sources {
+                    if *ndx == dx && *ndz == dz {
+                        // Calculate the corresponding column in the neighbor chunk
+                        use std::cmp::Ordering;
+                        let nx = match dx.cmp(&0) {
+                            Ordering::Less => 15,
+                            Ordering::Greater => 0,
+                            Ordering::Equal => x,
+                        };
+                        let nz = match dz.cmp(&0) {
+                            Ordering::Less => 15,
+                            Ordering::Greater => 0,
+                            Ordering::Equal => z,
+                        };
+                        let idx = nz * 16 + nx;
+                        return heights[idx];
+                    }
+                }
+                i32::MIN // No neighbor data available
+            };
+
+            // Selective enqueue: only blocks at lowestSourceY or below neighbor heights
+            // Collect all enqueue positions first, then drop the lock before processing
+            let mut enqueue_positions = Vec::new();
+            for z in 0..16 {
+                for x in 0..16 {
+                    let lowest_source_y = sky_sources.get(x, z);
+
+                    // Skip if no sky light in this column
+                    if lowest_source_y == i32::MIN {
+                        continue;
+                    }
+
+                    // Get neighbor heights for boundary checking (only for edge columns)
+                    let north_height = if z == 0 {
+                        get_neighbor_height(x, z, 0, -1)
+                    } else {
+                        i32::MIN
+                    };
+                    let south_height = if z == 15 {
+                        get_neighbor_height(x, z, 0, 1)
+                    } else {
+                        i32::MIN
+                    };
+                    let west_height = if x == 0 {
+                        get_neighbor_height(x, z, -1, 0)
+                    } else {
+                        i32::MIN
+                    };
+                    let east_height = if x == 15 {
+                        get_neighbor_height(x, z, 1, 0)
+                    } else {
+                        i32::MIN
+                    };
+
+                    // Calculate the maximum neighbor height for this column
+                    let neighbor_max = [north_height, south_height, west_height, east_height]
+                        .iter()
+                        .filter(|&&h| h != i32::MIN)
+                        .copied()
+                        .max()
+                        .unwrap_or(i32::MIN);
+
+                    // Determine Y range to check: from lowest_source_y down to just below neighbor_max
+                    let min_y_to_check =
+                        if neighbor_max != i32::MIN && neighbor_max > lowest_source_y {
+                            lowest_source_y
+                        } else if neighbor_max != i32::MIN {
+                            neighbor_max - 1
+                        } else {
+                            lowest_source_y
+                        };
+
+                    // Only process Y positions that need to be enqueued
+                    for y in min_y_to_check..=lowest_source_y {
+                        // Vanilla condition: enqueue if at lowestSourceY OR below neighbor height
+                        let at_lowest = y == lowest_source_y;
+                        let below_neighbor = neighbor_max != i32::MIN && y < neighbor_max;
+
+                        if at_lowest || below_neighbor {
+                            enqueue_positions.push((x, y, z));
+                        }
+                    }
+                }
+            }
+
+            drop(sky_sources);
+            enqueue_positions
+        }; // End of scope - sky_sources is definitely dropped here
+
+        // Now enqueue all the collected positions
+        for (x, y, z) in enqueue_positions {
+            let section_idx = ((y - chunk_min_y) / 16) as usize;
+            let section_y = (y - chunk_min_y) % 16;
+            let light_section_idx = section_idx + 1;
+
+            if section_idx >= num_sections || light_section_idx >= sections.sky_light.len() {
+                continue;
+            }
+
+            let sky_light =
+                sections.sky_light[light_section_idx]
+                    .read()
+                    .get(x, section_y as usize, z);
+
+            if sky_light > 0 {
+                let world_x = (chunk_pos.0.x * 16) + x as i32;
+                let world_z = (chunk_pos.0.y * 16) + z as i32;
+                let pos = BlockPos(Vector3::new(world_x, y, world_z));
+
+                let block_state =
+                    sections.sections[section_idx]
+                        .read()
+                        .states
+                        .get(x, section_y as usize, z);
+                let is_empty_shape = !self.has_collision(block_state);
+
+                // Enqueue with all-directional propagation
+                sky_engine_horizontal.enqueue_increase(
+                    pos,
+                    QueueEntry::increase_from_emission(sky_light, is_empty_shape),
+                );
+            }
+        }
+
+        // PHASE 1: Center chunk only horizontal propagation (synchronous, lock-free)
+        {
+            let (_, sections_for_sky_phase1) = match &**chunk_guard {
+                ChunkAccess::Proto(proto_chunk) => (proto_chunk.pos, &proto_chunk.sections),
+                ChunkAccess::Full(level_chunk) => (level_chunk.pos, &level_chunk.sections),
+            };
+
+            let center_access_sky = CenterOnlyChunkAccess::new(
+                chunk_pos,
+                sections_for_sky_phase1,
+                chunk_min_y,
+                self.block_registry.clone(),
+                LightType::Sky,
+            );
+
+            sky_engine_horizontal.run_center_chunk_updates(&center_access_sky);
+        }
+
+        // PHASE 2: Iterative boundary crossing propagation for sky light
+        let sky_current_crossings = sky_engine_horizontal.take_boundary_crossings();
+
+        let mut sky_crossings_by_chunk: FxHashMap<ChunkPos, Vec<BoundaryCrossing>> =
+            FxHashMap::default();
+
+        for crossing in sky_current_crossings {
+            let target_chunk_x = crossing.pos.0.x >> 4;
+            let target_chunk_z = crossing.pos.0.z >> 4;
+            let target_chunk = ChunkPos(steel_utils::math::Vector2::new(
+                target_chunk_x,
+                target_chunk_z,
+            ));
+
+            sky_crossings_by_chunk
+                .entry(target_chunk)
+                .or_default()
+                .push(crossing);
+        }
+
+        let mut sky_consecutive_failed_iterations = 0;
+
+        while !sky_crossings_by_chunk.is_empty() {
+            let mut sky_next_crossings_by_chunk: FxHashMap<ChunkPos, Vec<BoundaryCrossing>> =
+                FxHashMap::default();
+            let mut sky_locked_any_this_iteration = false;
+
+            let mut sky_sorted_chunks: Vec<_> = sky_crossings_by_chunk.into_iter().collect();
+            sky_sorted_chunks.sort_by_key(|(chunk_pos, _)| (chunk_pos.0.x, chunk_pos.0.y));
+
+            for (target_chunk, chunk_crossings) in sky_sorted_chunks {
+                if target_chunk == chunk_pos {
+                    continue;
+                }
+
+                let chunk_holder = cache.get(target_chunk.0.x, target_chunk.0.y);
+                let chunk_lock_opt = chunk_holder.try_chunk(ChunkStatus::InitializeLight);
+
+                let Some(chunk_lock) = chunk_lock_opt else {
+                    sky_next_crossings_by_chunk
+                        .entry(target_chunk)
+                        .or_default()
+                        .extend(chunk_crossings);
+                    continue;
+                };
+
+                sky_locked_any_this_iteration = true;
+
+                if let Some(chunk_arc) = chunk_lock.as_ref() {
+                    let sections = match chunk_arc.as_ref() {
+                        ChunkAccess::Proto(proto) => &proto.sections,
+                        ChunkAccess::Full(full) => &full.sections,
+                    };
+
+                    let mut neighbor_sky_engine = LightEngine::new();
+
+                    for crossing in chunk_crossings {
+                        let rel_x = (crossing.pos.0.x & 15) as usize;
+                        let rel_y = (crossing.pos.0.y - chunk_min_y) as usize;
+                        let rel_z = (crossing.pos.0.z & 15) as usize;
+
+                        let section_idx = rel_y / 16;
+                        let section_y = rel_y % 16;
+                        let light_section_idx = section_idx + 1;
+
+                        if light_section_idx < sections.sky_light.len() {
+                            let current_light = sections.sky_light[light_section_idx]
+                                .read()
+                                .get(rel_x, section_y, rel_z);
+                            let new_light = crossing.entry.level();
+
+                            if new_light > current_light {
+                                sections.sky_light[light_section_idx]
+                                    .write()
+                                    .set(rel_x, section_y, rel_z, new_light);
+                                chunk_holder.mark_light_storage_section_changed(
+                                    light_section_idx as u32,
+                                    true,
+                                );
+
+                                neighbor_sky_engine.enqueue_increase(crossing.pos, crossing.entry);
+                            }
+                        }
+                    }
+
+                    if neighbor_sky_engine.has_work() {
+                        let neighbor_access_sky = CenterOnlyChunkAccess::new(
+                            target_chunk,
+                            sections,
+                            chunk_min_y,
+                            self.block_registry.clone(),
+                            LightType::Sky,
+                        );
+
+                        neighbor_sky_engine.run_center_chunk_updates(&neighbor_access_sky);
+
+                        let new_crossings = neighbor_sky_engine.take_boundary_crossings();
+                        for crossing in new_crossings {
+                            let target_chunk_x = crossing.pos.0.x >> 4;
+                            let target_chunk_z = crossing.pos.0.z >> 4;
+                            let target_chunk = ChunkPos(steel_utils::math::Vector2::new(
+                                target_chunk_x,
+                                target_chunk_z,
+                            ));
+
+                            sky_next_crossings_by_chunk
+                                .entry(target_chunk)
+                                .or_default()
+                                .push(crossing);
+                        }
+                    }
+                }
+            }
+
+            if sky_locked_any_this_iteration {
+                sky_consecutive_failed_iterations = 0;
+            } else if !sky_next_crossings_by_chunk.is_empty() {
+                sky_consecutive_failed_iterations += 1;
+            }
+
+            if sky_consecutive_failed_iterations >= 10 && !sky_next_crossings_by_chunk.is_empty() {
+                tokio::task::yield_now().await;
+                sky_consecutive_failed_iterations = 0;
+            }
+
+            sky_crossings_by_chunk = sky_next_crossings_by_chunk;
+        }
+
+        // Mark all sky light sections in center chunk as changed
+        for section_idx in 0..num_light_sections {
+            center_holder.mark_light_storage_section_changed(section_idx as u32, true);
+        }
 
         // ===== STEP 2: Scan for block light sources and enqueue =====
         // Create a new light engine instance for this chunk to avoid lock contention
@@ -412,6 +726,7 @@ impl ThreadedLevelLightEngine {
                 sections_for_phase1,
                 chunk_min_y,
                 self.block_registry.clone(),
+                LightType::Block,
             );
 
             engine.run_center_chunk_updates(&center_access);
@@ -423,9 +738,7 @@ impl ThreadedLevelLightEngine {
         }
 
         // PHASE 2: Iterative boundary crossing propagation
-        let _phase2_start = Instant::now();
         let current_crossings = engine.take_boundary_crossings();
-        let _total_crossings = current_crossings.len();
 
         // Pre-group crossings once to avoid regrouping on every retry
         let mut crossings_by_chunk: FxHashMap<ChunkPos, Vec<BoundaryCrossing>> =
@@ -450,7 +763,7 @@ impl ThreadedLevelLightEngine {
         while !crossings_by_chunk.is_empty() {
             let mut next_crossings_by_chunk: FxHashMap<ChunkPos, Vec<BoundaryCrossing>> =
                 FxHashMap::default();
-            let locked_any_this_iteration = false;
+            let mut locked_any_this_iteration = false;
 
             // Sort chunks by position for deterministic lock ordering (prevents deadlocks)
             let mut sorted_chunks: Vec<_> = crossings_by_chunk.into_iter().collect();
@@ -476,6 +789,9 @@ impl ThreadedLevelLightEngine {
                         .extend(chunk_crossings);
                     continue;
                 };
+
+                // Successfully locked a chunk this iteration
+                locked_any_this_iteration = true;
 
                 if let Some(chunk_arc) = chunk_lock.as_ref() {
                     let sections = match chunk_arc.as_ref() {
@@ -524,6 +840,7 @@ impl ThreadedLevelLightEngine {
                             sections,
                             chunk_min_y,
                             self.block_registry.clone(),
+                            LightType::Block,
                         );
 
                         neighbor_engine.run_center_chunk_updates(&neighbor_access);
@@ -565,8 +882,10 @@ impl ThreadedLevelLightEngine {
             crossings_by_chunk = next_crossings_by_chunk;
         }
 
-        let total_duration = overall_start.elapsed();
-        log::info!("Light propagation for chunk {chunk_pos:?} completed in {total_duration:?}");
+        log::trace!(
+            "Chunk {chunk_pos:?} lighting completed in {}µs",
+            overall_start.elapsed().as_micros()
+        );
 
         Ok(())
     }
@@ -578,19 +897,5 @@ impl ThreadedLevelLightEngine {
         } else {
             false // Unknown blocks treated as no collision
         }
-    }
-
-    /// Checks if there are any pending tasks or light updates.
-    #[must_use]
-    pub fn has_work(&self) -> bool {
-        let tasks = self.light_tasks.lock();
-        let has_tasks = !tasks.is_empty();
-        drop(tasks);
-
-        let engine = self.light_engine.lock();
-        let has_light_work = engine.has_work();
-        drop(engine);
-
-        has_tasks || has_light_work
     }
 }

--- a/steel-core/src/chunk/light_storage.rs
+++ b/steel-core/src/chunk/light_storage.rs
@@ -1,0 +1,189 @@
+//! Light storage for chunk sections.
+//!
+//! Light values are stored as 4-bit values (0-15), packed as two values per byte.
+//! For a 16x16x16 section, this requires 2048 bytes (4096 blocks / 2).
+
+use std::fmt::Debug;
+
+/// The number of bytes needed to store light data for a 16x16x16 section.
+/// 16*16*16 blocks = 4096 blocks, at 4 bits per block = 2048 bytes
+pub const LIGHT_ARRAY_SIZE: usize = 2048;
+
+/// Storage for light data in a chunk section.
+/// Light values range from 0-15 (4 bits per block).
+#[derive(Debug, Clone)]
+pub enum LightStorage {
+    /// All blocks in the section have the same light level (0-15).
+    Homogeneous(u8),
+    /// Blocks have different light levels, stored as packed nibbles.
+    /// Each byte contains two 4-bit light values.
+    Heterogeneous(Box<[u8; LIGHT_ARRAY_SIZE]>),
+}
+
+impl LightStorage {
+    /// Creates a new homogeneous light storage with all blocks at the given light level.
+    #[must_use]
+    pub fn new_filled(light_level: u8) -> Self {
+        debug_assert!(light_level <= 15, "Light level must be 0-15");
+        Self::Homogeneous(light_level)
+    }
+
+    /// Creates a new empty (dark) light storage.
+    #[must_use]
+    pub fn new_empty() -> Self {
+        Self::Homogeneous(0)
+    }
+
+    /// Gets the light level at the given position.
+    ///
+    /// # Arguments
+    /// * `x` - X coordinate (0-15)
+    /// * `y` - Y coordinate (0-15)
+    /// * `z` - Z coordinate (0-15)
+    #[must_use]
+    #[inline]
+    pub fn get(&self, x: usize, y: usize, z: usize) -> u8 {
+        debug_assert!(x < 16 && y < 16 && z < 16, "Coordinates must be 0-15");
+
+        match self {
+            Self::Homogeneous(level) => *level,
+            Self::Heterogeneous(data) => {
+                // Calculate index: y * 16 * 16 + z * 16 + x
+                let block_index = y * 256 + z * 16 + x;
+                let byte_index = block_index >> 1;
+                let is_upper_nibble = (block_index & 1) == 1;
+
+                if is_upper_nibble {
+                    (data[byte_index] >> 4) & 0x0F
+                } else {
+                    data[byte_index] & 0x0F
+                }
+            }
+        }
+    }
+
+    /// Sets the light level at the given position.
+    ///
+    /// If currently homogeneous and setting a different value, upgrades to heterogeneous.
+    ///
+    /// # Arguments
+    /// * `x` - X coordinate (0-15)
+    /// * `y` - Y coordinate (0-15)
+    /// * `z` - Z coordinate (0-15)
+    /// * `light_level` - Light level (0-15)
+    #[inline]
+    pub fn set(&mut self, x: usize, y: usize, z: usize, light_level: u8) {
+        debug_assert!(x < 16 && y < 16 && z < 16, "Coordinates must be 0-15");
+        debug_assert!(light_level <= 15, "Light level must be 0-15");
+
+        match self {
+            Self::Homogeneous(current_level) => {
+                if light_level == *current_level {
+                    // No change needed
+                    return;
+                }
+
+                // Upgrade to heterogeneous
+                let mut data = if *current_level == 0 {
+                    Box::new([0u8; LIGHT_ARRAY_SIZE])
+                } else {
+                    // Fill with current level in both nibbles
+                    let packed = (*current_level & 0x0F) | ((*current_level & 0x0F) << 4);
+                    Box::new([packed; LIGHT_ARRAY_SIZE])
+                };
+
+                // Set the new value
+                let block_index = y * 256 + z * 16 + x;
+                let byte_index = block_index >> 1;
+                let is_upper_nibble = (block_index & 1) == 1;
+
+                if is_upper_nibble {
+                    data[byte_index] = (data[byte_index] & 0x0F) | ((light_level & 0x0F) << 4);
+                } else {
+                    data[byte_index] = (data[byte_index] & 0xF0) | (light_level & 0x0F);
+                }
+
+                *self = Self::Heterogeneous(data);
+            }
+            Self::Heterogeneous(data) => {
+                let block_index = y * 256 + z * 16 + x;
+                let byte_index = block_index >> 1;
+                let is_upper_nibble = (block_index & 1) == 1;
+
+                if is_upper_nibble {
+                    data[byte_index] = (data[byte_index] & 0x0F) | ((light_level & 0x0F) << 4);
+                } else {
+                    data[byte_index] = (data[byte_index] & 0xF0) | (light_level & 0x0F);
+                }
+            }
+        }
+    }
+
+    /// Returns the raw data for sending to the client.
+    ///
+    /// For homogeneous storage, creates a filled array.
+    /// For heterogeneous storage, returns a clone of the data.
+    #[must_use]
+    pub fn to_packet_data(&self) -> Vec<u8> {
+        match self {
+            Self::Homogeneous(level) => {
+                // Pack the level into both nibbles of each byte
+                let packed = (*level & 0x0F) | ((*level & 0x0F) << 4);
+                vec![packed; LIGHT_ARRAY_SIZE]
+            }
+            Self::Heterogeneous(data) => data.to_vec(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_homogeneous_get() {
+        let storage = LightStorage::new_filled(15);
+        assert_eq!(storage.get(0, 0, 0), 15);
+        assert_eq!(storage.get(15, 15, 15), 15);
+    }
+
+    #[test]
+    fn test_set_upgrades_to_heterogeneous() {
+        let mut storage = LightStorage::new_empty();
+        storage.set(5, 5, 5, 14);
+
+        assert_eq!(storage.get(5, 5, 5), 14);
+        assert_eq!(storage.get(0, 0, 0), 0);
+
+        assert!(matches!(storage, LightStorage::Heterogeneous(_)));
+    }
+
+    #[test]
+    fn test_heterogeneous_get_set() {
+        let mut storage = LightStorage::new_empty();
+
+        // Set various light levels
+        storage.set(0, 0, 0, 15);
+        storage.set(1, 0, 0, 14);
+        storage.set(0, 1, 0, 7);
+        storage.set(15, 15, 15, 1);
+
+        assert_eq!(storage.get(0, 0, 0), 15);
+        assert_eq!(storage.get(1, 0, 0), 14);
+        assert_eq!(storage.get(0, 1, 0), 7);
+        assert_eq!(storage.get(15, 15, 15), 1);
+        assert_eq!(storage.get(8, 8, 8), 0); // Unchanged
+    }
+
+    #[test]
+    fn test_packed_nibbles() {
+        let mut storage = LightStorage::new_empty();
+
+        // Set two adjacent blocks (they share a byte)
+        storage.set(0, 0, 0, 5);
+        storage.set(1, 0, 0, 10);
+
+        assert_eq!(storage.get(0, 0, 0), 5);
+        assert_eq!(storage.get(1, 0, 0), 10);
+    }
+}

--- a/steel-core/src/chunk/mod.rs
+++ b/steel-core/src/chunk/mod.rs
@@ -16,6 +16,7 @@ pub mod player_chunk_view;
 /// Generates flat worlds with configurable layers.
 pub mod flat_chunk_generator;
 pub mod level_chunk;
+pub mod light_storage;
 pub mod paletted_container;
 pub mod proto_chunk;
 pub mod section;

--- a/steel-core/src/chunk/mod.rs
+++ b/steel-core/src/chunk/mod.rs
@@ -22,5 +22,8 @@ pub mod light_storage;
 pub mod paletted_container;
 pub mod proto_chunk;
 pub mod section;
+pub mod sky_light_sources;
 
 pub mod world_gen_context;
+
+pub use sky_light_sources::ChunkSkyLightSources;

--- a/steel-core/src/chunk/mod.rs
+++ b/steel-core/src/chunk/mod.rs
@@ -16,6 +16,8 @@ pub mod player_chunk_view;
 /// Generates flat worlds with configurable layers.
 pub mod flat_chunk_generator;
 pub mod level_chunk;
+/// Light engine for chunk lighting using flood-fill propagation.
+pub mod light_engine;
 pub mod light_storage;
 pub mod paletted_container;
 pub mod proto_chunk;

--- a/steel-core/src/chunk/section.rs
+++ b/steel-core/src/chunk/section.rs
@@ -6,6 +6,7 @@ use steel_utils::{BlockStateId, locks::SyncRwLock, serial::WriteTo};
 use crate::chunk::{
     light_storage::LightStorage,
     paletted_container::{BiomePalette, BlockPalette},
+    sky_light_sources::ChunkSkyLightSources,
 };
 
 /// A collection of chunk sections.
@@ -19,6 +20,8 @@ pub struct Sections {
     /// Block light data for each section.
     /// Note: Length is `sections.len() + 2` for padding above and below.
     pub block_light: Box<[LightStorage]>,
+    /// Sky light source tracking for optimization.
+    pub sky_light_sources: ChunkSkyLightSources,
 }
 
 impl Sections {

--- a/steel-core/src/chunk/section.rs
+++ b/steel-core/src/chunk/section.rs
@@ -16,23 +16,35 @@ pub struct Sections {
     pub sections: Box<[Arc<SyncRwLock<ChunkSection>>]>,
     /// Sky light data for each section.
     /// Note: Length is `sections.len() + 2` for padding above and below.
-    pub sky_light: Box<[LightStorage]>,
+    pub sky_light: Box<[Arc<SyncRwLock<LightStorage>>]>,
     /// Block light data for each section.
     /// Note: Length is `sections.len() + 2` for padding above and below.
-    pub block_light: Box<[LightStorage]>,
+    pub block_light: Box<[Arc<SyncRwLock<LightStorage>>]>,
     /// Sky light source tracking for optimization.
-    pub sky_light_sources: ChunkSkyLightSources,
+    /// Wrapped in SyncRwLock for interior mutability.
+    pub sky_light_sources: Arc<SyncRwLock<ChunkSkyLightSources>>,
 }
 
 impl Sections {
     /// Creates a new `Sections` from a box of owned `ChunkSection`s.
     #[must_use]
     pub fn from_owned(sections: Box<[ChunkSection]>) -> Self {
+        let section_count = sections.len();
+        let sky_light = (0..(section_count + 2))
+            .map(|_| Arc::new(SyncRwLock::new(LightStorage::new_empty())))
+            .collect();
+        let block_light = (0..(section_count + 2))
+            .map(|_| Arc::new(SyncRwLock::new(LightStorage::new_empty())))
+            .collect();
+
         Self {
             sections: sections
                 .into_iter()
                 .map(|section| Arc::new(SyncRwLock::new(section)))
                 .collect(),
+            sky_light,
+            block_light,
+            sky_light_sources: Arc::new(SyncRwLock::new(ChunkSkyLightSources::default())),
         }
     }
 

--- a/steel-core/src/chunk/section.rs
+++ b/steel-core/src/chunk/section.rs
@@ -3,13 +3,22 @@ use std::{fmt::Debug, io::Cursor, sync::Arc};
 
 use steel_utils::{BlockStateId, locks::SyncRwLock, serial::WriteTo};
 
-use crate::chunk::paletted_container::{BiomePalette, BlockPalette};
+use crate::chunk::{
+    light_storage::LightStorage,
+    paletted_container::{BiomePalette, BlockPalette},
+};
 
 /// A collection of chunk sections.
 #[derive(Debug, Clone)]
 pub struct Sections {
     /// The sections in the collection.
     pub sections: Box<[Arc<SyncRwLock<ChunkSection>>]>,
+    /// Sky light data for each section.
+    /// Note: Length is `sections.len() + 2` for padding above and below.
+    pub sky_light: Box<[LightStorage]>,
+    /// Block light data for each section.
+    /// Note: Length is `sections.len() + 2` for padding above and below.
+    pub block_light: Box<[LightStorage]>,
 }
 
 impl Sections {

--- a/steel-core/src/chunk/section.rs
+++ b/steel-core/src/chunk/section.rs
@@ -21,7 +21,7 @@ pub struct Sections {
     /// Note: Length is `sections.len() + 2` for padding above and below.
     pub block_light: Box<[Arc<SyncRwLock<LightStorage>>]>,
     /// Sky light source tracking for optimization.
-    /// Wrapped in SyncRwLock for interior mutability.
+    /// Wrapped in `SyncRwLock` for interior mutability.
     pub sky_light_sources: Arc<SyncRwLock<ChunkSkyLightSources>>,
 }
 

--- a/steel-core/src/chunk/sky_light_sources.rs
+++ b/steel-core/src/chunk/sky_light_sources.rs
@@ -88,7 +88,9 @@ impl ChunkSkyLightSources {
     /// then sets the sky light source to one block above that position.
     pub fn update_from_chunk_sections(
         &mut self,
-        chunk_sections: &[crate::chunk::section::ChunkSection],
+        chunk_sections: &[std::sync::Arc<
+            steel_utils::locks::SyncRwLock<crate::chunk::section::ChunkSection>,
+        >],
         chunk_min_y: i32,
     ) {
         use crate::chunk::paletted_container::PalettedContainer;
@@ -103,7 +105,7 @@ impl ChunkSkyLightSources {
 
                 // Scan from top to bottom
                 for section_idx in (0..num_sections).rev() {
-                    let section = &chunk_sections[section_idx];
+                    let section = chunk_sections[section_idx].read();
                     let section_base_y = chunk_min_y + (section_idx as i32 * 16);
 
                     // Check if section is all air - skip if so

--- a/steel-core/src/chunk/sky_light_sources.rs
+++ b/steel-core/src/chunk/sky_light_sources.rs
@@ -1,0 +1,222 @@
+//! Sky light source tracking for chunk columns.
+
+/// Tracks the lowest Y-coordinate where sky light enters each column of a chunk.
+///
+/// This structure maintains a 16x16 grid (one entry per XZ column) indicating
+/// the lowest block position where sky light (level 15) enters from above.
+/// This allows the lighting engine to skip unnecessary work when propagating
+/// sky light.
+///
+/// # Storage Format
+///
+/// Heights are stored as Y-coordinates relative to world minimum Y (typically -64).
+/// A value of 0 means the lowest possible Y, higher values mean higher positions.
+///
+/// Special value: `i32::MIN` indicates "no sky light source" (column is fully occluded).
+#[derive(Debug, Clone)]
+pub struct ChunkSkyLightSources {
+    /// Minimum Y coordinate of the world.
+    min_y: i32,
+
+    /// Maximum Y coordinate of the world.
+    max_y: i32,
+
+    /// Sky light source heights for each column (16x16 = 256 entries).
+    /// Stored in Z-major order: index = z * 16 + x
+    heights: Box<[i32; 256]>,
+}
+
+impl ChunkSkyLightSources {
+    /// Creates a new sky light sources tracker.
+    ///
+    /// # Arguments
+    /// * `min_y` - World minimum Y coordinate (typically -64)
+    /// * `max_y` - World maximum Y coordinate (typically 320)
+    #[must_use]
+    pub fn new(min_y: i32, max_y: i32) -> Self {
+        Self {
+            min_y,
+            max_y,
+            heights: Box::new([max_y; 256]),
+        }
+    }
+
+    /// Creates an empty sources tracker (all columns fully occluded).
+    #[must_use]
+    pub fn empty(min_y: i32, max_y: i32) -> Self {
+        Self {
+            min_y,
+            max_y,
+            heights: Box::new([i32::MIN; 256]),
+        }
+    }
+
+    /// Gets the sky light source Y-coordinate for a column.
+    ///
+    /// # Arguments
+    /// * `x` - Column X coordinate (0-15)
+    /// * `z` - Column Z coordinate (0-15)
+    ///
+    /// # Returns
+    /// The Y-coordinate where sky light enters, or `i32::MIN` if fully occluded.
+    #[inline]
+    #[must_use]
+    pub fn get(&self, x: usize, z: usize) -> i32 {
+        debug_assert!(x < 16 && z < 16, "Column coordinates must be 0-15");
+        self.heights[z * 16 + x]
+    }
+
+    /// Sets the sky light source Y-coordinate for a column.
+    ///
+    /// # Arguments
+    /// * `x` - Column X coordinate (0-15)
+    /// * `z` - Column Z coordinate (0-15)
+    /// * `y` - Y-coordinate where sky light enters
+    #[inline]
+    pub fn set(&mut self, x: usize, z: usize, y: i32) {
+        debug_assert!(x < 16 && z < 16, "Column coordinates must be 0-15");
+        debug_assert!(
+            y == i32::MIN || (y >= self.min_y && y <= self.max_y),
+            "Y coordinate must be within world bounds or i32::MIN"
+        );
+        self.heights[z * 16 + x] = y;
+    }
+
+    /// Updates sky light sources based on chunk sections.
+    ///
+    /// Scans from top to bottom to find the highest solid block in each column,
+    /// then sets the sky light source to one block above that position.
+    pub fn update_from_chunk_sections(
+        &mut self,
+        chunk_sections: &[crate::chunk::section::ChunkSection],
+        chunk_min_y: i32,
+    ) {
+        use crate::chunk::paletted_container::PalettedContainer;
+        use steel_utils::BlockStateId;
+
+        let num_sections = chunk_sections.len();
+
+        for z in 0..16 {
+            for x in 0..16 {
+                let mut sky_source_y = self.max_y;
+                let mut found_solid = false;
+
+                // Scan from top to bottom
+                for section_idx in (0..num_sections).rev() {
+                    let section = &chunk_sections[section_idx];
+                    let section_base_y = chunk_min_y + (section_idx as i32 * 16);
+
+                    // Check if section is all air - skip if so
+                    let is_all_air = match &section.states {
+                        PalettedContainer::Homogeneous(id) => *id == BlockStateId(0),
+                        PalettedContainer::Heterogeneous(_) => false,
+                    };
+
+                    if is_all_air {
+                        continue;
+                    }
+
+                    // Scan this section from top to bottom
+                    for y in (0..16).rev() {
+                        let block_state = section.states.get(x, y, z);
+                        let is_air = block_state == BlockStateId(0);
+
+                        if !is_air {
+                            // Found highest solid block
+                            sky_source_y = section_base_y + y as i32 + 1;
+                            found_solid = true;
+                            break;
+                        }
+                    }
+
+                    if found_solid {
+                        break;
+                    }
+                }
+
+                // If no solid block found, sky light comes from above max_y
+                // If solid block found, sky light comes from one block above it
+                self.set(x, z, sky_source_y);
+            }
+        }
+    }
+
+    /// Checks if a column has sky light access.
+    #[inline]
+    #[must_use]
+    pub fn has_sky_light(&self, x: usize, z: usize) -> bool {
+        self.get(x, z) != i32::MIN
+    }
+
+    /// Gets the minimum Y across all columns (lowest sky light entry point).
+    #[must_use]
+    pub fn min_source_y(&self) -> i32 {
+        let mut min = self.max_y;
+        for &height in self.heights.iter() {
+            if height != i32::MIN && height < min {
+                min = height;
+            }
+        }
+        min
+    }
+
+    /// Gets the maximum Y across all columns (highest sky light entry point).
+    #[must_use]
+    pub fn max_source_y(&self) -> i32 {
+        let mut max = self.min_y;
+        for &height in self.heights.iter() {
+            if height != i32::MIN && height > max {
+                max = height;
+            }
+        }
+        max
+    }
+}
+
+impl Default for ChunkSkyLightSources {
+    fn default() -> Self {
+        // Default to standard Minecraft world height
+        Self::new(-64, 320)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_set() {
+        let mut sources = ChunkSkyLightSources::new(-64, 320);
+
+        sources.set(0, 0, 100);
+        assert_eq!(sources.get(0, 0), 100);
+
+        sources.set(15, 15, -64);
+        assert_eq!(sources.get(15, 15), -64);
+    }
+
+    #[test]
+    fn test_empty() {
+        let sources = ChunkSkyLightSources::empty(-64, 320);
+
+        for z in 0..16 {
+            for x in 0..16 {
+                assert_eq!(sources.get(x, z), i32::MIN);
+                assert!(!sources.has_sky_light(x, z));
+            }
+        }
+    }
+
+    #[test]
+    fn test_min_max_source_y() {
+        // Start with empty sources (all i32::MIN)
+        let mut sources = ChunkSkyLightSources::empty(-64, 320);
+
+        sources.set(0, 0, 100);
+        sources.set(5, 5, 50);
+        sources.set(15, 15, 200);
+
+        assert_eq!(sources.min_source_y(), 50);
+        assert_eq!(sources.max_source_y(), 200);
+    }
+}

--- a/steel-core/src/chunk/world_gen_context.rs
+++ b/steel-core/src/chunk/world_gen_context.rs
@@ -23,6 +23,8 @@ pub struct WorldGenContext {
     pub generator: Arc<ChunkGeneratorType>,
     /// The light engine for chunk lighting.
     pub light_engine: Arc<ThreadedLevelLightEngine>,
+    /// Tokio runtime handle for async operations in sync contexts.
+    pub runtime_handle: tokio::runtime::Handle,
     // Add other fields as needed:
     // pub level: ServerLevel,
     // pub structure_manager: StructureTemplateManager,

--- a/steel-core/src/chunk/world_gen_context.rs
+++ b/steel-core/src/chunk/world_gen_context.rs
@@ -7,6 +7,7 @@ use enum_dispatch::enum_dispatch;
 use crate::chunk::{
     chunk_access::ChunkAccess, chunk_generator::ChunkGenerator,
     flat_chunk_generator::FlatChunkGenerator,
+    light_engine::ThreadedLevelLightEngine,
 };
 
 #[allow(missing_docs)]
@@ -20,10 +21,11 @@ pub enum ChunkGeneratorType {
 pub struct WorldGenContext {
     /// The chunk generator to use.
     pub generator: Arc<ChunkGeneratorType>,
+    /// The light engine for chunk lighting.
+    pub light_engine: Arc<ThreadedLevelLightEngine>,
     // Add other fields as needed:
     // pub level: ServerLevel,
     // pub structure_manager: StructureTemplateManager,
-    // pub light_engine: ThreadedLevelLightEngine,
     // pub main_thread_executor: Executor,
     // pub unsaved_listener: UnsavedListener,
 }

--- a/steel-core/src/chunk/world_gen_context.rs
+++ b/steel-core/src/chunk/world_gen_context.rs
@@ -6,8 +6,7 @@ use enum_dispatch::enum_dispatch;
 
 use crate::chunk::{
     chunk_access::ChunkAccess, chunk_generator::ChunkGenerator,
-    flat_chunk_generator::FlatChunkGenerator,
-    light_engine::ThreadedLevelLightEngine,
+    flat_chunk_generator::FlatChunkGenerator, light_engine::ThreadedLevelLightEngine,
 };
 
 #[allow(missing_docs)]

--- a/steel-core/src/chunk_saver/region_manager.rs
+++ b/steel-core/src/chunk_saver/region_manager.rs
@@ -16,6 +16,7 @@ use tokio::{
 };
 
 use crate::chunk::{
+    ChunkSkyLightSources,
     chunk_access::{ChunkAccess, ChunkStatus},
     level_chunk::LevelChunk,
     paletted_container::PalettedContainer,
@@ -705,6 +706,7 @@ impl RegionManager {
                         .collect(),
                     sky_light,
                     block_light,
+                    sky_light_sources: ChunkSkyLightSources::default(),
                 },
                 pos,
             )),
@@ -716,6 +718,7 @@ impl RegionManager {
                         .collect(),
                     sky_light,
                     block_light,
+                    sky_light_sources: ChunkSkyLightSources::default(),
                 },
                 pos,
             )),

--- a/steel-core/src/chunk_saver/region_manager.rs
+++ b/steel-core/src/chunk_saver/region_manager.rs
@@ -691,10 +691,10 @@ impl RegionManager {
         // Initialize light storage for loaded chunks
         // TODO: Load actual light data from persistent storage
         let sky_light = (0..(section_count + 2))
-            .map(|_| LightStorage::new_empty())
+            .map(|_| Arc::new(SyncRwLock::new(LightStorage::new_empty())))
             .collect();
         let block_light = (0..(section_count + 2))
-            .map(|_| LightStorage::new_empty())
+            .map(|_| Arc::new(SyncRwLock::new(LightStorage::new_empty())))
             .collect();
 
         match status {
@@ -706,7 +706,7 @@ impl RegionManager {
                         .collect(),
                     sky_light,
                     block_light,
-                    sky_light_sources: ChunkSkyLightSources::default(),
+                    sky_light_sources: Arc::new(SyncRwLock::new(ChunkSkyLightSources::default())),
                 },
                 pos,
             )),
@@ -718,7 +718,7 @@ impl RegionManager {
                         .collect(),
                     sky_light,
                     block_light,
-                    sky_light_sources: ChunkSkyLightSources::default(),
+                    sky_light_sources: Arc::new(SyncRwLock::new(ChunkSkyLightSources::default())),
                 },
                 pos,
             )),

--- a/steel-core/src/chunk_saver/region_manager.rs
+++ b/steel-core/src/chunk_saver/region_manager.rs
@@ -677,10 +677,23 @@ impl RegionManager {
         pos: ChunkPos,
         status: ChunkStatus,
     ) -> ChunkAccess {
+        use crate::chunk::light_storage::LightStorage;
+
         let sections: Vec<ChunkSection> = persistent
             .sections
             .iter()
             .map(|section| self.persistent_to_section(section, persistent))
+            .collect();
+
+        let section_count = sections.len();
+
+        // Initialize light storage for loaded chunks
+        // TODO: Load actual light data from persistent storage
+        let sky_light = (0..(section_count + 2))
+            .map(|_| LightStorage::new_empty())
+            .collect();
+        let block_light = (0..(section_count + 2))
+            .map(|_| LightStorage::new_empty())
             .collect();
 
         match status {
@@ -690,6 +703,8 @@ impl RegionManager {
                         .into_iter()
                         .map(|section| Arc::new(SyncRwLock::new(section)))
                         .collect(),
+                    sky_light,
+                    block_light,
                 },
                 pos,
             )),
@@ -699,6 +714,8 @@ impl RegionManager {
                         .into_iter()
                         .map(|section| Arc::new(SyncRwLock::new(section)))
                         .collect(),
+                    sky_light,
+                    block_light,
                 },
                 pos,
             )),

--- a/steel-core/src/player/chunk_sender.rs
+++ b/steel-core/src/player/chunk_sender.rs
@@ -56,7 +56,7 @@ impl ChunkSender {
         player_chunk_pos: ChunkPos,
     ) {
         // First, broadcast any light updates for already-sent chunks
-        self.broadcast_light_updates(connection.clone(), world, player_chunk_pos);
+        Self::broadcast_light_updates(connection.clone(), world, player_chunk_pos);
 
         if self.unacknowledged_batches < self.max_unacknowledged_batches {
             let max_batch_size = self.desired_chunks_per_tick.max(1.0);
@@ -150,7 +150,6 @@ impl ChunkSender {
 
     /// Broadcasts light updates for chunks that have had their light modified by neighbors.
     fn broadcast_light_updates(
-        &self,
         connection: Arc<JavaConnection>,
         world: &World,
         player_chunk_pos: ChunkPos,
@@ -164,35 +163,47 @@ impl ChunkSender {
                     player_chunk_pos.0.y + dz,
                 ));
 
-                if let Some(holder) = world.chunk_map.chunks.read_sync(&pos, |_, chunk| chunk.clone()) {
+                if let Some(holder) = world
+                    .chunk_map
+                    .chunks
+                    .read_sync(&pos, |_, chunk| chunk.clone())
+                {
                     // Check if this chunk has light changes and is already at Full status
-                    if holder.has_light_changes() && holder.persisted_status() == Some(ChunkStatus::Full) {
+                    if holder.has_light_changes()
+                        && holder.persisted_status() == Some(ChunkStatus::Full)
+                    {
                         // Get the changed section flags before clearing
-                        let sky_changed = holder.sky_changed_sections.load(std::sync::atomic::Ordering::Relaxed);
-                        let block_changed = holder.block_changed_sections.load(std::sync::atomic::Ordering::Relaxed);
+                        let sky_changed = holder
+                            .sky_changed_sections
+                            .load(std::sync::atomic::Ordering::Relaxed);
+                        let block_changed = holder
+                            .block_changed_sections
+                            .load(std::sync::atomic::Ordering::Relaxed);
 
                         // Only send if there are actual changes
-                        if sky_changed != 0 || block_changed != 0 {
-                            if let Some(chunk_lock) = holder.try_chunk(ChunkStatus::Full) {
-                                let chunk = chunk_lock.read();
-                                if let Some(ChunkAccess::Full(level_chunk)) = &*chunk {
-                                    // Extract only the changed light sections
-                                    let light_data = level_chunk.extract_changed_light_data(sky_changed, block_changed);
+                        if (sky_changed != 0 || block_changed != 0)
+                            && let Some(chunk_lock) = holder.try_chunk(ChunkStatus::Full)
+                        {
+                            let chunk = chunk_lock.read();
+                            if let Some(ChunkAccess::Full(level_chunk)) = &*chunk {
+                                // Extract only the changed light sections
+                                let light_data = level_chunk
+                                    .extract_changed_light_data(sky_changed, block_changed);
 
-                                    // Verify arrays match masks before sending
-                                    if !light_data.sky_updates.is_empty() || !light_data.block_updates.is_empty()
-                                        || (light_data.empty_sky_y_mask.0.first().map_or(0, |v| *v) != 0)
-                                        || (light_data.empty_block_y_mask.0.first().map_or(0, |v| *v) != 0) {
-                                        let light_update = CLightUpdate {
-                                            pos,
-                                            light_data,
-                                        };
-                                        connection.send_packet(light_update);
-                                    }
-
-                                    // Clear the changed sections now that we've sent the update
-                                    holder.clear_light_changes();
+                                // Verify arrays match masks before sending
+                                if !light_data.sky_updates.is_empty()
+                                    || !light_data.block_updates.is_empty()
+                                    || (light_data.empty_sky_y_mask.0.first().map_or(0, |v| *v)
+                                        != 0)
+                                    || (light_data.empty_block_y_mask.0.first().map_or(0, |v| *v)
+                                        != 0)
+                                {
+                                    let light_update = CLightUpdate { pos, light_data };
+                                    connection.send_packet(light_update);
                                 }
+
+                                // Clear the changed sections now that we've sent the update
+                                holder.clear_light_changes();
                             }
                         }
                     }

--- a/steel-core/src/player/chunk_sender.rs
+++ b/steel-core/src/player/chunk_sender.rs
@@ -3,7 +3,7 @@ use rustc_hash::FxHashSet;
 use std::sync::Arc;
 
 use steel_protocol::packets::game::{
-    CChunkBatchFinished, CChunkBatchStart, CForgetLevelChunk, CLevelChunkWithLight,
+    CChunkBatchFinished, CChunkBatchStart, CForgetLevelChunk, CLevelChunkWithLight, CLightUpdate,
 };
 use steel_utils::ChunkPos;
 use tokio::task::spawn_blocking;
@@ -55,6 +55,9 @@ impl ChunkSender {
         world: &World,
         player_chunk_pos: ChunkPos,
     ) {
+        // First, broadcast any light updates for already-sent chunks
+        self.broadcast_light_updates(connection.clone(), world, player_chunk_pos);
+
         if self.unacknowledged_batches < self.max_unacknowledged_batches {
             let max_batch_size = self.desired_chunks_per_tick.max(1.0);
             self.batch_quota =
@@ -142,6 +145,59 @@ impl ChunkSender {
     pub fn on_chunk_batch_received_by_client(&mut self, _batch_size: f32) {
         if self.unacknowledged_batches > 0 {
             self.unacknowledged_batches -= 1;
+        }
+    }
+
+    /// Broadcasts light updates for chunks that have had their light modified by neighbors.
+    fn broadcast_light_updates(
+        &self,
+        connection: Arc<JavaConnection>,
+        world: &World,
+        player_chunk_pos: ChunkPos,
+    ) {
+        let view_distance = 10; // TODO: Get from player settings
+
+        for dx in -view_distance..=view_distance {
+            for dz in -view_distance..=view_distance {
+                let pos = ChunkPos(steel_utils::math::Vector2::new(
+                    player_chunk_pos.0.x + dx,
+                    player_chunk_pos.0.y + dz,
+                ));
+
+                if let Some(holder) = world.chunk_map.chunks.read_sync(&pos, |_, chunk| chunk.clone()) {
+                    // Check if this chunk has light changes and is already at Full status
+                    if holder.has_light_changes() && holder.persisted_status() == Some(ChunkStatus::Full) {
+                        // Get the changed section flags before clearing
+                        let sky_changed = holder.sky_changed_sections.load(std::sync::atomic::Ordering::Relaxed);
+                        let block_changed = holder.block_changed_sections.load(std::sync::atomic::Ordering::Relaxed);
+
+                        // Only send if there are actual changes
+                        if sky_changed != 0 || block_changed != 0 {
+                            if let Some(chunk_lock) = holder.try_chunk(ChunkStatus::Full) {
+                                let chunk = chunk_lock.read();
+                                if let Some(ChunkAccess::Full(level_chunk)) = &*chunk {
+                                    // Extract only the changed light sections
+                                    let light_data = level_chunk.extract_changed_light_data(sky_changed, block_changed);
+
+                                    // Verify arrays match masks before sending
+                                    if !light_data.sky_updates.is_empty() || !light_data.block_updates.is_empty()
+                                        || (light_data.empty_sky_y_mask.0.first().map_or(0, |v| *v) != 0)
+                                        || (light_data.empty_block_y_mask.0.first().map_or(0, |v| *v) != 0) {
+                                        let light_update = CLightUpdate {
+                                            pos,
+                                            light_data,
+                                        };
+                                        connection.send_packet(light_update);
+                                    }
+
+                                    // Clear the changed sections now that we've sent the update
+                                    holder.clear_light_changes();
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/steel-core/src/player/chunk_sender.rs
+++ b/steel-core/src/player/chunk_sender.rs
@@ -184,8 +184,9 @@ impl ChunkSender {
                         if (sky_changed != 0 || block_changed != 0)
                             && let Some(chunk_lock) = holder.try_chunk(ChunkStatus::Full)
                         {
-                            let chunk = chunk_lock.read();
-                            if let Some(ChunkAccess::Full(level_chunk)) = &*chunk {
+                            if let Some(chunk_arc) = chunk_lock.as_ref()
+                                && let ChunkAccess::Full(level_chunk) = chunk_arc.as_ref()
+                            {
                                 // Extract only the changed light sections
                                 let light_data = level_chunk
                                     .extract_changed_light_data(sky_changed, block_changed);

--- a/steel-core/src/server/mod.rs
+++ b/steel-core/src/server/mod.rs
@@ -69,7 +69,7 @@ impl Server {
                 dimension_type: 0,
                 dimension: Identifier::vanilla_static("overworld"),
                 seed: 0,
-                game_type: GameType::Survival,
+                game_type: GameType::Spectator,
                 previous_game_type: None,
                 is_debug: false,
                 is_flat: true,

--- a/steel-protocol/src/packets/game/c_light_update.rs
+++ b/steel-protocol/src/packets/game/c_light_update.rs
@@ -1,0 +1,27 @@
+use std::io::{Result, Write};
+
+use steel_macros::ClientPacket;
+use steel_registry::packets::play::C_LIGHT_UPDATE;
+use steel_utils::{ChunkPos, codec::VarInt, serial::WriteTo};
+
+use super::c_level_chunk_with_light::LightUpdatePacketData;
+
+#[derive(ClientPacket, Debug, Clone)]
+#[packet_id(Play = C_LIGHT_UPDATE)]
+pub struct CLightUpdate {
+    pub pos: ChunkPos,
+    pub light_data: LightUpdatePacketData,
+}
+
+// Custom WriteTo implementation because CLightUpdate writes chunk pos as VarInt,
+// unlike CLevelChunkWithLight which writes as i32
+impl WriteTo for CLightUpdate {
+    fn write(&self, writer: &mut impl Write) -> Result<()> {
+        // Write chunk position as VarInts (not i32)
+        VarInt(self.pos.0.x).write(writer)?;
+        VarInt(self.pos.0.y).write(writer)?;
+        // Write light data
+        self.light_data.write(writer)?;
+        Ok(())
+    }
+}

--- a/steel-protocol/src/packets/game/mod.rs
+++ b/steel-protocol/src/packets/game/mod.rs
@@ -4,6 +4,7 @@ mod c_disguised_chat;
 mod c_forget_level_chunk;
 mod c_game_event;
 mod c_level_chunk_with_light;
+mod c_light_update;
 mod c_login;
 mod c_player_chat;
 mod c_player_info_update;
@@ -29,6 +30,7 @@ pub use c_level_chunk_with_light::{
     BlockEntityInfo, CLevelChunkWithLight, ChunkPacketData, HeightmapType, Heightmaps,
     LightUpdatePacketData,
 };
+pub use c_light_update::CLightUpdate;
 pub use c_login::CLogin;
 pub use c_login::CommonPlayerSpawnInfo;
 pub use c_player_chat::{CPlayerChat, ChatTypeBound, FilterType, PreviousMessage};

--- a/steel-registry/build/blocks.rs
+++ b/steel-registry/build/blocks.rs
@@ -374,7 +374,7 @@ pub(crate) fn build() -> TokenStream {
         let default_opacity = block.light_properties.default.opacity;
 
         // Create a map of offsets to their light properties
-        let mut offset_map = std::collections::HashMap::new();
+        let mut offset_map = rustc_hash::FxHashMap::default();
         for overwrite in &block.light_properties.overwrites {
             offset_map.insert(overwrite.offset, (overwrite.luminance, overwrite.opacity));
         }

--- a/steel-registry/src/lib.rs
+++ b/steel-registry/src/lib.rs
@@ -7,6 +7,7 @@
 )]
 #![allow(internal_features)]
 
+use std::sync::LazyLock;
 use steel_utils::Identifier;
 
 use crate::{
@@ -373,3 +374,15 @@ impl Registry {
         self.timelines.freeze();
     }
 }
+
+/// Global vanilla registry instance.
+///
+/// This is lazily initialized on first access and contains all vanilla game registries
+/// (blocks, items, biomes, etc.). Use this for quick access to block/item properties.
+///
+/// # Example
+/// ```
+/// use steel_registry::REGISTRY;
+/// let block = REGISTRY.blocks.by_state_id(state_id);
+/// ```
+pub static REGISTRY: LazyLock<Registry> = LazyLock::new(Registry::new_vanilla);

--- a/steel-utils/src/codec/bit_set.rs
+++ b/steel-utils/src/codec/bit_set.rs
@@ -36,6 +36,13 @@ impl ReadFrom for BitSet {
 #[allow(missing_docs)]
 impl WriteTo for BitSet {
     fn write(&self, writer: &mut impl Write) -> Result<()> {
-        self.0.write_prefixed::<VarInt>(writer)
+        // Trim trailing zero u64s to match Java's BitSet.toLongArray() behavior
+        let mut trimmed_len = self.0.len();
+        while trimmed_len > 0 && self.0[trimmed_len - 1] == 0 {
+            trimmed_len -= 1;
+        }
+
+        // Write the trimmed slice
+        self.0[..trimmed_len].write_prefixed::<VarInt>(writer)
     }
 }

--- a/steel-utils/src/locks.rs
+++ b/steel-utils/src/locks.rs
@@ -13,11 +13,11 @@ pub type AsyncMutex<T> = SteelMutex<tokio::sync::Mutex<T>, T>;
 pub type AsyncRwLock<T> = SteelRwLock<tokio::sync::RwLock<T>, T>;
 
 /// A trait for locks that can be used with the `SteelLock` wrapper.
-pub trait GenericLock<T: ?Sized + Send + Sync> {}
+pub trait GenericLock<T: ?Sized + Send> {}
 
-impl<T: ?Sized + Send + Sync> GenericLock<T> for tokio::sync::Mutex<T> {}
+impl<T: ?Sized + Send> GenericLock<T> for tokio::sync::Mutex<T> {}
 
-impl<T: ?Sized + Send + Sync> GenericLock<T> for parking_lot::Mutex<T> {}
+impl<T: ?Sized + Send> GenericLock<T> for parking_lot::Mutex<T> {}
 
 impl<T: ?Sized + Send + Sync> GenericLock<T> for tokio::sync::RwLock<T> {}
 
@@ -28,12 +28,12 @@ impl<T: ?Sized + Send + Sync> GenericLock<T> for parking_lot::RwLock<T> {}
 /// Use [`SteelMutex::new_sync`] for synchronous contexts (`parking_lot::Mutex`)
 /// or [`SteelMutex::new_async`] for async contexts (`tokio::sync::Mutex`).
 #[derive(Debug)]
-pub struct SteelMutex<Mutex: GenericLock<T>, T: ?Sized + Send + Sync> {
+pub struct SteelMutex<Mutex: GenericLock<T>, T: ?Sized + Send> {
     mutex: Mutex,
-    _marker: PhantomData<T>,
+    _marker: PhantomData<fn() -> T>,
 }
 
-impl<T: Sized + Send + Sync> SteelMutex<parking_lot::Mutex<T>, T> {
+impl<T: Sized + Send> SteelMutex<parking_lot::Mutex<T>, T> {
     /// Creates a new synchronous mutex backed by `parking_lot::Mutex`.
     pub fn new(data: T) -> Self {
         Self {
@@ -55,7 +55,7 @@ impl<T: Sized + Send + Sync> SteelMutex<parking_lot::Mutex<T>, T> {
     }
 }
 
-impl<T: Sized + Send + Sync> SteelMutex<tokio::sync::Mutex<T>, T> {
+impl<T: Sized + Send> SteelMutex<tokio::sync::Mutex<T>, T> {
     /// Creates a new asynchronous mutex backed by `tokio::sync::Mutex`.
     pub fn new(data: T) -> Self {
         Self {
@@ -85,7 +85,7 @@ impl<T: Sized + Send + Sync> SteelMutex<tokio::sync::Mutex<T>, T> {
 #[derive(Debug)]
 pub struct SteelRwLock<RwLock: GenericLock<T>, T: ?Sized + Send + Sync> {
     rwlock: RwLock,
-    _marker: PhantomData<T>,
+    _marker: PhantomData<fn() -> T>,
 }
 
 impl<T: Sized + Send + Sync> SteelRwLock<parking_lot::RwLock<T>, T> {

--- a/steel-utils/src/types.rs
+++ b/steel-utils/src/types.rs
@@ -113,6 +113,17 @@ impl BlockPos {
             | (y & Self::PACKED_Y_MASK)
             | ((z & Self::PACKED_Z_MASK) << Self::Z_OFFSET)
     }
+
+    /// Returns a new `BlockPos` offset in the given direction.
+    ///
+    /// # Arguments
+    /// * `dx` - X offset
+    /// * `dy` - Y offset
+    /// * `dz` - Z offset
+    #[must_use]
+    pub fn offset_by(self, dx: i32, dy: i32, dz: i32) -> Self {
+        Self(Vector3::new(self.0.x + dx, self.0.y + dy, self.0.z + dz))
+    }
 }
 
 /// The game type.


### PR DESCRIPTION
Adds block states that will be needed later. For now, we need it for the opacity.

Adds sky light initialization to the generation steps. Sets block light to 0, as it does not need to be 15 for fullbright.

No propagation yet, but we also don't save the chunks, so no need to do propagation, becasue the client handles that fine on it's own. Once we store chunks, we can impl the light spreading.