### PR TITLE
make the code life forever

### DIFF
--- a/.github/workflows/life_forever.yml
+++ b/.github/workflows/life_forever.yml
@@ -1,0 +1,13 @@
+name: life_forever
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  save:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: sdruskat/swh-save-action@v1.0.1


### PR DESCRIPTION
A GitHub Action that saves the GitHub repository it is being run on to the [Software Heritage Archive](https://www.softwareheritage.org/).

This is something like the wayback machine but for software code, so even if github will go down or shutdown or paywall this software will not be lost!

