### PR TITLE
Add nether water evaporation for buckets

### DIFF
--- a/steel-core/src/behavior/items/bucket.rs
+++ b/steel-core/src/behavior/items/bucket.rs
@@ -223,6 +223,7 @@ fn use_filled_bucket(fluid_block: BlockRef, context: &mut UseItemContext) -> Int
 
         // Vanilla parity: in dimensions where water evaporates (e.g. the Nether),
         // water buckets fizz out without placing any fluid.
+        // TODO: Per-position environment attributes (vanilla uses EnvironmentAttributes.WATER_EVAPORATES per-pos)
         if is_water_bucket && context.world.dimension.water_evaporates {
             context
                 .world
@@ -243,7 +244,7 @@ fn use_filled_bucket(fluid_block: BlockRef, context: &mut UseItemContext) -> Int
         }
 
         // 2. Try Standard Placement (Replaceable block)
-        if state.can_be_replaced_by_fluid(fluid_block) {
+        if can_replace {
             // If same fluid already exists and is source, just consume bucket (parity)
             let is_same_fluid = if is_water_bucket {
                 fluid_state.is_water()

--- a/steel-core/src/behavior/items/bucket.rs
+++ b/steel-core/src/behavior/items/bucket.rs
@@ -5,8 +5,6 @@
 //! Mirrors vanilla's `BucketItem(Fluid fluid)`: `fluid_block = None` = empty bucket,
 //! `Some(block)` = filled bucket. Logic is dispatched in `use_item`.
 //!
-// TODO: Spawn particles
-
 use crate::behavior::context::InteractionResult;
 use crate::behavior::{
     BLOCK_BEHAVIORS, BlockStateBehaviorExt, FLUID_BEHAVIORS, ItemBehavior, UseItemContext,
@@ -22,6 +20,7 @@ use steel_registry::blocks::properties::BlockStateProperties;
 use steel_registry::fluid::FluidState;
 use steel_registry::item_stack::ItemStack;
 use steel_registry::items::ItemRef;
+use steel_registry::level_events;
 use steel_registry::sound_events;
 use steel_registry::vanilla_blocks;
 use steel_registry::vanilla_fluids;
@@ -203,9 +202,15 @@ fn use_filled_bucket(fluid_block: BlockRef, context: &mut UseItemContext) -> Int
         let state = context.world.get_block_state(pos);
         let fluid_state = state.get_fluid_state();
 
-        // TODO: Nether water evaporation (vanilla uses EnvironmentAttributes.WATER_EVAPORATES)
-        // If the dimension evaporates water and we are placing WATER, play FIRE_EXTINGUISH
-        // sound, spawn LARGE_SMOKE particles, and consume the bucket without placing.
+        // Vanilla parity: in dimensions where water evaporates (e.g. the Nether),
+        // water buckets fizz out without placing any fluid.
+        if fluid_block == vanilla_blocks::WATER && context.world.dimension.water_evaporates {
+            context
+                .world
+                .level_event(level_events::PARTICLES_WATER_EVAPORATING, pos, 0, None);
+            consume_bucket(context, &vanilla_items::ITEMS.bucket);
+            return Some(InteractionResult::Success);
+        }
 
         // Vanilla parity (bl4): when sneaking, only air allows placement at this position.
         // Non-air blocks redirect to the neighbor — handled by the secondary call.

--- a/steel-core/src/behavior/items/bucket.rs
+++ b/steel-core/src/behavior/items/bucket.rs
@@ -202,16 +202,6 @@ fn use_filled_bucket(fluid_block: BlockRef, context: &mut UseItemContext) -> Int
         let state = context.world.get_block_state(pos);
         let fluid_state = state.get_fluid_state();
 
-        // Vanilla parity: in dimensions where water evaporates (e.g. the Nether),
-        // water buckets fizz out without placing any fluid.
-        if fluid_block == vanilla_blocks::WATER && context.world.dimension.water_evaporates {
-            context
-                .world
-                .level_event(level_events::PARTICLES_WATER_EVAPORATING, pos, 0, None);
-            consume_bucket(context, &vanilla_items::ITEMS.bucket);
-            return Some(InteractionResult::Success);
-        }
-
         // Vanilla parity (bl4): when sneaking, only air allows placement at this position.
         // Non-air blocks redirect to the neighbor — handled by the secondary call.
         // The secondary call bypasses this check (hitResult == null in vanilla).
@@ -219,24 +209,37 @@ fn use_filled_bucket(fluid_block: BlockRef, context: &mut UseItemContext) -> Int
             return None;
         }
 
-        // 1. Try Waterlogging via LiquidBlockContainer (only if Water bucket)
         let is_water_bucket = fluid_block == &vanilla_blocks::WATER;
+        let behavior = BLOCK_BEHAVIORS.get_behavior(state.get_block());
+        let can_waterlog = is_water_bucket
+            && behavior
+                .can_place_liquid(state, FluidState::source(&vanilla_fluids::WATER).fluid_id);
+        let can_replace = state.can_be_replaced_by_fluid(fluid_block);
 
-        if is_water_bucket {
+        // Vanilla parity: block must be replaceable or waterloggable for placement
+        if !can_waterlog && !can_replace {
+            return None;
+        }
+
+        // Vanilla parity: in dimensions where water evaporates (e.g. the Nether),
+        // water buckets fizz out without placing any fluid.
+        if is_water_bucket && context.world.dimension.water_evaporates {
+            context
+                .world
+                .level_event(level_events::PARTICLES_WATER_EVAPORATING, pos, 0, None);
+            consume_bucket(context, &vanilla_items::ITEMS.bucket);
+            return Some(InteractionResult::Success);
+        }
+
+        // 1. Try Waterlogging via LiquidBlockContainer (only if Water bucket)
+        if can_waterlog {
             let source_water = FluidState::source(&vanilla_fluids::WATER);
-            let behavior = BLOCK_BEHAVIORS.get_behavior(state.get_block());
-            if behavior.can_place_liquid(state, source_water.fluid_id) {
-                behavior.place_liquid(context.world, pos, state, source_water);
-                context.world.play_block_sound(
-                    sound_events::ITEM_BUCKET_EMPTY,
-                    pos,
-                    1.0,
-                    1.0,
-                    None,
-                );
-                consume_bucket(context, &vanilla_items::ITEMS.bucket);
-                return Some(InteractionResult::Success);
-            }
+            behavior.place_liquid(context.world, pos, state, source_water);
+            context
+                .world
+                .play_block_sound(sound_events::ITEM_BUCKET_EMPTY, pos, 1.0, 1.0, None);
+            consume_bucket(context, &vanilla_items::ITEMS.bucket);
+            return Some(InteractionResult::Success);
         }
 
         // 2. Try Standard Placement (Replaceable block)


### PR DESCRIPTION
## Summary
- Water buckets now fizz out in dimensions where `water_evaporates` is true (e.g. the Nether)
- Fires `PARTICLES_WATER_EVAPORATING` level event for smoke particles and sound
- Consumes the bucket without placing any fluid, matching vanilla parity

## Demonstation
https://github.com/user-attachments/assets/4317b068-ddc3-4a9e-bd51-340afeb69ff2