### PR TITLE
Better retry for username verification

### DIFF
--- a/steel-login/src/authentication.rs
+++ b/steel-login/src/authentication.rs
@@ -56,8 +56,6 @@ pub enum TextureError {
     JSONError(String),
 }
 
-const MAX_RETRIES: u32 = 3;
-
 /// Authenticates a player with Mojang's servers.
 pub async fn mojang_authenticate(
     username: &str,
@@ -70,49 +68,34 @@ pub async fn mojang_authenticate(
     auth_url += SERVER_ID_ARG;
     auth_url += server_hash;
 
-    let mut last_error = AuthError::FailedResponse;
+    let Ok(response) = reqwest::get(&auth_url).await else {
+        return Err(AuthError::FailedResponse);
+    };
 
-    for _ in 0..MAX_RETRIES {
-        let Ok(response) = reqwest::get(&auth_url).await else {
-            last_error = AuthError::FailedResponse;
-            continue;
-        };
-
-        match response.status() {
-            StatusCode::OK => {
-                return response.json().await.map_err(|_| AuthError::FailedParse);
-            }
-            StatusCode::NO_CONTENT => last_error = AuthError::UnverifiedUsername,
-            other => last_error = AuthError::UnknownStatusCode(other),
+    match response.status() {
+        StatusCode::OK => response.json().await.map_err(|_| AuthError::FailedParse),
+        StatusCode::NO_CONTENT => {
+            log::warn!("Player {username} auth failed");
+            Err(AuthError::UnverifiedUsername)
         }
+        StatusCode::FORBIDDEN => Err(AuthError::Banned),
+        other => Err(AuthError::UnknownStatusCode(other)),
     }
-
-    log::warn!("Player {username} auth failed");
-
-    Err(last_error)
 }
 
 /// Converts a signed bytes big endian to a hex string.
+///
+/// Replicates Java's `new BigInteger(bytes).toString(16)`.
 #[must_use]
 pub fn signed_bytes_be_to_hex(bytes: &[u8]) -> String {
     if bytes.is_empty() {
         return "0".to_string();
     }
 
-    // Find the first non-zero byte to handle cases like `[0x00, 0x1a]`
-    let first_digit = bytes.iter().position(|&b| b != 0);
-
-    // If all bytes are zero, the number is 0.
-    let Some(start_index) = first_digit else {
-        return "0".to_string();
-    };
-
-    let significant_bytes = &bytes[start_index..];
-    let is_negative = (significant_bytes[0] & 0x80) != 0;
+    // Sign is determined by the MSB of the *first* byte (two's complement).
+    let is_negative = (bytes[0] & 0x80) != 0;
 
     if is_negative {
-        // Negative case: calculate two's complement of the original full byte array
-        // to preserve the correct number of bits for the calculation.
         let mut inverted_bytes: Vec<u8> = bytes.iter().map(|b| !*b).collect();
         for byte in inverted_bytes.iter_mut().rev() {
             let (result, carry) = byte.overflowing_add(1);
@@ -121,14 +104,16 @@ pub fn signed_bytes_be_to_hex(bytes: &[u8]) -> String {
                 break;
             }
         }
-
-        // Now, find the first significant digit of the *result*
-        let mag_start_index = inverted_bytes.iter().position(|&b| b != 0).unwrap_or(0);
-
-        // Format the result with a leading '-'
-        format!("-{}", hex::encode(&inverted_bytes[mag_start_index..]))
+        let hex = hex::encode(&inverted_bytes);
+        let trimmed = hex.trim_start_matches('0');
+        format!("-{}", if trimmed.is_empty() { "0" } else { trimmed })
     } else {
-        // Positive case: just encode the significant bytes.
-        hex::encode(significant_bytes)
+        let hex = hex::encode(bytes);
+        let trimmed = hex.trim_start_matches('0');
+        if trimmed.is_empty() {
+            "0".to_string()
+        } else {
+            trimmed.to_string()
+        }
     }
 }

--- a/steel-login/src/handlers/login.rs
+++ b/steel-login/src/handlers/login.rs
@@ -1,8 +1,13 @@
 //! Login state packet handlers.
 
+use crate::{
+    AuthError, is_valid_player_name, mojang_authenticate, offline_uuid, signed_bytes_be_to_hex,
+    tcp_client::{ConnectionUpdate, JavaTcpClient},
+};
 use rsa::Pkcs1v15Encrypt;
 use sha1::Sha1;
 use sha2::Digest;
+use std::time::Duration;
 use steel_core::{config::STEEL_CONFIG, player::GameProfile};
 use steel_protocol::{
     packets::login::{CHello, CLoginCompression, CLoginFinished, SHello, SKey},
@@ -10,11 +15,7 @@ use steel_protocol::{
 };
 use steel_utils::translations;
 use text_components::TextComponent;
-
-use crate::{
-    AuthError, is_valid_player_name, mojang_authenticate, offline_uuid, signed_bytes_be_to_hex,
-    tcp_client::{ConnectionUpdate, JavaTcpClient},
-};
+use tokio::time::sleep;
 
 impl JavaTcpClient {
     /// Handles the hello packet during the login state.
@@ -84,26 +85,24 @@ impl JavaTcpClient {
             return;
         }
 
-        let Ok(secret_key) = self
-            .server
-            .key_store
-            .private_key
-            .decrypt(Pkcs1v15Encrypt, &packet.key)
-        else {
-            self.kick("Invalid key".into()).await;
-            return;
-        };
-
-        let secret_key: [u8; 16] = if let Ok(secret_key) = secret_key.try_into() {
-            secret_key
-        } else {
-            self.kick("Invalid key".into()).await;
-            return;
-        };
-
         let Ok(_) = self
             .connection_updates
-            .send(ConnectionUpdate::EnableEncryption(secret_key))
+            .send(ConnectionUpdate::EnableEncryption({
+                let Ok(secret_key) = self
+                    .server
+                    .key_store
+                    .private_key
+                    .decrypt(Pkcs1v15Encrypt, &packet.key)
+                else {
+                    self.kick("Invalid key".into()).await;
+                    return;
+                };
+                let Ok(secret_key) = secret_key.try_into() else {
+                    self.kick("Invalid key".into()).await;
+                    return;
+                };
+                secret_key
+            }))
         else {
             self.kick("Failed to send connection update".into()).await;
             return;
@@ -119,28 +118,54 @@ impl JavaTcpClient {
         };
 
         if STEEL_CONFIG.online_mode {
-            let server_hash = &Sha1::new()
-                .chain_update(secret_key)
-                .chain_update(&self.server.key_store.public_key_der)
-                .finalize();
-
-            let server_hash = signed_bytes_be_to_hex(server_hash);
-
-            match mojang_authenticate(&profile.name, &server_hash).await {
-                Ok(new_profile) => *profile = new_profile,
-                Err(error) => {
-                    self.kick(match error {
-                        AuthError::FailedResponse => TextComponent::translated(
-                            translations::MULTIPLAYER_DISCONNECT_AUTHSERVERS_DOWN.msg(),
-                        ),
-                        AuthError::UnverifiedUsername => TextComponent::translated(
-                            translations::MULTIPLAYER_DISCONNECT_UNVERIFIED_USERNAME.msg(),
-                        ),
-                        e => e.to_string().into(),
-                    })
-                    .await;
+            let mut i = 1;
+            let retries = 3;
+            let waiting_time = 1;
+            loop {
+                let Ok(secret_key) = self
+                    .server
+                    .key_store
+                    .private_key
+                    .decrypt(Pkcs1v15Encrypt, &packet.key)
+                else {
+                    self.kick("Invalid key".into()).await;
                     return;
+                };
+                let Ok(secret_key): Result<[u8; 16], _> = secret_key.try_into() else {
+                    self.kick("Invalid key".into()).await;
+                    return;
+                };
+                let server_hash = signed_bytes_be_to_hex(
+                    &Sha1::new()
+                        .chain_update(secret_key)
+                        .chain_update(&self.server.key_store.public_key_der)
+                        .finalize(),
+                );
+                let username = profile.name.clone();
+                match mojang_authenticate(&username, &server_hash).await {
+                    Ok(val) => {
+                        *profile = val;
+                        break;
+                    }
+                    Err(error) => {
+                        if i > retries {
+                            self.kick(match error {
+                                AuthError::FailedResponse => TextComponent::translated(
+                                    translations::MULTIPLAYER_DISCONNECT_AUTHSERVERS_DOWN.msg(),
+                                ),
+                                AuthError::UnverifiedUsername => TextComponent::translated(
+                                    translations::MULTIPLAYER_DISCONNECT_UNVERIFIED_USERNAME.msg(),
+                                ),
+                                e => e.to_string().into(),
+                            })
+                            .await;
+                            return;
+                        }
+                        i += 1;
+                    }
                 }
+                log::warn!("Player {username} auth failed");
+                sleep(Duration::from_secs(waiting_time)).await;
             }
         }
 


### PR DESCRIPTION
Was not able to get the verification fail after I changed that code....
So be still in draft, but would be nice if other people can try it.

I was out of ideas, because I did also a loop around mojang_auth and looped it 100 times, so I asked AI and it says, the secret is the same and that's the problem, so the secret will be generated each loop now.
But like already written, was not able to reproduce