### PR TITLE
Fix update-minecraft-src.sh script for MacOS

### DIFF
--- a/update-minecraft-src.sh
+++ b/update-minecraft-src.sh
@@ -16,9 +16,12 @@ trap "rm -rf $TEMP_DIR" EXIT
 # Clone GitCraft
 git clone https://github.com/WinPlay02/GitCraft "$TEMP_DIR/GitCraft"
 
+# Increase heap from default 4G to 8G
+sed -i.bak "s/-Xmx4G/-Xmx8G/" "$TEMP_DIR/GitCraft/build.gradle" && rm -f "$TEMP_DIR/GitCraft/build.gradle.bak"
+
 # Run GitCraft
 cd "$TEMP_DIR/GitCraft"
 echo "Running GitCraft..."
-JAVA_TOOL_OPTIONS="-Xmx8G" ./gradlew run --args="--override-repo-target=$MINECRAFT_SRC_DIR --only-unobfuscated --mappings=identity_unmapped --min-version=1.21.11 --only-stable"
+./gradlew run --args="--override-repo-target=$MINECRAFT_SRC_DIR --only-unobfuscated --mappings=identity_unmapped --min-version=1.21.11 --only-stable"
 
 echo "Done! minecraft-src has been updated."

--- a/update-minecraft-src.sh
+++ b/update-minecraft-src.sh
@@ -16,9 +16,6 @@ trap "rm -rf $TEMP_DIR" EXIT
 # Clone GitCraft
 git clone https://github.com/WinPlay02/GitCraft "$TEMP_DIR/GitCraft"
 
-# Pin fabric-loom to avoid TinyJavadocProvider API breakage in newer versions
-sed -i.bak 's/loom_version = 1\.+/loom_version = 1.15.5/' "$TEMP_DIR/GitCraft/gradle.properties"
-
 # Run GitCraft
 cd "$TEMP_DIR/GitCraft"
 echo "Running GitCraft..."

--- a/update-minecraft-src.sh
+++ b/update-minecraft-src.sh
@@ -16,10 +16,8 @@ trap "rm -rf $TEMP_DIR" EXIT
 # Clone GitCraft
 git clone https://github.com/WinPlay02/GitCraft "$TEMP_DIR/GitCraft"
 
-# Patch Groovy version (use specific version instead of dynamic 5.0.+)
-sed -i.bak 's/groovy_version = 5\.0\.+/groovy_version = 5.0.0/' "$TEMP_DIR/GitCraft/gradle.properties"
-echo "Patched gradle.properties:"
-grep groovy "$TEMP_DIR/GitCraft/gradle.properties"
+# Pin fabric-loom to avoid TinyJavadocProvider API breakage in newer versions
+sed -i.bak 's/loom_version = 1\.+/loom_version = 1.15.5/' "$TEMP_DIR/GitCraft/gradle.properties"
 
 # Run GitCraft
 cd "$TEMP_DIR/GitCraft"

--- a/update-minecraft-src.sh
+++ b/update-minecraft-src.sh
@@ -17,7 +17,7 @@ trap "rm -rf $TEMP_DIR" EXIT
 git clone https://github.com/WinPlay02/GitCraft "$TEMP_DIR/GitCraft"
 
 # Patch Groovy version (use specific version instead of dynamic 5.0.+)
-sed -i 's/groovy_version = 5\.0\.+/groovy_version = 5.0.0/' "$TEMP_DIR/GitCraft/gradle.properties"
+sed -i.bak 's/groovy_version = 5\.0\.+/groovy_version = 5.0.0/' "$TEMP_DIR/GitCraft/gradle.properties"
 echo "Patched gradle.properties:"
 grep groovy "$TEMP_DIR/GitCraft/gradle.properties"
 


### PR DESCRIPTION
## Summary
- Fix sed -i compatibility in update-minecraft-src.sh for macOS
  - macOS sed requires a backup extension argument, unlike GNU sed
  - Use sed -i.bak which works on both macOS and Linux