### PR TITLE
Registry rework

### DIFF
--- a/steel-core/benches/worldgen.rs
+++ b/steel-core/benches/worldgen.rs
@@ -85,7 +85,7 @@ fn sample_chunk_biomes(
 // ── Biome benchmarks ────────────────────────────────────────────────────────
 
 fn bench_overworld_biome(c: &mut Criterion) {
-    let dim = vanilla_dimension_types::OVERWORLD;
+    let dim = &vanilla_dimension_types::OVERWORLD;
     let source = BiomeSourceKind::overworld(0);
     c.bench_function("overworld_biome", |b| {
         b.iter(|| {
@@ -102,7 +102,7 @@ fn bench_overworld_biome(c: &mut Criterion) {
 }
 
 fn bench_nether_biome(c: &mut Criterion) {
-    let dim = vanilla_dimension_types::THE_NETHER;
+    let dim = &vanilla_dimension_types::THE_NETHER;
     let source = BiomeSourceKind::nether(0);
     c.bench_function("nether_biome", |b| {
         b.iter(|| {
@@ -119,7 +119,7 @@ fn bench_nether_biome(c: &mut Criterion) {
 }
 
 fn bench_end_biome(c: &mut Criterion) {
-    let dim = vanilla_dimension_types::THE_END;
+    let dim = &vanilla_dimension_types::THE_END;
     let source = BiomeSourceKind::end(0);
     c.bench_function("end_biome", |b| {
         b.iter(|| {
@@ -139,7 +139,7 @@ fn bench_end_biome(c: &mut Criterion) {
 
 fn bench_overworld_noise(c: &mut Criterion) {
     ensure_registry();
-    let dim = vanilla_dimension_types::OVERWORLD;
+    let dim = &vanilla_dimension_types::OVERWORLD;
     let source = BiomeSourceKind::overworld(0);
     let generator = OverworldGenerator::new(source, 0);
 
@@ -153,7 +153,7 @@ fn bench_overworld_noise(c: &mut Criterion) {
 
 fn bench_nether_noise(c: &mut Criterion) {
     ensure_registry();
-    let dim = vanilla_dimension_types::THE_NETHER;
+    let dim = &vanilla_dimension_types::THE_NETHER;
     let source = BiomeSourceKind::nether(0);
     let generator = NetherGenerator::new(source, 0);
 
@@ -167,7 +167,7 @@ fn bench_nether_noise(c: &mut Criterion) {
 
 fn bench_end_noise(c: &mut Criterion) {
     ensure_registry();
-    let dim = vanilla_dimension_types::THE_END;
+    let dim = &vanilla_dimension_types::THE_END;
     let source = BiomeSourceKind::end(0);
     let generator = EndGenerator::new(source, 0);
 
@@ -183,7 +183,7 @@ fn bench_end_noise(c: &mut Criterion) {
 
 fn bench_overworld_surface(c: &mut Criterion) {
     ensure_registry();
-    let dim = vanilla_dimension_types::OVERWORLD;
+    let dim = &vanilla_dimension_types::OVERWORLD;
     let source = BiomeSourceKind::overworld(0);
     let generator = OverworldGenerator::new(source, 0);
 
@@ -206,7 +206,7 @@ fn bench_overworld_surface(c: &mut Criterion) {
 
 fn bench_nether_surface(c: &mut Criterion) {
     ensure_registry();
-    let dim = vanilla_dimension_types::THE_NETHER;
+    let dim = &vanilla_dimension_types::THE_NETHER;
     let source = BiomeSourceKind::nether(0);
     let generator = NetherGenerator::new(source, 0);
 
@@ -229,7 +229,7 @@ fn bench_nether_surface(c: &mut Criterion) {
 
 fn bench_end_surface(c: &mut Criterion) {
     ensure_registry();
-    let dim = vanilla_dimension_types::THE_END;
+    let dim = &vanilla_dimension_types::THE_END;
     let source = BiomeSourceKind::end(0);
     let generator = EndGenerator::new(source, 0);
 

--- a/steel-core/build/blocks.rs
+++ b/steel-core/build/blocks.rs
@@ -69,8 +69,8 @@ pub fn build(blocks: &[BlockClass]) -> String {
 
         let registration = quote! {
             registry.set_behavior(
-                vanilla_blocks::#const_ident,
-                Box::new(#struct_ident::new(vanilla_blocks::#const_ident #(, #args)*)),
+                &vanilla_blocks::#const_ident,
+                Box::new(#struct_ident::new(&vanilla_blocks::#const_ident #(, #args)*)),
             );
         };
 

--- a/steel-core/build/common.rs
+++ b/steel-core/build/common.rs
@@ -244,7 +244,13 @@ pub(crate) fn generate_arg(
             } else {
                 let module_ident = Ident::new(module, Span::call_site());
                 let const_ident = to_block_ident(name);
-                quote! { #module_ident::#const_ident }
+                // vanilla_blocks statics are owned `Block` values; constructors
+                // expect `BlockRef = &'static Block`, so auto-borrow here.
+                if module == "vanilla_blocks" {
+                    quote! { &#module_ident::#const_ident }
+                } else {
+                    quote! { #module_ident::#const_ident }
+                }
             }
         }
         JsonArgKind::Enum { type_name, .. } => {

--- a/steel-core/build/strippables.rs
+++ b/steel-core/build/strippables.rs
@@ -15,7 +15,7 @@ pub fn build() -> String {
     let strippables: Vec<proc_macro2::TokenStream> = strippables_entries
         .iter()
         .map(|(normal, stripped)| (to_block_ident(normal), to_block_ident(stripped)))
-        .map(|(from, to)| quote! { b if b == vanilla_blocks::#from => Some(vanilla_blocks::#to) , })
+        .map(|(from, to)| quote! { b if b == &vanilla_blocks::#from => Some(&vanilla_blocks::#to) , })
         .collect();
 
     let output = quote! {

--- a/steel-core/build/waxables.rs
+++ b/steel-core/build/waxables.rs
@@ -14,13 +14,13 @@ pub fn build() -> String {
     let waxables: Vec<proc_macro2::TokenStream> = waxables_raw
         .iter()
         .map(|(normal, waxed)| (to_block_ident(normal), to_block_ident(waxed)))
-        .map(|(from, to)| quote! { b if b == vanilla_blocks::#from => Some(vanilla_blocks::#to) , })
+        .map(|(from, to)| quote! { b if b == &vanilla_blocks::#from => Some(&vanilla_blocks::#to) , })
         .collect();
 
     let waxables_reverse: Vec<proc_macro2::TokenStream> = waxables_raw
         .iter()
         .map(|(normal, waxed)| (to_block_ident(normal), to_block_ident(waxed)))
-        .map(|(from, to)| quote! { b if b == vanilla_blocks::#to => Some(vanilla_blocks::#from) , })
+        .map(|(from, to)| quote! { b if b == &vanilla_blocks::#to => Some(&vanilla_blocks::#from) , })
         .collect();
 
     let output = quote! {

--- a/steel-core/build/weathering.rs
+++ b/steel-core/build/weathering.rs
@@ -19,14 +19,14 @@ pub fn build() -> String {
     let oxidizables: Vec<proc_macro2::TokenStream> = oxidizables_raw
         .iter()
         .map(|(current, next)| (to_block_ident(current), to_block_ident(next)))
-        .map(|(from, to)| quote! { b if b == vanilla_blocks::#from => Some(vanilla_blocks::#to) , })
+        .map(|(from, to)| quote! { b if b == &vanilla_blocks::#from => Some(&vanilla_blocks::#to) , })
         .collect();
 
     // Build the reverse map: next -> current
     let oxidizables_reverse: Vec<proc_macro2::TokenStream> = oxidizables_raw
         .iter()
         .map(|(current, next)| (to_block_ident(current), to_block_ident(next)))
-        .map(|(from, to)| quote! { b if b == vanilla_blocks::#to => Some(vanilla_blocks::#from) , })
+        .map(|(from, to)| quote! { b if b == &vanilla_blocks::#to => Some(&vanilla_blocks::#from) , })
         .collect();
 
     // Derive WeatherState for every block by walking chains.
@@ -46,7 +46,7 @@ pub fn build() -> String {
             let block_ident = to_block_ident(current);
             let state_ident = proc_macro2::Ident::new(stage_name, proc_macro2::Span::call_site());
             weather_state_arms.push(
-                quote! { b if b == vanilla_blocks::#block_ident => Some(WeatherState::#state_ident) , },
+                quote! { b if b == &vanilla_blocks::#block_ident => Some(WeatherState::#state_ident) , },
             );
 
             let Some(next) = oxidizables_raw.get(current) else {
@@ -58,7 +58,7 @@ pub fn build() -> String {
         // The final block in the chain is Oxidized
         let block_ident = to_block_ident(current);
         weather_state_arms.push(
-            quote! { b if b == vanilla_blocks::#block_ident => Some(WeatherState::Oxidized) , },
+            quote! { b if b == &vanilla_blocks::#block_ident => Some(WeatherState::Oxidized) , },
         );
     }
 

--- a/steel-core/src/behavior/blocks/container/barrel_block.rs
+++ b/steel-core/src/behavior/blocks/container/barrel_block.rs
@@ -94,7 +94,7 @@ impl BlockBehavior for BarrelBlock {
         pos: BlockPos,
         state: BlockStateId,
     ) -> Option<SharedBlockEntity> {
-        BLOCK_ENTITIES.create(vanilla_block_entity_types::BARREL, level, pos, state)
+        BLOCK_ENTITIES.create(&vanilla_block_entity_types::BARREL, level, pos, state)
     }
 
     fn has_analog_output_signal(&self, _state: BlockStateId) -> bool {

--- a/steel-core/src/behavior/blocks/decoration/candle_block.rs
+++ b/steel-core/src/behavior/blocks/decoration/candle_block.rs
@@ -78,7 +78,7 @@ impl BlockBehavior for CandleBlock {
         _neighbor_state: steel_utils::BlockStateId,
     ) -> steel_utils::BlockStateId {
         if !self.can_survive(state, world, pos) {
-            return REGISTRY.blocks.get_default_state_id(vanilla_blocks::AIR);
+            return REGISTRY.blocks.get_default_state_id(&vanilla_blocks::AIR);
         }
         state
     }

--- a/steel-core/src/behavior/blocks/decoration/sign_block.rs
+++ b/steel-core/src/behavior/blocks/decoration/sign_block.rs
@@ -299,7 +299,7 @@ impl BlockBehavior for StandingSignBlock {
     ) -> BlockStateId {
         // Standing signs break when the block below is removed
         if direction == Direction::Down && !can_support_standing_sign(world, pos) {
-            return REGISTRY.blocks.get_default_state_id(vanilla_blocks::AIR);
+            return REGISTRY.blocks.get_default_state_id(&vanilla_blocks::AIR);
         }
         state
     }
@@ -383,7 +383,7 @@ impl BlockBehavior for WallSignBlock {
             && direction.opposite() == facing
             && !can_wall_sign_survive(world, pos, facing)
         {
-            return REGISTRY.blocks.get_default_state_id(vanilla_blocks::AIR);
+            return REGISTRY.blocks.get_default_state_id(&vanilla_blocks::AIR);
         }
         state
     }
@@ -467,7 +467,7 @@ impl BlockBehavior for CeilingHangingSignBlock {
     ) -> BlockStateId {
         // Ceiling hanging signs break when the block above is removed
         if direction == Direction::Up && !can_ceiling_hanging_sign_survive(world, pos) {
-            return REGISTRY.blocks.get_default_state_id(vanilla_blocks::AIR);
+            return REGISTRY.blocks.get_default_state_id(&vanilla_blocks::AIR);
         }
         state
     }
@@ -605,7 +605,7 @@ impl BlockBehavior for WallHangingSignBlock {
             if direction.axis() == facing.rotate_y_clockwise().axis()
                 && !can_wall_hanging_sign_survive(world, pos, facing)
             {
-                return REGISTRY.blocks.get_default_state_id(vanilla_blocks::AIR);
+                return REGISTRY.blocks.get_default_state_id(&vanilla_blocks::AIR);
             }
         }
         state

--- a/steel-core/src/behavior/blocks/decoration/torch_block.rs
+++ b/steel-core/src/behavior/blocks/decoration/torch_block.rs
@@ -58,7 +58,7 @@ impl BlockBehavior for TorchBlock {
     ) -> BlockStateId {
         // Standing torches break when the block below is removed
         if direction == Direction::Down && !self.can_survive(state, world, pos) {
-            return REGISTRY.blocks.get_default_state_id(vanilla_blocks::AIR);
+            return REGISTRY.blocks.get_default_state_id(&vanilla_blocks::AIR);
         }
         state
     }
@@ -116,7 +116,7 @@ impl BlockBehavior for WallTorchBlock {
         let attach_direction = facing.opposite();
 
         if direction == attach_direction && !self.can_survive(state, world, pos) {
-            return REGISTRY.blocks.get_default_state_id(vanilla_blocks::AIR);
+            return REGISTRY.blocks.get_default_state_id(&vanilla_blocks::AIR);
         }
         state
     }

--- a/steel-core/src/behavior/blocks/farming/cactus_block.rs
+++ b/steel-core/src/behavior/blocks/farming/cactus_block.rs
@@ -206,7 +206,7 @@ impl BlockBehavior for CactusBlock {
         entity: &dyn Entity,
     ) {
         entity.hurt(
-            &DamageSource::environment(vanilla_damage_types::CACTUS),
+            &DamageSource::environment(&vanilla_damage_types::CACTUS),
             1.0,
         );
     }

--- a/steel-core/src/behavior/blocks/farming/cactus_block.rs
+++ b/steel-core/src/behavior/blocks/farming/cactus_block.rs
@@ -89,7 +89,7 @@ impl BlockBehavior for CactusBlock {
         let below = world.get_block_state(below_pos);
         let below_block = below.get_block();
 
-        let valid_below = below_block == vanilla_blocks::CACTUS
+        let valid_below = below_block == &vanilla_blocks::CACTUS
             || steel_registry::REGISTRY
                 .blocks
                 .is_in_tag(below_block, &vanilla_block_tags::SUPPORTS_CACTUS_TAG);
@@ -141,7 +141,7 @@ impl BlockBehavior for CactusBlock {
         while world
             .get_block_state(pos.offset(0, -(height as i32), 0))
             .get_block()
-            == vanilla_blocks::CACTUS
+            == &vanilla_blocks::CACTUS
         {
             height += 1;
             if height == MAX_CACTUS_HEIGHT && age == 15 {
@@ -173,7 +173,7 @@ impl BlockBehavior for CactusBlock {
             );
             let new_state = state.set_value(&BlockStateProperties::AGE_15, 0);
             world.set_block(pos, new_state, UpdateFlags::UPDATE_NONE);
-            world.neighbor_changed(above_pos, vanilla_blocks::CACTUS, false);
+            world.neighbor_changed(above_pos, &vanilla_blocks::CACTUS, false);
         }
 
         if age < 15 {

--- a/steel-core/src/behavior/blocks/farming/farmland_block.rs
+++ b/steel-core/src/behavior/blocks/farming/farmland_block.rs
@@ -47,7 +47,7 @@ impl FarmlandBlock {
                     let state = world.get_block_state(check_pos);
 
                     // Check if block is water
-                    if state.get_block() == vanilla_blocks::WATER {
+                    if state.get_block() == &vanilla_blocks::WATER {
                         return true;
                     }
 
@@ -72,16 +72,16 @@ impl FarmlandBlock {
 
         // Check for crops that maintain farmland
         // In vanilla this uses the MAINTAINS_FARMLAND tag
-        block == vanilla_blocks::WHEAT
-            || block == vanilla_blocks::CARROTS
-            || block == vanilla_blocks::POTATOES
-            || block == vanilla_blocks::BEETROOTS
-            || block == vanilla_blocks::MELON_STEM
-            || block == vanilla_blocks::PUMPKIN_STEM
-            || block == vanilla_blocks::ATTACHED_MELON_STEM
-            || block == vanilla_blocks::ATTACHED_PUMPKIN_STEM
-            || block == vanilla_blocks::TORCHFLOWER_CROP
-            || block == vanilla_blocks::PITCHER_CROP
+        block == &vanilla_blocks::WHEAT
+            || block == &vanilla_blocks::CARROTS
+            || block == &vanilla_blocks::POTATOES
+            || block == &vanilla_blocks::BEETROOTS
+            || block == &vanilla_blocks::MELON_STEM
+            || block == &vanilla_blocks::PUMPKIN_STEM
+            || block == &vanilla_blocks::ATTACHED_MELON_STEM
+            || block == &vanilla_blocks::ATTACHED_PUMPKIN_STEM
+            || block == &vanilla_blocks::TORCHFLOWER_CROP
+            || block == &vanilla_blocks::PITCHER_CROP
     }
 
     /// Turns the farmland into dirt.

--- a/steel-core/src/behavior/blocks/fluid/liquid_block.rs
+++ b/steel-core/src/behavior/blocks/fluid/liquid_block.rs
@@ -61,7 +61,7 @@ impl LiquidBlock {
         // Check if there's soul soil below (for basalt generation)
         let below_pos = pos.offset(0, -1, 0);
         let below_state = world.get_block_state(below_pos);
-        let has_soul_soil_below = below_state.get_block() == vanilla_blocks::SOUL_SOIL;
+        let has_soul_soil_below = below_state.get_block() == &vanilla_blocks::SOUL_SOIL;
 
         // Get fluid state to check if this is a source
         let fluid_state = world.get_block_state(pos).get_fluid_state();
@@ -75,9 +75,9 @@ impl LiquidBlock {
             if neighbor_fluid.is_water() {
                 // Lava + Water = Obsidian (if source) or Cobblestone (if flowing)
                 let new_block = if fluid_state.is_source() {
-                    vanilla_blocks::OBSIDIAN
+                    &vanilla_blocks::OBSIDIAN
                 } else {
-                    vanilla_blocks::COBBLESTONE
+                    &vanilla_blocks::COBBLESTONE
                 };
 
                 let new_state = REGISTRY.blocks.get_default_state_id(new_block);
@@ -89,8 +89,10 @@ impl LiquidBlock {
             // Check for basalt generation: soul soil below + blue ice adjacent
             if has_soul_soil_below {
                 let neighbor_state = world.get_block_state(neighbor_pos);
-                if neighbor_state.get_block() == vanilla_blocks::BLUE_ICE {
-                    let new_state = REGISTRY.blocks.get_default_state_id(vanilla_blocks::BASALT);
+                if neighbor_state.get_block() == &vanilla_blocks::BLUE_ICE {
+                    let new_state = REGISTRY
+                        .blocks
+                        .get_default_state_id(&vanilla_blocks::BASALT);
                     world.set_block(pos, new_state, UpdateFlags::UPDATE_ALL);
                     world.level_event(level_events::LAVA_FIZZ, pos, 0, None);
                     return false; // Don't schedule fluid tick - block was converted
@@ -192,7 +194,7 @@ impl BlockBehavior for LiquidBlock {
             return None;
         }
 
-        let air = REGISTRY.blocks.get_default_state_id(vanilla_blocks::AIR);
+        let air = REGISTRY.blocks.get_default_state_id(&vanilla_blocks::AIR);
         world.set_block(pos, air, UpdateFlags::UPDATE_ALL_IMMEDIATE);
 
         let bucket = if is_water_fluid(self.fluid) {

--- a/steel-core/src/behavior/blocks/portal/fire.rs
+++ b/steel-core/src/behavior/blocks/portal/fire.rs
@@ -67,7 +67,7 @@ impl FireBlock {
         }
 
         let has_obsidian = Direction::ALL.iter().any(|&dir| {
-            world.get_block_state(pos.relative(dir)).get_block() == vanilla_blocks::OBSIDIAN
+            world.get_block_state(pos.relative(dir)).get_block() == &vanilla_blocks::OBSIDIAN
         });
         if !has_obsidian {
             return false;

--- a/steel-core/src/behavior/blocks/portal/fire.rs
+++ b/steel-core/src/behavior/blocks/portal/fire.rs
@@ -33,8 +33,8 @@ impl FireBlock {
 
     /// Returns true if the dimension supports nether portal creation (Overworld or Nether).
     pub(crate) fn in_portal_dimension(world: &World) -> bool {
-        world.dimension == vanilla_dimension_types::OVERWORLD
-            || world.dimension == vanilla_dimension_types::THE_NETHER
+        world.dimension == &vanilla_dimension_types::OVERWORLD
+            || world.dimension == &vanilla_dimension_types::THE_NETHER
     }
 
     /// Checks if fire can be placed at `pos`, matching vanilla's `BaseFireBlock.canBePlacedAt`.

--- a/steel-core/src/behavior/blocks/redstone/button_block.rs
+++ b/steel-core/src/behavior/blocks/redstone/button_block.rs
@@ -142,7 +142,7 @@ impl BlockBehavior for ButtonBlock {
     ) -> BlockStateId {
         let support_dir = Self::get_connected_direction(state).opposite();
         if direction == support_dir && !self.can_survive(state, world, pos) {
-            return REGISTRY.blocks.get_default_state_id(vanilla_blocks::AIR);
+            return REGISTRY.blocks.get_default_state_id(&vanilla_blocks::AIR);
         }
         state
     }

--- a/steel-core/src/behavior/blocks/redstone/redstone_torch_block.rs
+++ b/steel-core/src/behavior/blocks/redstone/redstone_torch_block.rs
@@ -54,7 +54,7 @@ impl BlockBehavior for RedstoneTorchBlock {
         _neighbor_state: BlockStateId,
     ) -> BlockStateId {
         if direction == Direction::Down && !self.can_survive(state, world, pos) {
-            return REGISTRY.blocks.get_default_state_id(vanilla_blocks::AIR);
+            return REGISTRY.blocks.get_default_state_id(&vanilla_blocks::AIR);
         }
         state
     }
@@ -111,7 +111,7 @@ impl BlockBehavior for RedstoneWallTorchBlock {
         let attach_direction = facing.opposite();
 
         if direction == attach_direction && !self.can_survive(state, world, pos) {
-            return REGISTRY.blocks.get_default_state_id(vanilla_blocks::AIR);
+            return REGISTRY.blocks.get_default_state_id(&vanilla_blocks::AIR);
         }
         state
     }

--- a/steel-core/src/behavior/items/bucket.rs
+++ b/steel-core/src/behavior/items/bucket.rs
@@ -90,7 +90,7 @@ fn use_empty_bucket(context: &mut UseItemContext) -> InteractionResult {
         let state = world.get_block_state(pos);
         let block = state.get_block();
 
-        if block == vanilla_blocks::AIR {
+        if block == &vanilla_blocks::AIR {
             return RaytraceAction::Pass;
         }
 
@@ -168,7 +168,7 @@ fn use_filled_bucket(fluid_block: BlockRef, context: &mut UseItemContext) -> Int
         let state = world.get_block_state(pos);
         let block = state.get_block();
         // Pass through air and all fluids
-        if block == vanilla_blocks::AIR {
+        if block == &vanilla_blocks::AIR {
             return RaytraceAction::Pass;
         }
         // Check fluid state for pass-through
@@ -215,7 +215,7 @@ fn use_filled_bucket(fluid_block: BlockRef, context: &mut UseItemContext) -> Int
         }
 
         // 1. Try Waterlogging via LiquidBlockContainer (only if Water bucket)
-        let is_water_bucket = fluid_block == vanilla_blocks::WATER;
+        let is_water_bucket = fluid_block == &vanilla_blocks::WATER;
 
         if is_water_bucket {
             let source_water = FluidState::source(&vanilla_fluids::WATER);
@@ -293,7 +293,7 @@ fn use_filled_bucket(fluid_block: BlockRef, context: &mut UseItemContext) -> Int
     // WATERLOGGED property existence approximates the LiquidBlockContainer type check.
     // If primary fails, secondary retries at the offset pos without sneak check,
     // matching vanilla's recursive `emptyContents(hitResult=null)` fallback.
-    let is_water_bucket = fluid_block == vanilla_blocks::WATER;
+    let is_water_bucket = fluid_block == &vanilla_blocks::WATER;
     let clicked_is_waterloggable = clicked_state
         .try_get_value(&BlockStateProperties::WATERLOGGED)
         .is_some();

--- a/steel-core/src/behavior/items/hoe.rs
+++ b/steel-core/src/behavior/items/hoe.rs
@@ -15,14 +15,14 @@ pub struct HoeItem;
 impl HoeItem {
     fn get_tilled_variant(block: BlockRef) -> Option<BlockRef> {
         match block {
-            _ if block == vanilla_blocks::GRASS_BLOCK
-                || block == vanilla_blocks::DIRT_PATH
-                || block == vanilla_blocks::DIRT =>
+            _ if block == &vanilla_blocks::GRASS_BLOCK
+                || block == &vanilla_blocks::DIRT_PATH
+                || block == &vanilla_blocks::DIRT =>
             {
-                Some(vanilla_blocks::FARMLAND)
+                Some(&vanilla_blocks::FARMLAND)
             }
-            _ if block == vanilla_blocks::COARSE_DIRT => Some(vanilla_blocks::DIRT),
-            _ if block == vanilla_blocks::ROOTED_DIRT => Some(vanilla_blocks::DIRT),
+            _ if block == &vanilla_blocks::COARSE_DIRT => Some(&vanilla_blocks::DIRT),
+            _ if block == &vanilla_blocks::ROOTED_DIRT => Some(&vanilla_blocks::DIRT),
             _ => None,
         }
     }
@@ -40,7 +40,7 @@ impl ItemBehavior for HoeItem {
                 .world
                 .get_block_state(context.hit_result.block_pos.above())
                 .is_air())
-            && state.get_block() != vanilla_blocks::ROOTED_DIRT
+            && state.get_block() != &vanilla_blocks::ROOTED_DIRT
         {
             return InteractionResult::Pass;
         }
@@ -52,7 +52,7 @@ impl ItemBehavior for HoeItem {
         );
         // TODO: Emit GameEvent::BLOCK_CHANGE
 
-        if state.get_block() == vanilla_blocks::ROOTED_DIRT {
+        if state.get_block() == &vanilla_blocks::ROOTED_DIRT {
             context.world.pop_resource_from_face(
                 context.hit_result.block_pos,
                 context.hit_result.direction,

--- a/steel-core/src/behavior/items/shovel.rs
+++ b/steel-core/src/behavior/items/shovel.rs
@@ -14,12 +14,12 @@ use steel_utils::types::UpdateFlags;
 use crate::behavior::{InteractionResult, ItemBehavior, UseOnContext};
 
 const FLATTENABLES: [&Block; 6] = [
-    vanilla_blocks::GRASS_BLOCK,
-    vanilla_blocks::DIRT,
-    vanilla_blocks::PODZOL,
-    vanilla_blocks::COARSE_DIRT,
-    vanilla_blocks::MYCELIUM,
-    vanilla_blocks::ROOTED_DIRT,
+    &vanilla_blocks::GRASS_BLOCK,
+    &vanilla_blocks::DIRT,
+    &vanilla_blocks::PODZOL,
+    &vanilla_blocks::COARSE_DIRT,
+    &vanilla_blocks::MYCELIUM,
+    &vanilla_blocks::ROOTED_DIRT,
 ];
 
 const LIT_PROPERTY: BoolProperty = BlockStateProperties::LIT;

--- a/steel-core/src/block_entity/entities/barrel.rs
+++ b/steel-core/src/block_entity/entities/barrel.rs
@@ -61,7 +61,7 @@ impl BlockEntity for BarrelBlockEntity {
     }
 
     fn get_type(&self) -> BlockEntityTypeRef {
-        vanilla_block_entity_types::BARREL
+        &vanilla_block_entity_types::BARREL
     }
 
     fn get_block_pos(&self) -> BlockPos {

--- a/steel-core/src/block_entity/entities/sign.rs
+++ b/steel-core/src/block_entity/entities/sign.rs
@@ -154,13 +154,13 @@ impl SignBlockEntity {
     /// Creates a new sign block entity.
     #[must_use]
     pub fn new(level: Weak<World>, pos: BlockPos, state: BlockStateId) -> Self {
-        Self::with_type(level, vanilla_block_entity_types::SIGN, pos, state)
+        Self::with_type(level, &vanilla_block_entity_types::SIGN, pos, state)
     }
 
     /// Creates a new hanging sign block entity.
     #[must_use]
     pub fn new_hanging(level: Weak<World>, pos: BlockPos, state: BlockStateId) -> Self {
-        Self::with_type(level, vanilla_block_entity_types::HANGING_SIGN, pos, state)
+        Self::with_type(level, &vanilla_block_entity_types::HANGING_SIGN, pos, state)
     }
 
     /// Creates a sign block entity with a specific type.

--- a/steel-core/src/block_entity/registry.rs
+++ b/steel-core/src/block_entity/registry.rs
@@ -132,13 +132,13 @@ pub fn init_block_entities() {
     let mut registry = BlockEntityRegistry::new();
 
     // Register sign block entity factory
-    registry.register(vanilla_block_entity_types::SIGN, |level, pos, state| {
+    registry.register(&vanilla_block_entity_types::SIGN, |level, pos, state| {
         Arc::new(SyncMutex::new(SignBlockEntity::new(level, pos, state)))
     });
 
     // Register hanging sign block entity factory
     registry.register(
-        vanilla_block_entity_types::HANGING_SIGN,
+        &vanilla_block_entity_types::HANGING_SIGN,
         |level, pos, state| {
             Arc::new(SyncMutex::new(SignBlockEntity::new_hanging(
                 level, pos, state,
@@ -147,7 +147,7 @@ pub fn init_block_entities() {
     );
 
     // Register barrel block entity factory
-    registry.register(vanilla_block_entity_types::BARREL, |level, pos, state| {
+    registry.register(&vanilla_block_entity_types::BARREL, |level, pos, state| {
         Arc::new(SyncMutex::new(BarrelBlockEntity::new(level, pos, state)))
     });
 

--- a/steel-core/src/chunk/aquifer.rs
+++ b/steel-core/src/chunk/aquifer.rs
@@ -233,8 +233,8 @@ impl<N: DimensionNoises> Aquifer<N> {
         const AQUIFER_HASH: NameHash = NameHash::new("minecraft:aquifer");
 
         let sea_level = N::Settings::SEA_LEVEL;
-        let water_id = REGISTRY.blocks.get_default_state_id(vanilla_blocks::WATER);
-        let lava_id = REGISTRY.blocks.get_default_state_id(vanilla_blocks::LAVA);
+        let water_id = REGISTRY.blocks.get_default_state_id(&vanilla_blocks::WATER);
+        let lava_id = REGISTRY.blocks.get_default_state_id(&vanilla_blocks::LAVA);
         let default_fluid_id = N::Settings::default_fluid_id();
 
         let mut aquifer_rng = splitter.with_hash_of(&AQUIFER_HASH);

--- a/steel-core/src/chunk/level_chunk.rs
+++ b/steel-core/src/chunk/level_chunk.rs
@@ -608,14 +608,14 @@ impl LevelChunk {
 
         // Bounds check - return air if out of range
         if section_index >= self.sections.sections.len() {
-            return REGISTRY.blocks.get_base_state_id(vanilla_blocks::VOID_AIR);
+            return REGISTRY.blocks.get_base_state_id(&vanilla_blocks::VOID_AIR);
         }
 
         let section = &self.sections.sections[section_index];
         let section_guard = section.read();
 
         if section_guard.is_empty() {
-            return REGISTRY.blocks.get_base_state_id(vanilla_blocks::VOID_AIR);
+            return REGISTRY.blocks.get_base_state_id(&vanilla_blocks::VOID_AIR);
         }
 
         let local_x = (pos.0.x & 15) as usize;

--- a/steel-core/src/chunk/ore_veinifier.rs
+++ b/steel-core/src/chunk/ore_veinifier.rs
@@ -59,13 +59,13 @@ impl OreVeinifier {
         let copper = VeinType {
             ore: REGISTRY
                 .blocks
-                .get_default_state_id(vanilla_blocks::COPPER_ORE),
+                .get_default_state_id(&vanilla_blocks::COPPER_ORE),
             raw_ore_block: REGISTRY
                 .blocks
-                .get_default_state_id(vanilla_blocks::RAW_COPPER_BLOCK),
+                .get_default_state_id(&vanilla_blocks::RAW_COPPER_BLOCK),
             filler: REGISTRY
                 .blocks
-                .get_default_state_id(vanilla_blocks::GRANITE),
+                .get_default_state_id(&vanilla_blocks::GRANITE),
             min_y: 0,
             max_y: 50,
         };
@@ -73,11 +73,11 @@ impl OreVeinifier {
         let iron = VeinType {
             ore: REGISTRY
                 .blocks
-                .get_default_state_id(vanilla_blocks::DEEPSLATE_IRON_ORE),
+                .get_default_state_id(&vanilla_blocks::DEEPSLATE_IRON_ORE),
             raw_ore_block: REGISTRY
                 .blocks
-                .get_default_state_id(vanilla_blocks::RAW_IRON_BLOCK),
-            filler: REGISTRY.blocks.get_default_state_id(vanilla_blocks::TUFF),
+                .get_default_state_id(&vanilla_blocks::RAW_IRON_BLOCK),
+            filler: REGISTRY.blocks.get_default_state_id(&vanilla_blocks::TUFF),
             min_y: -60,
             max_y: -8,
         };

--- a/steel-core/src/chunk/proto_chunk.rs
+++ b/steel-core/src/chunk/proto_chunk.rs
@@ -125,7 +125,7 @@ impl ProtoChunk {
             return Some(
                 REGISTRY
                     .blocks
-                    .get_default_state_id(vanilla_blocks::VOID_AIR),
+                    .get_default_state_id(&vanilla_blocks::VOID_AIR),
             );
         }
 
@@ -183,7 +183,7 @@ impl ProtoChunk {
         // Check bounds
         if y < self.min_y || y >= self.min_y + self.height {
             // Out of bounds - return default air
-            return REGISTRY.blocks.get_default_state_id(vanilla_blocks::AIR);
+            return REGISTRY.blocks.get_default_state_id(&vanilla_blocks::AIR);
         }
 
         let section_index = self.get_section_index(y);
@@ -191,7 +191,7 @@ impl ProtoChunk {
 
         // Optimization: if section is empty, return air
         if section.read().states.has_only_air() {
-            return REGISTRY.blocks.get_default_state_id(vanilla_blocks::AIR);
+            return REGISTRY.blocks.get_default_state_id(&vanilla_blocks::AIR);
         }
 
         let local_x = (pos.0.x & 15) as usize;

--- a/steel-core/src/chunk/surface_system.rs
+++ b/steel-core/src/chunk/surface_system.rs
@@ -486,7 +486,7 @@ impl SurfaceSystem {
                 .unwrap_or(BlockStateId(0));
 
             let is_air = state.is_air();
-            let is_water = state.get_block() == vanilla_blocks::WATER;
+            let is_water = state.get_block() == &vanilla_blocks::WATER;
 
             if (is_air && y < extension_top as i32 && random.next_f64() > 0.01)
                 || (is_water

--- a/steel-core/src/command/commands/kill.rs
+++ b/steel-core/src/command/commands/kill.rs
@@ -28,7 +28,7 @@ pub fn command_handler() -> impl CommandHandlerDyn {
 /// `LivingEntity.kill()` — hurt with `genericKill` at `Float.MAX_VALUE`.
 fn kill_player(player: &Player) {
     player.hurt(
-        &DamageSource::environment(vanilla_damage_types::GENERIC_KILL),
+        &DamageSource::environment(&vanilla_damage_types::GENERIC_KILL),
         f32::MAX,
     );
 }

--- a/steel-core/src/command/commands/summon.rs
+++ b/steel-core/src/command/commands/summon.rs
@@ -52,7 +52,7 @@ impl CommandExecutor<()> for SummonAtSelfExecutor {
             Arc::downgrade(&world),
         ));
 
-        entity.set_block_state_id(REGISTRY.blocks.get_base_state_id(vanilla_blocks::STONE));
+        entity.set_block_state_id(REGISTRY.blocks.get_base_state_id(&vanilla_blocks::STONE));
 
         // Add it to the world
         world.add_entity(entity);

--- a/steel-core/src/command/commands/time.rs
+++ b/steel-core/src/command/commands/time.rs
@@ -84,7 +84,7 @@ impl CommandExecutor<((), i32)> for TimeExecutor {
                 (game_time, new_day_time)
             };
 
-            let advance_time = { world.get_game_rule(ADVANCE_TIME).as_bool().expect("todo") };
+            let advance_time = { world.get_game_rule(&ADVANCE_TIME).as_bool().expect("todo") };
 
             day_time_option = Some(new_day_time);
 
@@ -123,7 +123,7 @@ impl<const DAYTIME: i64> CommandExecutor<()> for TimeConstSetExecutor<DAYTIME> {
                 (game_time, new_day_time)
             };
 
-            let advance_time = { world.get_game_rule(ADVANCE_TIME).as_bool().expect("todo") };
+            let advance_time = { world.get_game_rule(&ADVANCE_TIME).as_bool().expect("todo") };
 
             let rate = if advance_time { 1.0 } else { 0.0 };
             world.broadcast_to_all(CSetTime::new(game_time, new_day_time, 0.0, rate));

--- a/steel-core/src/entity/entities/block_display.rs
+++ b/steel-core/src/entity/entities/block_display.rs
@@ -82,7 +82,7 @@ impl Entity for BlockDisplayEntity {
     }
 
     fn entity_type(&self) -> EntityTypeRef {
-        vanilla_entities::BLOCK_DISPLAY
+        &vanilla_entities::BLOCK_DISPLAY
     }
 
     fn bounding_box(&self) -> AABBd {

--- a/steel-core/src/entity/entities/item.rs
+++ b/steel-core/src/entity/entities/item.rs
@@ -704,7 +704,7 @@ impl Entity for ItemEntity {
     }
 
     fn entity_type(&self) -> EntityTypeRef {
-        vanilla_entities::ITEM
+        &vanilla_entities::ITEM
     }
 
     fn bounding_box(&self) -> AABBd {

--- a/steel-core/src/entity/registry.rs
+++ b/steel-core/src/entity/registry.rs
@@ -189,22 +189,22 @@ pub fn init_entities() {
     let mut registry = EntityRegistry::new();
 
     // Register block display entity factory
-    registry.register(vanilla_entities::BLOCK_DISPLAY, |id, pos, world| {
+    registry.register(&vanilla_entities::BLOCK_DISPLAY, |id, pos, world| {
         Arc::new(BlockDisplayEntity::new(id, pos, world))
     });
     registry.register_load(
-        vanilla_entities::BLOCK_DISPLAY,
+        &vanilla_entities::BLOCK_DISPLAY,
         |id, pos, uuid, _velocity, _rotation, _on_ground, world| {
             Arc::new(BlockDisplayEntity::from_saved(id, pos, uuid, world))
         },
     );
 
     // Register item entity factory
-    registry.register(vanilla_entities::ITEM, |id, pos, world| {
+    registry.register(&vanilla_entities::ITEM, |id, pos, world| {
         Arc::new(ItemEntity::new(id, pos, world))
     });
     registry.register_load(
-        vanilla_entities::ITEM,
+        &vanilla_entities::ITEM,
         |id, pos, uuid, velocity, rotation, on_ground, world| {
             Arc::new(ItemEntity::from_saved(
                 id, pos, uuid, velocity, rotation, on_ground, world,

--- a/steel-core/src/fluid/collision.rs
+++ b/steel-core/src/fluid/collision.rs
@@ -78,18 +78,18 @@ pub fn can_hold_any_fluid_state(state: BlockStateId) -> bool {
 /// Vanilla's `BlockState.blocksMotion()`:
 /// `block != Cobweb && block != BambooSapling && isSolid()`
 fn blocks_motion(block: BlockRef, state: BlockStateId) -> bool {
-    block != vanilla_blocks::COBWEB && block != vanilla_blocks::BAMBOO_SAPLING && state.is_solid()
+    block != &vanilla_blocks::COBWEB && block != &vanilla_blocks::BAMBOO_SAPLING && state.is_solid()
 }
 
 /// Returns true if a block is in the vanilla fluid exclusion list.
 fn is_fluid_excluded_block(block: BlockRef) -> bool {
-    block == vanilla_blocks::LADDER
-        || block == vanilla_blocks::SUGAR_CANE
-        || block == vanilla_blocks::BUBBLE_COLUMN
-        || block == vanilla_blocks::NETHER_PORTAL
-        || block == vanilla_blocks::END_PORTAL
-        || block == vanilla_blocks::END_GATEWAY
-        || block == vanilla_blocks::STRUCTURE_VOID
+    block == &vanilla_blocks::LADDER
+        || block == &vanilla_blocks::SUGAR_CANE
+        || block == &vanilla_blocks::BUBBLE_COLUMN
+        || block == &vanilla_blocks::NETHER_PORTAL
+        || block == &vanilla_blocks::END_PORTAL
+        || block == &vanilla_blocks::END_GATEWAY
+        || block == &vanilla_blocks::STRUCTURE_VOID
         || REGISTRY.blocks.is_in_tag(block, &SIGNS_TAG)
         || REGISTRY.blocks.is_in_tag(block, &DOORS_TAG)
 }

--- a/steel-core/src/fluid/flowing_fluid.rs
+++ b/steel-core/src/fluid/flowing_fluid.rs
@@ -41,7 +41,7 @@ pub trait FlowingFluid: FluidBehavior {
             if new_fluid.is_empty() {
                 current_fluid = new_fluid;
                 // Vanilla: unconditionally sets Blocks.AIR when fluid empties
-                let air = REGISTRY.blocks.get_default_state_id(vanilla_blocks::AIR);
+                let air = REGISTRY.blocks.get_default_state_id(&vanilla_blocks::AIR);
                 world.set_block(pos, air, UpdateFlags::UPDATE_ALL);
             } else if new_fluid != current_fluid {
                 let old_fluid = current_fluid;

--- a/steel-core/src/fluid/fluids/lava.rs
+++ b/steel-core/src/fluid/fluids/lava.rs
@@ -70,7 +70,7 @@ impl FluidBehavior for LavaFluid {
     }
 
     fn can_convert_to_source(&self, world: &Arc<World>) -> bool {
-        match world.get_game_rule(LAVA_SOURCE_CONVERSION) {
+        match world.get_game_rule(&LAVA_SOURCE_CONVERSION) {
             GameRuleValue::Bool(val) => val,
             GameRuleValue::Int(_) => false,
         }

--- a/steel-core/src/fluid/fluids/lava.rs
+++ b/steel-core/src/fluid/fluids/lava.rs
@@ -174,10 +174,10 @@ impl FlowingFluid for LavaFluid {
                 // Vanilla: stone only forms when the target is a pure water LiquidBlock,
                 // not a waterlogged block (stairs, slabs, etc.).
                 let below_block = world.get_block_state(pos).get_block();
-                if below_block == vanilla_blocks::WATER {
+                if below_block == &vanilla_blocks::WATER {
                     world.set_block(
                         pos,
-                        REGISTRY.blocks.get_default_state_id(vanilla_blocks::STONE),
+                        REGISTRY.blocks.get_default_state_id(&vanilla_blocks::STONE),
                         UpdateFlags::UPDATE_ALL_IMMEDIATE,
                     );
                 }

--- a/steel-core/src/fluid/fluids/water.rs
+++ b/steel-core/src/fluid/fluids/water.rs
@@ -48,7 +48,7 @@ impl FluidBehavior for WaterFluid {
     }
 
     fn can_convert_to_source(&self, world: &Arc<World>) -> bool {
-        match world.get_game_rule(WATER_SOURCE_CONVERSION) {
+        match world.get_game_rule(&WATER_SOURCE_CONVERSION) {
             GameRuleValue::Bool(val) => val,
             GameRuleValue::Int(_) => true,
         }

--- a/steel-core/src/fluid/state.rs
+++ b/steel-core/src/fluid/state.rs
@@ -29,12 +29,12 @@ pub fn get_fluid_state(world: &Arc<World>, pos: BlockPos) -> FluidState {
 pub fn get_fluid_state_from_block(state: BlockStateId) -> FluidState {
     let block = state.get_block();
 
-    if block == vanilla_blocks::WATER {
+    if block == &vanilla_blocks::WATER {
         let level: u8 = state
             .try_get_value(&BlockStateProperties::LEVEL)
             .unwrap_or(0);
         FluidState::from_block_level(water_id(), level)
-    } else if block == vanilla_blocks::LAVA {
+    } else if block == &vanilla_blocks::LAVA {
         let level: u8 = state
             .try_get_value(&BlockStateProperties::LEVEL)
             .unwrap_or(0);
@@ -69,7 +69,7 @@ pub fn fluid_state_to_block_with_existing(
         {
             return existing_state.set_value(&BlockStateProperties::WATERLOGGED, false);
         }
-        return REGISTRY.blocks.get_default_state_id(vanilla_blocks::AIR);
+        return REGISTRY.blocks.get_default_state_id(&vanilla_blocks::AIR);
     }
 
     // If it's water, check if the block can be waterlogged.
@@ -84,19 +84,19 @@ pub fn fluid_state_to_block_with_existing(
         }
 
         // If not waterloggable, fall back to pure water block
-        let base = REGISTRY.blocks.get_default_state_id(vanilla_blocks::WATER);
+        let base = REGISTRY.blocks.get_default_state_id(&vanilla_blocks::WATER);
         let level = fluid_state.to_block_level();
         return base.set_value(&BlockStateProperties::LEVEL, level);
     }
 
     if is_lava_fluid(fluid_id) {
-        let base = REGISTRY.blocks.get_default_state_id(vanilla_blocks::LAVA);
+        let base = REGISTRY.blocks.get_default_state_id(&vanilla_blocks::LAVA);
         let level = fluid_state.to_block_level();
         return base.set_value(&BlockStateProperties::LEVEL, level);
     }
 
     // Unknown fluid type - default to air
-    REGISTRY.blocks.get_default_state_id(vanilla_blocks::AIR)
+    REGISTRY.blocks.get_default_state_id(&vanilla_blocks::AIR)
 }
 
 /// Converts a `FluidState` into a `BlockStateId` directly without preserving any block.
@@ -106,19 +106,19 @@ pub fn fluid_state_to_block_with_existing(
 pub fn fluid_state_to_block(fluid_state: FluidState) -> BlockStateId {
     let fluid_id = fluid_state.fluid_id;
     if fluid_id.is_empty {
-        REGISTRY.blocks.get_default_state_id(vanilla_blocks::AIR)
+        REGISTRY.blocks.get_default_state_id(&vanilla_blocks::AIR)
     } else if is_water_fluid(fluid_id) {
-        let base = REGISTRY.blocks.get_default_state_id(vanilla_blocks::WATER);
+        let base = REGISTRY.blocks.get_default_state_id(&vanilla_blocks::WATER);
         // Use FluidState's to_block_level method for proper conversion
         let level = fluid_state.to_block_level();
         base.set_value(&BlockStateProperties::LEVEL, level)
     } else if is_lava_fluid(fluid_id) {
-        let base = REGISTRY.blocks.get_default_state_id(vanilla_blocks::LAVA);
+        let base = REGISTRY.blocks.get_default_state_id(&vanilla_blocks::LAVA);
         let level = fluid_state.to_block_level();
         base.set_value(&BlockStateProperties::LEVEL, level)
     } else {
         // Unknown fluid type - default to air
-        REGISTRY.blocks.get_default_state_id(vanilla_blocks::AIR)
+        REGISTRY.blocks.get_default_state_id(&vanilla_blocks::AIR)
     }
 }
 

--- a/steel-core/src/inventory/chest_menu.rs
+++ b/steel-core/src/inventory/chest_menu.rs
@@ -168,12 +168,12 @@ impl ChestMenu {
     #[must_use]
     pub fn menu_type_for_rows(rows: usize) -> MenuTypeRef {
         match rows {
-            1 => vanilla_menu_types::GENERIC_9X1,
-            2 => vanilla_menu_types::GENERIC_9X2,
-            3 => vanilla_menu_types::GENERIC_9X3,
-            4 => vanilla_menu_types::GENERIC_9X4,
-            5 => vanilla_menu_types::GENERIC_9X5,
-            6 => vanilla_menu_types::GENERIC_9X6,
+            1 => &vanilla_menu_types::GENERIC_9X1,
+            2 => &vanilla_menu_types::GENERIC_9X2,
+            3 => &vanilla_menu_types::GENERIC_9X3,
+            4 => &vanilla_menu_types::GENERIC_9X4,
+            5 => &vanilla_menu_types::GENERIC_9X5,
+            6 => &vanilla_menu_types::GENERIC_9X6,
             _ => panic!("Invalid row count: {rows}"),
         }
     }

--- a/steel-core/src/inventory/crafting_menu.rs
+++ b/steel-core/src/inventory/crafting_menu.rs
@@ -101,7 +101,7 @@ impl CraftingMenu {
             behavior: MenuBehavior::new(
                 menu_slots,
                 container_id,
-                Some(vanilla_menu_types::CRAFTING),
+                Some(&vanilla_menu_types::CRAFTING),
             ),
             crafting_container,
             result_container,
@@ -112,7 +112,7 @@ impl CraftingMenu {
     /// Returns the menu type for the crafting table.
     #[must_use]
     pub fn menu_type() -> MenuTypeRef {
-        vanilla_menu_types::CRAFTING
+        &vanilla_menu_types::CRAFTING
     }
 
     /// Returns a reference to the crafting container.
@@ -331,7 +331,7 @@ impl Menu for CraftingMenu {
 
 impl MenuInstance for CraftingMenu {
     fn menu_type(&self) -> MenuTypeRef {
-        vanilla_menu_types::CRAFTING
+        &vanilla_menu_types::CRAFTING
     }
 
     fn container_id(&self) -> u8 {

--- a/steel-core/src/physics/entity_move.rs
+++ b/steel-core/src/physics/entity_move.rs
@@ -463,9 +463,9 @@ mod tests {
     impl CollisionWorld for MockWorld {
         fn get_block_state(&self, pos: BlockPos) -> steel_utils::BlockStateId {
             if self.has_floor && pos.y() == 0 {
-                REGISTRY.blocks.get_base_state_id(vanilla_blocks::STONE)
+                REGISTRY.blocks.get_base_state_id(&vanilla_blocks::STONE)
             } else {
-                REGISTRY.blocks.get_base_state_id(vanilla_blocks::AIR)
+                REGISTRY.blocks.get_base_state_id(&vanilla_blocks::AIR)
             }
         }
 

--- a/steel-core/src/physics/entity_move.rs
+++ b/steel-core/src/physics/entity_move.rs
@@ -495,7 +495,7 @@ mod tests {
     #[test]
     fn test_move_entity_free_fall() {
         let mut state =
-            EntityPhysicsState::new(DVec3::new(0.0, 10.0, 0.0), vanilla_entities::PLAYER);
+            EntityPhysicsState::new(DVec3::new(0.0, 10.0, 0.0), &vanilla_entities::PLAYER);
         state.on_ground = false;
 
         let world = MockWorld { has_floor: true };
@@ -513,7 +513,7 @@ mod tests {
     #[test]
     fn test_move_entity_land_on_ground() {
         let mut state =
-            EntityPhysicsState::new(DVec3::new(0.0, 5.0, 0.0), vanilla_entities::PLAYER);
+            EntityPhysicsState::new(DVec3::new(0.0, 5.0, 0.0), &vanilla_entities::PLAYER);
         state.on_ground = false;
 
         let world = MockWorld { has_floor: true };
@@ -531,7 +531,7 @@ mod tests {
 
     #[test]
     fn test_move_entity_no_collision_in_air() {
-        let state = EntityPhysicsState::new(DVec3::new(0.0, 10.0, 0.0), vanilla_entities::PLAYER);
+        let state = EntityPhysicsState::new(DVec3::new(0.0, 10.0, 0.0), &vanilla_entities::PLAYER);
 
         let world = MockWorld { has_floor: false };
         let movement = DVec3::new(1.0, 0.0, 1.0);
@@ -549,7 +549,7 @@ mod tests {
     fn test_item_on_ground_with_accumulated_velocity() {
         // Simulates an item that's on the ground (Y=1.0 on top of floor)
         // and has accumulated negative velocity from gravity
-        let mut state = EntityPhysicsState::new(DVec3::new(0.0, 1.0, 0.0), vanilla_entities::ITEM);
+        let mut state = EntityPhysicsState::new(DVec3::new(0.0, 1.0, 0.0), &vanilla_entities::ITEM);
         state.on_ground = true;
 
         let world = MockWorld { has_floor: true };
@@ -578,7 +578,7 @@ mod tests {
         // Simulates an item that's slightly above the ground due to floating point
         // Floor at Y=1.0, item at Y=1.00001 (just above)
         let mut state =
-            EntityPhysicsState::new(DVec3::new(0.0, 1.00001, 0.0), vanilla_entities::ITEM);
+            EntityPhysicsState::new(DVec3::new(0.0, 1.00001, 0.0), &vanilla_entities::ITEM);
         state.on_ground = false; // Not quite on ground yet
 
         let world = MockWorld { has_floor: true };

--- a/steel-core/src/player/mod.rs
+++ b/steel-core/src/player/mod.rs
@@ -888,14 +888,14 @@ impl Player {
     /// Returns `true` if movement should be validated, `false` to skip validation.
     fn should_validate_movement(world: &World, is_fall_flying: bool) -> bool {
         // Check playerMovementCheck gamerule
-        let player_check = world.get_game_rule(PLAYER_MOVEMENT_CHECK);
+        let player_check = world.get_game_rule(&PLAYER_MOVEMENT_CHECK);
         if player_check != GameRuleValue::Bool(true) {
             return false;
         }
 
         // If fall flying, also check elytraMovementCheck gamerule
         if is_fall_flying {
-            let elytra_check = world.get_game_rule(ELYTRA_MOVEMENT_CHECK);
+            let elytra_check = world.get_game_rule(&ELYTRA_MOVEMENT_CHECK);
             return elytra_check == GameRuleValue::Bool(true);
         }
 
@@ -2517,7 +2517,7 @@ impl Player {
         let pos = *self.position.lock();
         if pos.y < f64::from(self.get_world().get_min_y() - 64) {
             self.hurt(
-                &DamageSource::environment(vanilla_damage_types::OUT_OF_WORLD),
+                &DamageSource::environment(&vanilla_damage_types::OUT_OF_WORLD),
                 4.0,
             );
         }
@@ -2662,7 +2662,7 @@ impl Player {
         );
 
         let show_death_messages =
-            world.get_game_rule(SHOW_DEATH_MESSAGES) == GameRuleValue::Bool(true);
+            world.get_game_rule(&SHOW_DEATH_MESSAGES) == GameRuleValue::Bool(true);
 
         // TODO: use CombatTracker for multi-arg messages (killer name, item, etc.)
         let death_key = format!("death.attack.{}", source.damage_type.message_id);
@@ -2692,7 +2692,7 @@ impl Player {
             });
         }
 
-        if world.get_game_rule(KEEP_INVENTORY) != GameRuleValue::Bool(true) {
+        if world.get_game_rule(&KEEP_INVENTORY) != GameRuleValue::Bool(true) {
             let items: Vec<ItemStack> = {
                 let mut inventory = self.inventory.lock();
                 (0..inventory.get_container_size())
@@ -2712,7 +2712,7 @@ impl Player {
             }
         }
 
-        if world.get_game_rule(IMMEDIATE_RESPAWN) == GameRuleValue::Bool(true) {
+        if world.get_game_rule(&IMMEDIATE_RESPAWN) == GameRuleValue::Bool(true) {
             self.respawn();
         }
     }
@@ -2773,7 +2773,7 @@ impl Player {
         // Handle XP loss on death
         {
             let mut experience = self.experience.lock();
-            if world.get_game_rule(KEEP_INVENTORY) != GameRuleValue::Bool(true)
+            if world.get_game_rule(&KEEP_INVENTORY) != GameRuleValue::Bool(true)
                 && self.game_mode.load() != GameType::Spectator
             {
                 // TODO: drop XP orbs (min(level * 7, 100))
@@ -2960,7 +2960,7 @@ impl Player {
             drop(level_data);
 
             let advance_time = world
-                .get_game_rule(ADVANCE_TIME)
+                .get_game_rule(&ADVANCE_TIME)
                 .as_bool()
                 .expect("gamerule advance_time should always be a bool.");
             let rate = if advance_time { 1.0 } else { 0.0 };
@@ -3033,7 +3033,7 @@ pub enum ResetReason {
 
 impl Entity for Player {
     fn entity_type(&self) -> EntityTypeRef {
-        vanilla_entities::PLAYER
+        &vanilla_entities::PLAYER
     }
 
     fn id(&self) -> i32 {

--- a/steel-core/src/player/movement.rs
+++ b/steel-core/src/player/movement.rs
@@ -120,7 +120,7 @@ pub fn simulate_move(
     on_ground: bool,
 ) -> MoveResult {
     // Create physics state for the player
-    let mut state = EntityPhysicsState::new(start_pos, vanilla_entities::PLAYER);
+    let mut state = EntityPhysicsState::new(start_pos, &vanilla_entities::PLAYER);
     state.is_crouching = is_crouching;
     state.on_ground = on_ground;
 

--- a/steel-core/src/portal/portal_shape.rs
+++ b/steel-core/src/portal/portal_shape.rs
@@ -54,8 +54,8 @@ pub fn nether_portal_config() -> PortalFrameConfig {
         max_width: 21,
         min_height: 3,
         max_height: 21,
-        frame: vanilla_blocks::OBSIDIAN,
-        portal: vanilla_blocks::NETHER_PORTAL,
+        frame: &vanilla_blocks::OBSIDIAN,
+        portal: &vanilla_blocks::NETHER_PORTAL,
     }
 }
 

--- a/steel-core/src/server/mod.rs
+++ b/steel-core/src/server/mod.rs
@@ -124,9 +124,9 @@ impl Server {
 
         let overworld = World::new_with_config(
             chunk_runtime.clone(),
-            OVERWORLD,
+            &OVERWORLD,
             seed,
-            Self::make_world_config(OVERWORLD, seed),
+            Self::make_world_config(&OVERWORLD, seed),
             generation_pool.clone(),
         )
         .await
@@ -134,9 +134,9 @@ impl Server {
 
         let nether = World::new_with_config(
             chunk_runtime.clone(),
-            THE_NETHER,
+            &THE_NETHER,
             seed,
-            Self::make_world_config(THE_NETHER, seed),
+            Self::make_world_config(&THE_NETHER, seed),
             generation_pool.clone(),
         )
         .await
@@ -144,9 +144,9 @@ impl Server {
 
         let end = World::new_with_config(
             chunk_runtime.clone(),
-            THE_END,
+            &THE_END,
             seed,
-            Self::make_world_config(THE_END, seed),
+            Self::make_world_config(&THE_END, seed),
             generation_pool,
         )
         .await
@@ -204,10 +204,11 @@ impl Server {
 
         // Get gamerule values
         let reduced_debug_info =
-            world.get_game_rule(REDUCED_DEBUG_INFO) == GameRuleValue::Bool(true);
-        let immediate_respawn = world.get_game_rule(IMMEDIATE_RESPAWN) == GameRuleValue::Bool(true);
+            world.get_game_rule(&REDUCED_DEBUG_INFO) == GameRuleValue::Bool(true);
+        let immediate_respawn =
+            world.get_game_rule(&IMMEDIATE_RESPAWN) == GameRuleValue::Bool(true);
         let do_limited_crafting =
-            world.get_game_rule(LIMITED_CRAFTING) == GameRuleValue::Bool(true);
+            world.get_game_rule(&LIMITED_CRAFTING) == GameRuleValue::Bool(true);
 
         // Get world data
         let hashed_seed = world.obfuscated_seed();
@@ -715,10 +716,10 @@ impl Server {
             WorldGeneratorTypes::Empty => ChunkGeneratorType::Empty(EmptyChunkGenerator::new()),
             WorldGeneratorTypes::Vanilla => {
                 let seed_u64 = seed as u64;
-                if dimension == OVERWORLD {
+                if dimension == &OVERWORLD {
                     let source = BiomeSourceKind::overworld(seed_u64);
                     ChunkGeneratorType::Overworld(VanillaGenerator::new(source, seed_u64))
-                } else if dimension == THE_NETHER {
+                } else if dimension == &THE_NETHER {
                     let source = BiomeSourceKind::nether(seed_u64);
                     ChunkGeneratorType::Nether(VanillaGenerator::new(source, seed_u64))
                 } else {
@@ -727,7 +728,7 @@ impl Server {
                 }
             }
             WorldGeneratorTypes::Flat => {
-                if dimension == THE_NETHER {
+                if dimension == &THE_NETHER {
                     ChunkGeneratorType::Flat(FlatChunkGenerator::new(
                         REGISTRY
                             .blocks
@@ -739,7 +740,7 @@ impl Server {
                             .blocks
                             .get_default_state_id(&vanilla_blocks::NETHERRACK),
                     ))
-                } else if dimension == THE_END {
+                } else if dimension == &THE_END {
                     ChunkGeneratorType::Flat(FlatChunkGenerator::new(
                         REGISTRY
                             .blocks

--- a/steel-core/src/server/mod.rs
+++ b/steel-core/src/server/mod.rs
@@ -731,35 +731,35 @@ impl Server {
                     ChunkGeneratorType::Flat(FlatChunkGenerator::new(
                         REGISTRY
                             .blocks
-                            .get_default_state_id(vanilla_blocks::BEDROCK),
+                            .get_default_state_id(&vanilla_blocks::BEDROCK),
                         REGISTRY
                             .blocks
-                            .get_default_state_id(vanilla_blocks::NETHER_BRICKS),
+                            .get_default_state_id(&vanilla_blocks::NETHER_BRICKS),
                         REGISTRY
                             .blocks
-                            .get_default_state_id(vanilla_blocks::NETHERRACK),
+                            .get_default_state_id(&vanilla_blocks::NETHERRACK),
                     ))
                 } else if dimension == THE_END {
                     ChunkGeneratorType::Flat(FlatChunkGenerator::new(
                         REGISTRY
                             .blocks
-                            .get_default_state_id(vanilla_blocks::BEDROCK),
+                            .get_default_state_id(&vanilla_blocks::BEDROCK),
                         REGISTRY
                             .blocks
-                            .get_default_state_id(vanilla_blocks::END_STONE),
+                            .get_default_state_id(&vanilla_blocks::END_STONE),
                         REGISTRY
                             .blocks
-                            .get_default_state_id(vanilla_blocks::END_STONE),
+                            .get_default_state_id(&vanilla_blocks::END_STONE),
                     ))
                 } else {
                     ChunkGeneratorType::Flat(FlatChunkGenerator::new(
                         REGISTRY
                             .blocks
-                            .get_default_state_id(vanilla_blocks::BEDROCK),
-                        REGISTRY.blocks.get_default_state_id(vanilla_blocks::DIRT),
+                            .get_default_state_id(&vanilla_blocks::BEDROCK),
+                        REGISTRY.blocks.get_default_state_id(&vanilla_blocks::DIRT),
                         REGISTRY
                             .blocks
-                            .get_default_state_id(vanilla_blocks::GRASS_BLOCK),
+                            .get_default_state_id(&vanilla_blocks::GRASS_BLOCK),
                     ))
                 }
             }

--- a/steel-core/src/world/mod.rs
+++ b/steel-core/src/world/mod.rs
@@ -689,7 +689,7 @@ impl World {
             self.tick_time();
         }
 
-        let random_tick_speed = self.get_game_rule(RANDOM_TICK_SPEED).as_int().unwrap_or(3) as u32;
+        let random_tick_speed = self.get_game_rule(&RANDOM_TICK_SPEED).as_int().unwrap_or(3) as u32;
 
         let chunk_map_timings =
             self.chunk_map
@@ -734,7 +734,7 @@ impl World {
             let mut level_data = self.level_data.write();
 
             if self
-                .get_game_rule_with_guard(ADVANCE_WEATHER, &level_data)
+                .get_game_rule_with_guard(&ADVANCE_WEATHER, &level_data)
                 .as_bool()
                 .expect("gamerule `ADVANCE_WEATHER` should always be a boolean.")
             {
@@ -982,7 +982,7 @@ impl World {
     /// then sends an update to all clients in this world every 20th tick.
     fn tick_time(&self) {
         let advance_time = self
-            .get_game_rule(ADVANCE_TIME)
+            .get_game_rule(&ADVANCE_TIME)
             .as_bool()
             .expect("gamerule advance_time should always be a bool.");
 
@@ -1985,7 +1985,7 @@ impl World {
         }
 
         // Respect doTileDrops gamerule
-        if !self.get_game_rule(BLOCK_DROPS).as_bool().unwrap_or(true) {
+        if !self.get_game_rule(&BLOCK_DROPS).as_bool().unwrap_or(true) {
             return None;
         }
 

--- a/steel-core/src/world/mod.rs
+++ b/steel-core/src/world/mod.rs
@@ -431,13 +431,13 @@ impl World {
     #[must_use]
     pub fn get_block_state(&self, pos: BlockPos) -> BlockStateId {
         if !self.is_in_valid_bounds(pos) {
-            return REGISTRY.blocks.get_base_state_id(vanilla_blocks::AIR);
+            return REGISTRY.blocks.get_base_state_id(&vanilla_blocks::AIR);
         }
 
         let chunk_pos = Self::chunk_pos_for_block(pos);
         self.chunk_map
             .with_full_chunk(chunk_pos, |chunk| chunk.get_block_state(pos))
-            .unwrap_or_else(|| REGISTRY.blocks.get_base_state_id(vanilla_blocks::AIR))
+            .unwrap_or_else(|| REGISTRY.blocks.get_base_state_id(&vanilla_blocks::AIR))
     }
 
     /// Sets a block at the given position.
@@ -559,7 +559,7 @@ impl World {
         let current_state = self.get_block_state(pos);
 
         if flags.contains(UpdateFlags::UPDATE_SKIP_SHAPE_UPDATE_ON_WIRE)
-            && current_state.get_block() == vanilla_blocks::REDSTONE_WIRE
+            && current_state.get_block() == &vanilla_blocks::REDSTONE_WIRE
         {
             return;
         }
@@ -1700,7 +1700,7 @@ impl World {
         }
 
         let block = state.get_block();
-        let is_fire = block == vanilla_blocks::FIRE || block == vanilla_blocks::SOUL_FIRE;
+        let is_fire = block == &vanilla_blocks::FIRE || block == &vanilla_blocks::SOUL_FIRE;
         if !is_fire {
             self.destroy_block_effect(pos, u32::from(state.0), None);
         }

--- a/steel-core/tests/chunk_stage_hashes.rs
+++ b/steel-core/tests/chunk_stage_hashes.rs
@@ -365,9 +365,9 @@ fn chunk_stage_hashes_inner() {
 
         let dim_short = dim_key.strip_prefix("minecraft:").unwrap_or(dim_key);
         let dim_type = match dim_key {
-            "minecraft:overworld" => vanilla_dimension_types::OVERWORLD,
-            "minecraft:the_nether" => vanilla_dimension_types::THE_NETHER,
-            "minecraft:the_end" => vanilla_dimension_types::THE_END,
+            "minecraft:overworld" => &vanilla_dimension_types::OVERWORLD,
+            "minecraft:the_nether" => &vanilla_dimension_types::THE_NETHER,
+            "minecraft:the_end" => &vanilla_dimension_types::THE_END,
             _ => panic!("Unknown dimension: {dim_key}"),
         };
 

--- a/steel-registry/build/banner_patterns.rs
+++ b/steel-registry/build/banner_patterns.rs
@@ -61,14 +61,14 @@ pub(crate) fn build() -> TokenStream {
         let translation_key = banner_pattern.translation_key.as_str();
 
         stream.extend(quote! {
-            pub static #banner_pattern_ident: &BannerPattern = &BannerPattern {
+            pub static #banner_pattern_ident: BannerPattern = BannerPattern {
                 key: #key,
                 asset_id: #asset_id,
                 translation_key: #translation_key,
             };
         });
         register_stream.extend(quote! {
-            registry.register(#banner_pattern_ident);
+            registry.register(&#banner_pattern_ident);
         });
     }
 

--- a/steel-registry/build/biomes.rs
+++ b/steel-registry/build/biomes.rs
@@ -553,7 +553,7 @@ pub(crate) fn build() -> TokenStream {
         };
         use steel_utils::Identifier;
         use std::borrow::Cow;
-        use std::sync::LazyLock;
+        use std::sync::{LazyLock, OnceLock};
         use rustc_hash::FxHashMap;
     });
 
@@ -591,6 +591,7 @@ pub(crate) fn build() -> TokenStream {
                 spawn_costs: #spawn_costs,
                 carvers: #carvers,
                 features: #features,
+                id: OnceLock::new(),
             });
         });
         let biome_ident = Ident::new(&biome_name.to_shouty_snake_case(), Span::call_site());

--- a/steel-registry/build/biomes.rs
+++ b/steel-registry/build/biomes.rs
@@ -595,7 +595,7 @@ pub(crate) fn build() -> TokenStream {
         });
         let biome_ident = Ident::new(&biome_name.to_shouty_snake_case(), Span::call_site());
         register_stream.extend(quote! {
-            registry.register(&#biome_ident, #biome_ident.key.clone());
+            registry.register(&#biome_ident);
         });
     }
 

--- a/steel-registry/build/block_entity_types.rs
+++ b/steel-registry/build/block_entity_types.rs
@@ -39,12 +39,12 @@ pub(crate) fn build() -> TokenStream {
         let key = quote! { Identifier::vanilla_static(#block_entity_type_name_str) };
 
         stream.extend(quote! {
-            pub static #block_entity_type_ident: &BlockEntityType = &BlockEntityType {
+            pub static #block_entity_type_ident: BlockEntityType = BlockEntityType {
                 key: #key,
             };
         });
         register_stream.extend(quote! {
-            registry.register(#block_entity_type_ident);
+            registry.register(&#block_entity_type_ident);
         });
     }
 

--- a/steel-registry/build/blocks.rs
+++ b/steel-registry/build/blocks.rs
@@ -578,7 +578,7 @@ pub(crate) fn build() -> TokenStream {
         );
 
         stream.extend(quote! {
-            pub static #block_name: &Block = &Block::new(
+            pub static #block_name: Block = Block::new(
                 Identifier::vanilla_static(#block_name_str),
                 BlockConfig::new()#(#builder_calls)*,
                 &[
@@ -594,7 +594,7 @@ pub(crate) fn build() -> TokenStream {
         let block_name = Ident::new(&block.name.to_shouty_snake_case(), Span::call_site());
 
         register_stream.extend(quote! {
-            registry.register(#block_name);
+            registry.register(&#block_name);
         });
     }
 

--- a/steel-registry/build/cat_sound_variants.rs
+++ b/steel-registry/build/cat_sound_variants.rs
@@ -96,7 +96,7 @@ pub(crate) fn build() -> TokenStream {
             generate_identifier(&cat_sound_variant.baby_sounds.stray_ambient_sound);
 
         stream.extend(quote! {
-            pub static #cat_sound_variant_ident: &CatSoundVariant = &CatSoundVariant {
+            pub static #cat_sound_variant_ident: CatSoundVariant = CatSoundVariant {
                 key: #key,
                 adult_sounds: CatAge {
                     ambient_sound: #adult_ambient_sound,
@@ -124,7 +124,7 @@ pub(crate) fn build() -> TokenStream {
         });
 
         register_stream.extend(quote! {
-            registry.register(#cat_sound_variant_ident);
+            registry.register(&#cat_sound_variant_ident);
         });
     }
 

--- a/steel-registry/build/cat_variants.rs
+++ b/steel-registry/build/cat_variants.rs
@@ -155,7 +155,7 @@ pub(crate) fn build() -> TokenStream {
             .collect();
 
         stream.extend(quote! {
-            pub static #cat_variant_ident: &CatVariant = &CatVariant {
+            pub static #cat_variant_ident: CatVariant = CatVariant {
                 key: #key,
                 asset_id: #asset_id,
                 baby_asset_id: #baby_asset_id,
@@ -163,7 +163,7 @@ pub(crate) fn build() -> TokenStream {
             };
         });
         register_stream.extend(quote! {
-            registry.register(#cat_variant_ident);
+            registry.register(&#cat_variant_ident);
         });
     }
 

--- a/steel-registry/build/chat_types.rs
+++ b/steel-registry/build/chat_types.rs
@@ -131,14 +131,14 @@ pub(crate) fn build() -> TokenStream {
         let narration = generate_chat_type_decoration(&chat_type.narration);
 
         stream.extend(quote! {
-            pub static #chat_type_ident: &ChatType = &ChatType {
+            pub static #chat_type_ident: ChatType = ChatType {
                 key: #key,
                 chat: #chat,
                 narration: #narration,
             };
         });
         register_stream.extend(quote! {
-            registry.register(#chat_type_ident);
+            registry.register(&#chat_type_ident);
         });
     }
 

--- a/steel-registry/build/chicken_sound_variants.rs
+++ b/steel-registry/build/chicken_sound_variants.rs
@@ -84,7 +84,7 @@ pub(crate) fn build() -> TokenStream {
         let baby_step_sound = generate_identifier(&chicken_sound_variant.baby_sounds.step_sound);
 
         stream.extend(quote! {
-            pub static #chicken_sound_variant_ident: &ChickenSoundVariant = &ChickenSoundVariant {
+            pub static #chicken_sound_variant_ident: ChickenSoundVariant = ChickenSoundVariant {
                 key: #key,
                 adult_sounds: ChickenAge {
                     ambient_sound: #adult_ambient_sound,
@@ -102,7 +102,7 @@ pub(crate) fn build() -> TokenStream {
         });
 
         register_stream.extend(quote! {
-            registry.register(#chicken_sound_variant_ident);
+            registry.register(&#chicken_sound_variant_ident);
         });
     }
 

--- a/steel-registry/build/chicken_variants.rs
+++ b/steel-registry/build/chicken_variants.rs
@@ -131,7 +131,7 @@ pub(crate) fn build() -> TokenStream {
             .collect();
 
         stream.extend(quote! {
-            pub static #chicken_variant_ident: &ChickenVariant = &ChickenVariant {
+            pub static #chicken_variant_ident: ChickenVariant = ChickenVariant {
                 key: #key,
                 asset_id: #asset_id,
                 baby_asset_id: #baby_asset_id,
@@ -140,7 +140,7 @@ pub(crate) fn build() -> TokenStream {
             };
         });
         register_stream.extend(quote! {
-            registry.register(#chicken_variant_ident);
+            registry.register(&#chicken_variant_ident);
         });
     }
 

--- a/steel-registry/build/cow_sound_variants.rs
+++ b/steel-registry/build/cow_sound_variants.rs
@@ -66,7 +66,7 @@ pub(crate) fn build() -> TokenStream {
         let step_sound = generate_identifier(&cow_sound_variant.step_sound);
 
         stream.extend(quote! {
-            pub static #cow_sound_variant_ident: &CowSoundVariant = &CowSoundVariant {
+            pub static #cow_sound_variant_ident: CowSoundVariant = CowSoundVariant {
                 key: #key,
                 ambient_sound: #ambient_sound,
                 death_sound: #death_sound,
@@ -76,7 +76,7 @@ pub(crate) fn build() -> TokenStream {
         });
 
         register_stream.extend(quote! {
-            registry.register(#cow_sound_variant_ident);
+            registry.register(&#cow_sound_variant_ident);
         });
     }
 

--- a/steel-registry/build/cow_variants.rs
+++ b/steel-registry/build/cow_variants.rs
@@ -130,7 +130,7 @@ pub(crate) fn build() -> TokenStream {
             .collect();
 
         stream.extend(quote! {
-            pub static #cow_variant_ident: &CowVariant = &CowVariant {
+            pub static #cow_variant_ident: CowVariant = CowVariant {
                 key: #key,
                 asset_id: #asset_id,
                 baby_asset_id: #baby_asset_id,
@@ -141,7 +141,7 @@ pub(crate) fn build() -> TokenStream {
         let cow_variant_ident =
             Ident::new(&cow_variant_name.to_shouty_snake_case(), Span::call_site());
         register_stream.extend(quote! {
-            registry.register(#cow_variant_ident);
+            registry.register(&#cow_variant_ident);
         });
     }
 

--- a/steel-registry/build/damage_types.rs
+++ b/steel-registry/build/damage_types.rs
@@ -121,7 +121,7 @@ pub(crate) fn build() -> TokenStream {
         let death_message_type = generate_death_message_type(damage_type.death_message_type);
 
         stream.extend(quote! {
-            pub static #damage_type_ident: &DamageType = &DamageType {
+            pub static #damage_type_ident: DamageType = DamageType {
                 key: #key,
                 message_id: #message_id,
                 scaling: #scaling,
@@ -131,7 +131,7 @@ pub(crate) fn build() -> TokenStream {
             };
         });
         register_stream.extend(quote! {
-            registry.register(#damage_type_ident);
+            registry.register(&#damage_type_ident);
         });
     }
 

--- a/steel-registry/build/density_functions.rs
+++ b/steel-registry/build/density_functions.rs
@@ -731,13 +731,13 @@ fn generate_noise_settings(dimension: &str, prefix: &str) -> TokenStream {
             /// Get the default block state ID for this dimension.
             #[inline]
             pub fn default_block_id() -> steel_utils::BlockStateId {
-                crate::REGISTRY.blocks.get_default_state_id(crate::vanilla_blocks::#default_block_ident)
+                crate::REGISTRY.blocks.get_default_state_id(&crate::vanilla_blocks::#default_block_ident)
             }
 
             /// Get the default fluid state ID for this dimension.
             #[inline]
             pub fn default_fluid_id() -> steel_utils::BlockStateId {
-                crate::REGISTRY.blocks.get_default_state_id(crate::vanilla_blocks::#default_fluid_ident)
+                crate::REGISTRY.blocks.get_default_state_id(&crate::vanilla_blocks::#default_fluid_ident)
             }
         }
 

--- a/steel-registry/build/dialogs.rs
+++ b/steel-registry/build/dialogs.rs
@@ -110,7 +110,7 @@ pub(crate) fn build() -> TokenStream {
                 let title = generate_text_component(&dialog_list.title);
 
                 stream.extend(quote! {
-                    pub static #dialog_ident: &Dialog = &Dialog {
+                    pub static #dialog_ident: Dialog = Dialog {
                         key: #key,
                         button_width: #button_width,
                         columns: #columns,
@@ -129,7 +129,7 @@ pub(crate) fn build() -> TokenStream {
                 let title = generate_text_component(&server_links.title);
 
                 stream.extend(quote! {
-                    pub static #dialog_ident: &Dialog = &Dialog {
+                    pub static #dialog_ident: Dialog = Dialog {
                         key: #key,
                         button_width: #button_width,
                         columns: #columns,
@@ -142,7 +142,7 @@ pub(crate) fn build() -> TokenStream {
             }
         }
         register_stream.extend(quote! {
-            registry.register(#dialog_ident);
+            registry.register(&#dialog_ident);
         });
     }
 

--- a/steel-registry/build/dimension_types.rs
+++ b/steel-registry/build/dimension_types.rs
@@ -463,7 +463,7 @@ pub(crate) fn build() -> TokenStream {
         let has_ender_dragon_fight = dimension_type.has_ender_dragon_fight;
 
         stream.extend(quote! {
-            pub static #dimension_type_ident: &DimensionType = &DimensionType {
+            pub static #dimension_type_ident: DimensionType = DimensionType {
                 key: #key,
                 fixed_time: #fixed_time,
                 has_skylight: #has_skylight,
@@ -506,7 +506,7 @@ pub(crate) fn build() -> TokenStream {
         });
 
         register_stream.extend(quote! {
-            registry.register(#dimension_type_ident);
+            registry.register(&#dimension_type_ident);
         });
     }
 

--- a/steel-registry/build/entities.rs
+++ b/steel-registry/build/entities.rs
@@ -109,7 +109,7 @@ pub(crate) fn build() -> TokenStream {
         let can_be_seen_as_enemy = flags.is_some_and(|f| f.can_be_seen_as_enemy);
 
         stream.extend(quote! {
-            pub static #entity_type_ident: &EntityType = &EntityType {
+            pub static #entity_type_ident: EntityType = EntityType {
                 key: Identifier::vanilla_static(#entity_type_key),
                 client_tracking_range: #client_tracking_range,
                 update_interval: #update_interval,
@@ -135,7 +135,7 @@ pub(crate) fn build() -> TokenStream {
             };
         });
         register_stream.extend(quote! {
-            registry.register(#entity_type_ident);
+            registry.register(&#entity_type_ident);
         });
     }
 

--- a/steel-registry/build/frog_variants.rs
+++ b/steel-registry/build/frog_variants.rs
@@ -117,7 +117,7 @@ pub(crate) fn build() -> TokenStream {
             .collect();
 
         stream.extend(quote! {
-            pub static #frog_variant_ident: &FrogVariant = &FrogVariant {
+            pub static #frog_variant_ident: FrogVariant = FrogVariant {
                 key: #key,
                 asset_id: #asset_id,
                 spawn_conditions: &[#(#spawn_conditions),*],
@@ -125,7 +125,7 @@ pub(crate) fn build() -> TokenStream {
         });
 
         register_stream.extend(quote! {
-            registry.register(#frog_variant_ident);
+            registry.register(&#frog_variant_ident);
         });
     }
 

--- a/steel-registry/build/game_rules.rs
+++ b/steel-registry/build/game_rules.rs
@@ -66,7 +66,7 @@ pub fn build() -> TokenStream {
         };
 
         constants.extend(quote! {
-            pub static #const_name: &GameRule = &GameRule {
+            pub static #const_name: GameRule = GameRule {
                 key: Identifier::vanilla_static(#rule_name),
                 category: GameRuleCategory::#category,
                 value_type: #value_type,
@@ -77,7 +77,7 @@ pub fn build() -> TokenStream {
         });
 
         registrations.extend(quote! {
-            registry.register(#const_name);
+            registry.register(&#const_name);
         });
     }
 

--- a/steel-registry/build/instruments.rs
+++ b/steel-registry/build/instruments.rs
@@ -78,7 +78,7 @@ pub(crate) fn build() -> TokenStream {
         let description = generate_text_component(&instrument.description);
 
         stream.extend(quote! {
-            pub static #instrument_ident: &Instrument = &Instrument {
+            pub static #instrument_ident: Instrument = Instrument {
                 key: #key,
                 sound_event: #sound_event,
                 use_duration: #use_duration,
@@ -89,7 +89,7 @@ pub(crate) fn build() -> TokenStream {
         let instrument_ident =
             Ident::new(&instrument_name.to_shouty_snake_case(), Span::call_site());
         register_stream.extend(quote! {
-            registry.register(#instrument_ident);
+            registry.register(&#instrument_ident);
         });
     }
 

--- a/steel-registry/build/items.rs
+++ b/steel-registry/build/items.rs
@@ -265,23 +265,23 @@ pub(crate) fn build() -> TokenStream {
             if builder_calls.is_empty() {
                 if block_name != &item.name {
                     item_construction.extend(quote! {
-                        #item_ident: Item::from_block_custom_name(vanilla_blocks::#block_ident, #item_name_str),
+                        #item_ident: Item::from_block_custom_name(&vanilla_blocks::#block_ident, #item_name_str),
                     });
                 } else {
                     item_construction.extend(quote! {
-                        #item_ident: Item::from_block(vanilla_blocks::#block_ident),
+                        #item_ident: Item::from_block(&vanilla_blocks::#block_ident),
                     });
                 }
             } else {
                 // Block item with custom components
                 if block_name != &item.name {
                     item_construction.extend(quote! {
-                        #item_ident: Item::from_block_custom_name(vanilla_blocks::#block_ident, #item_name_str)
+                        #item_ident: Item::from_block_custom_name(&vanilla_blocks::#block_ident, #item_name_str)
                             #(#builder_calls)*,
                     });
                 } else {
                     item_construction.extend(quote! {
-                        #item_ident: Item::from_block(vanilla_blocks::#block_ident)
+                        #item_ident: Item::from_block(&vanilla_blocks::#block_ident)
                             #(#builder_calls)*,
                     });
                 }

--- a/steel-registry/build/items.rs
+++ b/steel-registry/build/items.rs
@@ -301,6 +301,7 @@ pub(crate) fn build() -> TokenStream {
                     components: DataComponentMap::common_item_components()
                         #(#builder_calls)*,
                     craft_remainder: #craft_remainder_value,
+                    id: OnceLock::new(),
                 },
             });
         }
@@ -317,7 +318,7 @@ pub(crate) fn build() -> TokenStream {
             items::{Item, ItemRegistry},
         };
         use steel_utils::Identifier;
-        use std::sync::LazyLock;
+        use std::sync::{LazyLock, OnceLock};
 
         pub static ITEMS: LazyLock<Items> = LazyLock::new(Items::init);
 

--- a/steel-registry/build/jukebox_songs.rs
+++ b/steel-registry/build/jukebox_songs.rs
@@ -85,7 +85,7 @@ pub(crate) fn build() -> TokenStream {
         let comparator_output = jukebox_song.comparator_output;
 
         stream.extend(quote! {
-            pub static #jukebox_song_ident: &JukeboxSong = &JukeboxSong {
+            pub static #jukebox_song_ident: JukeboxSong = JukeboxSong {
                 key: #key,
                 sound_event: #sound_event,
                 description: #description,
@@ -95,7 +95,7 @@ pub(crate) fn build() -> TokenStream {
         });
 
         register_stream.extend(quote! {
-            registry.register(#jukebox_song_ident);
+            registry.register(&#jukebox_song_ident);
         });
     }
 

--- a/steel-registry/build/loot_tables.rs
+++ b/steel-registry/build/loot_tables.rs
@@ -1685,7 +1685,7 @@ pub(crate) fn build() -> TokenStream {
         };
 
         stream.extend(quote! {
-            pub static #const_ident: &LootTable = &LootTable {
+            pub static #const_ident: LootTable = LootTable {
                 key: Identifier::vanilla_static(#key),
                 loot_type: #loot_type,
                 pools: &[#(#pools),*],
@@ -1700,7 +1700,7 @@ pub(crate) fn build() -> TokenStream {
         .iter()
         .map(|t| {
             let const_ident = &t.const_ident;
-            quote! { registry.register(#const_ident); }
+            quote! { registry.register(&#const_ident); }
         })
         .collect();
 
@@ -1768,7 +1768,7 @@ pub(crate) fn build() -> TokenStream {
             .iter()
             .map(|(table, field_ident)| {
                 let const_ident = &table.const_ident;
-                quote! { #field_ident: #const_ident, }
+                quote! { #field_ident: &#const_ident, }
             })
             .collect();
 

--- a/steel-registry/build/menu_types.rs
+++ b/steel-registry/build/menu_types.rs
@@ -30,13 +30,13 @@ pub(crate) fn build() -> TokenStream {
         let key = quote! { Identifier::vanilla_static(#menu_type_name_str) };
 
         stream.extend(quote! {
-            pub static #menu_type_ident: &MenuType = &MenuType {
+            pub static #menu_type_ident: MenuType = MenuType {
                 key: #key,
             };
         });
 
         register_stream.extend(quote! {
-            registry.register(#menu_type_ident);
+            registry.register(&#menu_type_ident);
         });
     }
 

--- a/steel-registry/build/painting_variants.rs
+++ b/steel-registry/build/painting_variants.rs
@@ -147,7 +147,7 @@ pub(crate) fn build() -> TokenStream {
         let author = generate_option(&painting_variant.author, generate_text_component);
 
         stream.extend(quote! {
-            pub static #painting_variant_ident: &PaintingVariant = &PaintingVariant {
+            pub static #painting_variant_ident: PaintingVariant = PaintingVariant {
                 key: #key,
                 width: #width,
                 height: #height,
@@ -158,7 +158,7 @@ pub(crate) fn build() -> TokenStream {
         });
 
         register_stream.extend(quote! {
-            registry.register(#painting_variant_ident);
+            registry.register(&#painting_variant_ident);
         });
     }
 

--- a/steel-registry/build/pig_sound_variants.rs
+++ b/steel-registry/build/pig_sound_variants.rs
@@ -79,7 +79,7 @@ pub(crate) fn build() -> TokenStream {
         let baby_eat_sound = generate_identifier(&pig_sound_variant.baby_sounds.eat_sound);
 
         stream.extend(quote! {
-            pub static #pig_sound_variant_ident: &PigSoundVariant = &PigSoundVariant {
+            pub static #pig_sound_variant_ident: PigSoundVariant = PigSoundVariant {
                 key: #key,
                 adult_sounds: PigAge {
                     ambient_sound: #adult_ambient_sound,
@@ -99,7 +99,7 @@ pub(crate) fn build() -> TokenStream {
         });
 
         register_stream.extend(quote! {
-            registry.register(#pig_sound_variant_ident);
+            registry.register(&#pig_sound_variant_ident);
         });
     }
 

--- a/steel-registry/build/pig_variants.rs
+++ b/steel-registry/build/pig_variants.rs
@@ -129,7 +129,7 @@ pub(crate) fn build() -> TokenStream {
             .collect();
 
         stream.extend(quote! {
-            pub static #pig_variant_ident: &PigVariant = &PigVariant {
+            pub static #pig_variant_ident: PigVariant = PigVariant {
                 key: #key,
                 asset_id: #asset_id,
                 baby_asset_id: #baby_asset_id,
@@ -139,7 +139,7 @@ pub(crate) fn build() -> TokenStream {
         });
 
         register_stream.extend(quote! {
-            registry.register(#pig_variant_ident);
+            registry.register(&#pig_variant_ident);
         });
     }
 

--- a/steel-registry/build/surface_rules.rs
+++ b/steel-registry/build/surface_rules.rs
@@ -113,8 +113,6 @@ pub enum VerticalAnchorJson {
 pub struct SurfaceRuleTranspiler {
     /// Collected noise IDs referenced by NoiseThreshold conditions.
     pub noise_ids: Vec<String>,
-    /// Unique biome names for generating cached `OnceLock<u16>` statics.
-    pub biome_names: Vec<String>,
     /// Min Y for this dimension.
     min_y: i32,
     /// Height for this dimension.
@@ -125,7 +123,6 @@ impl SurfaceRuleTranspiler {
     pub fn new(min_y: i32, height: i32) -> Self {
         Self {
             noise_ids: Vec::new(),
-            biome_names: Vec::new(),
             min_y,
             height,
         }
@@ -218,15 +215,8 @@ impl SurfaceRuleTranspiler {
                             .strip_prefix("minecraft:")
                             .unwrap_or(b.as_str());
                         let upper = biome_name.to_uppercase();
-                        if !self.biome_names.contains(&upper) {
-                            self.biome_names.push(upper.clone());
-                        }
-                        let static_name = Ident::new(
-                            &format!("BIOME_ID_{upper}"),
-                            Span::call_site(),
-                        );
                         let biome_ident = Ident::new(&upper, Span::call_site());
-                        quote! { ctx.biome_id == *#static_name.get_or_init(|| crate::RegistryEntry::id(&*crate::vanilla_biomes::#biome_ident) as u16) }
+                        quote! { ctx.biome_id == crate::RegistryEntry::id(&*crate::vanilla_biomes::#biome_ident) as u16 }
                     })
                     .collect();
                 if checks.len() == 1 {
@@ -351,24 +341,12 @@ pub fn generate_surface_rule_function(
     let body = transpiler.transpile_rule(rule);
     let noise_ids = transpiler.noise_ids.clone();
 
-    let biome_statics: Vec<_> = transpiler
-        .biome_names
-        .iter()
-        .map(|name| {
-            let static_name = Ident::new(&format!("BIOME_ID_{name}"), Span::call_site());
-            quote! {
-                static #static_name: std::sync::OnceLock<u16> = std::sync::OnceLock::new();
-            }
-        })
-        .collect();
-
     let func = quote! {
         /// Apply this dimension's surface rule at the current context position.
         #[allow(clippy::collapsible_if, clippy::needless_return, clippy::erasing_op, unused_comparisons)]
         fn apply_surface_rule_impl(
             ctx: &steel_utils::surface::SurfaceRuleContext<'_>,
         ) -> Option<steel_utils::BlockStateId> {
-            #(#biome_statics)*
             #body
             None
         }

--- a/steel-registry/build/timelines.rs
+++ b/steel-registry/build/timelines.rs
@@ -231,7 +231,7 @@ pub(crate) fn build() -> TokenStream {
             .collect();
 
         stream.extend(quote! {
-            pub static #timeline_ident: &Timeline = &Timeline {
+            pub static #timeline_ident: Timeline = Timeline {
                 key: #key,
                 clock: #clock_ts,
                 period_ticks: #period_ticks_ts,
@@ -245,7 +245,7 @@ pub(crate) fn build() -> TokenStream {
         });
 
         register_stream.extend(quote! {
-            registry.register(#timeline_ident);
+            registry.register(&#timeline_ident);
         });
     }
 

--- a/steel-registry/build/trim_materials.rs
+++ b/steel-registry/build/trim_materials.rs
@@ -43,7 +43,7 @@ where
 
 fn generate_hashmap_resource_string(map: &FxHashMap<Identifier, String>) -> TokenStream {
     if map.is_empty() {
-        return quote! { rustc_hash::FxHashMap::default() };
+        return quote! { FxHashMap::default() };
     }
     let entries: Vec<_> = map
         .iter()
@@ -52,7 +52,7 @@ fn generate_hashmap_resource_string(map: &FxHashMap<Identifier, String>) -> Toke
             quote! { (#key, #v.to_string()) }
         })
         .collect();
-    quote! { rustc_hash::FxHashMap::from_iter([#(#entries),*]) }
+    quote! { FxHashMap::from_iter([#(#entries),*]) }
 }
 
 pub(crate) fn build() -> TokenStream {
@@ -120,7 +120,7 @@ pub(crate) fn build() -> TokenStream {
         });
 
         register_stream.extend(quote! {
-            registry.register(&#trim_material_ident, #trim_material_ident.key.clone());
+            registry.register(&#trim_material_ident);
         });
     }
 

--- a/steel-registry/build/trim_patterns.rs
+++ b/steel-registry/build/trim_patterns.rs
@@ -70,7 +70,7 @@ pub(crate) fn build() -> TokenStream {
         let decal = trim_pattern.decal;
 
         stream.extend(quote! {
-            pub static #trim_pattern_ident: &TrimPattern = &TrimPattern {
+            pub static #trim_pattern_ident: TrimPattern = TrimPattern {
                 key: #key,
                 asset_id: #asset_id,
                 description: TextComponent::translated(TranslatedMessage::new(#translate, None)),
@@ -79,7 +79,7 @@ pub(crate) fn build() -> TokenStream {
         });
 
         register_stream.extend(quote! {
-            registry.register(#trim_pattern_ident);
+            registry.register(&#trim_pattern_ident);
         });
     }
 

--- a/steel-registry/build/wolf_sound_variants.rs
+++ b/steel-registry/build/wolf_sound_variants.rs
@@ -85,7 +85,7 @@ pub(crate) fn build() -> TokenStream {
         let baby_step_sound = generate_identifier(&wolf_sound_variant.baby_sounds.step_sound);
 
         stream.extend(quote! {
-            pub static #wolf_sound_variant_ident: &WolfSoundVariant = &WolfSoundVariant {
+            pub static #wolf_sound_variant_ident: WolfSoundVariant = WolfSoundVariant {
                 key: #key,
                 adult_sounds: WolfAge {
                     ambient_sound: #adult_ambient_sound,
@@ -109,7 +109,7 @@ pub(crate) fn build() -> TokenStream {
         });
 
         register_stream.extend(quote! {
-            registry.register(#wolf_sound_variant_ident);
+            registry.register(&#wolf_sound_variant_ident);
         });
     }
 

--- a/steel-registry/build/wolf_variants.rs
+++ b/steel-registry/build/wolf_variants.rs
@@ -130,7 +130,7 @@ pub(crate) fn build() -> TokenStream {
             .collect();
 
         stream.extend(quote! {
-            pub static #wolf_variant_ident: &WolfVariant = &WolfVariant {
+            pub static #wolf_variant_ident: WolfVariant = WolfVariant {
                 key: #key,
                 assets: WolfAssetInfo {
                     wild: #wild,
@@ -147,7 +147,7 @@ pub(crate) fn build() -> TokenStream {
         });
 
         register_stream.extend(quote! {
-            registry.register(#wolf_variant_ident);
+            registry.register(&#wolf_variant_ident);
         });
     }
 

--- a/steel-registry/build/world_clocks.rs
+++ b/steel-registry/build/world_clocks.rs
@@ -47,13 +47,13 @@ pub(crate) fn build() -> TokenStream {
         let key = quote! { Identifier::vanilla_static(#world_clock_name_str) };
 
         stream.extend(quote! {
-            pub static #world_clock_ident: &WorldClock = &WorldClock {
+            pub static #world_clock_ident: WorldClock = WorldClock {
                 key: #key,
             };
         });
 
         register_stream.extend(quote! {
-            registry.register(#world_clock_ident);
+            registry.register(&#world_clock_ident);
         });
     }
 

--- a/steel-registry/build/zombie_nautilus_variants.rs
+++ b/steel-registry/build/zombie_nautilus_variants.rs
@@ -131,7 +131,7 @@ pub(crate) fn build() -> TokenStream {
             .collect();
 
         stream.extend(quote! {
-            pub static #zombie_nautilus_variant_ident: &ZombieNautilusVariant = &ZombieNautilusVariant {
+            pub static #zombie_nautilus_variant_ident: ZombieNautilusVariant = ZombieNautilusVariant {
                 key: #key,
                 asset_id: #asset_id,
                 model: #model,
@@ -144,7 +144,7 @@ pub(crate) fn build() -> TokenStream {
             Span::call_site(),
         );
         register_stream.extend(quote! {
-            registry.register(#zombie_nautilus_variant_ident);
+            registry.register(&#zombie_nautilus_variant_ident);
         });
     }
 

--- a/steel-registry/src/banner_pattern.rs
+++ b/steel-registry/src/banner_pattern.rs
@@ -41,44 +41,15 @@ impl BannerPatternRegistry {
             allows_registering: true,
         }
     }
-
-    pub fn register(&mut self, banner_pattern: BannerPatternRef) -> usize {
-        assert!(
-            self.allows_registering,
-            "Cannot register banner patterns after the registry has been frozen"
-        );
-
-        let id = self.banner_patterns_by_id.len();
-        self.banner_patterns_by_key
-            .insert(banner_pattern.key.clone(), id);
-        self.banner_patterns_by_id.push(banner_pattern);
-        id
-    }
-
-    /// Replaces a banner_pattern at a given index.
-    /// Returns true if the banner_pattern was replaced and false if the banner_pattern wasn't replaced
-    #[must_use]
-    pub fn replace(&mut self, banner_pattern: BannerPatternRef, id: usize) -> bool {
-        if id >= self.banner_patterns_by_id.len() {
-            return false;
-        }
-        self.banner_patterns_by_id[id] = banner_pattern;
-        true
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (usize, BannerPatternRef)> + '_ {
-        self.banner_patterns_by_id
-            .iter()
-            .enumerate()
-            .map(|(id, &pattern)| (id, pattern))
-    }
 }
 
-impl Default for BannerPatternRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+crate::impl_standard_methods!(
+    BannerPatternRegistry,
+    BannerPatternRef,
+    banner_patterns_by_id,
+    banner_patterns_by_key,
+    allows_registering
+);
 
 crate::impl_registry!(
     BannerPatternRegistry,

--- a/steel-registry/src/biome.rs
+++ b/steel-registry/src/biome.rs
@@ -265,42 +265,14 @@ impl BiomeRegistry {
             allows_registering: true,
         }
     }
-
-    pub fn register(&mut self, biome: BiomeRef, key: Identifier) -> usize {
-        assert!(
-            self.allows_registering,
-            "Cannot register biomes after the registry has been frozen"
-        );
-
-        let id = self.biomes_by_id.len();
-        self.biomes_by_key.insert(key, id);
-        self.biomes_by_id.push(biome);
-        id
-    }
-
-    /// Replaces a biome at a given index.
-    /// Returns true if the biome was replaced and false if the biome wasn't replaced
-    #[must_use]
-    pub fn replace(&mut self, biome: BiomeRef, id: usize) -> bool {
-        if id >= self.biomes_by_id.len() {
-            return false;
-        }
-        self.biomes_by_id[id] = biome;
-        true
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (usize, BiomeRef)> + '_ {
-        self.biomes_by_id
-            .iter()
-            .enumerate()
-            .map(|(id, &biome)| (id, biome))
-    }
 }
 
-impl Default for BiomeRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+crate::impl_standard_methods!(
+    BiomeRegistry,
+    BiomeRef,
+    biomes_by_id,
+    biomes_by_key,
+    allows_registering
+);
 
 crate::impl_registry!(BiomeRegistry, Biome, biomes_by_id, biomes_by_key, biomes);

--- a/steel-registry/src/biome.rs
+++ b/steel-registry/src/biome.rs
@@ -1,3 +1,5 @@
+use std::sync::OnceLock;
+
 use rustc_hash::FxHashMap;
 use simdnbt::ToNbtTag;
 use simdnbt::owned::NbtTag;
@@ -16,6 +18,8 @@ pub struct Biome {
     pub spawn_costs: FxHashMap<Identifier, SpawnCost>,
     pub carvers: Vec<Identifier>,
     pub features: Vec<Vec<Identifier>>,
+    /// Cached registry ID, set during registration for O(1) lookup on hot paths.
+    pub id: OnceLock<usize>,
 }
 
 #[derive(Debug)]
@@ -267,12 +271,42 @@ impl BiomeRegistry {
     }
 }
 
-crate::impl_standard_methods!(
-    BiomeRegistry,
-    BiomeRef,
-    biomes_by_id,
-    biomes_by_key,
-    allows_registering
-);
+impl BiomeRegistry {
+    pub fn register(&mut self, entry: BiomeRef) -> usize {
+        assert!(
+            self.allows_registering,
+            "Cannot register Biome after registry has been frozen"
+        );
+        let id = self.biomes_by_id.len();
+        let cached = entry.id.get_or_init(|| id);
+        assert_eq!(*cached, id, "biome registered with conflicting id");
+        self.biomes_by_id.push(entry);
+        self.biomes_by_key.insert(entry.key.clone(), id);
+        id
+    }
 
-crate::impl_registry!(BiomeRegistry, Biome, biomes_by_id, biomes_by_key, biomes);
+    pub fn iter(&self) -> impl Iterator<Item = (usize, BiomeRef)> + '_ {
+        self.biomes_by_id
+            .iter()
+            .enumerate()
+            .map(|(id, &entry)| (id, entry))
+    }
+}
+
+impl Default for BiomeRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+crate::impl_registry_ext!(BiomeRegistry, Biome, biomes_by_id, biomes_by_key);
+
+impl crate::RegistryEntry for Biome {
+    fn key(&self) -> &Identifier {
+        &self.key
+    }
+
+    fn try_id(&self) -> Option<usize> {
+        self.id.get().copied()
+    }
+}

--- a/steel-registry/src/block_entity_type.rs
+++ b/steel-registry/src/block_entity_type.rs
@@ -26,44 +26,15 @@ impl BlockEntityTypeRegistry {
             allows_registering: true,
         }
     }
-
-    pub fn register(&mut self, block_entity_type: BlockEntityTypeRef) -> usize {
-        assert!(
-            self.allows_registering,
-            "Cannot register block entity types after the registry has been frozen"
-        );
-
-        let id = self.block_entity_types_by_id.len();
-        self.block_entity_types_by_key
-            .insert(block_entity_type.key.clone(), id);
-        self.block_entity_types_by_id.push(block_entity_type);
-        id
-    }
-
-    /// Replaces a block_entity_type at a given index.
-    /// Returns true if the block_entity_type was replaced and false if the block_entity_type wasn't replaced
-    #[must_use]
-    pub fn replace(&mut self, block_entity_type: BlockEntityTypeRef, id: usize) -> bool {
-        if id >= self.block_entity_types_by_id.len() {
-            return false;
-        }
-        self.block_entity_types_by_id[id] = block_entity_type;
-        true
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (usize, BlockEntityTypeRef)> + '_ {
-        self.block_entity_types_by_id
-            .iter()
-            .enumerate()
-            .map(|(id, &block_entity_type)| (id, block_entity_type))
-    }
 }
 
-impl Default for BlockEntityTypeRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+crate::impl_standard_methods!(
+    BlockEntityTypeRegistry,
+    BlockEntityTypeRef,
+    block_entity_types_by_id,
+    block_entity_types_by_key,
+    allows_registering
+);
 
 crate::impl_registry!(
     BlockEntityTypeRegistry,

--- a/steel-registry/src/blocks/block_state_ext.rs
+++ b/steel-registry/src/blocks/block_state_ext.rs
@@ -125,11 +125,11 @@ impl FluidReplaceableExt for BlockStateId {
     fn can_be_replaced_by_fluid(&self, fluid: BlockRef) -> bool {
         let block = self.get_block();
 
-        if block == vanilla_blocks::AIR {
+        if block == &vanilla_blocks::AIR {
             return true;
         }
 
-        if fluid == vanilla_blocks::WATER
+        if fluid == &vanilla_blocks::WATER
             && let Some(false) = self.try_get_value(&BlockStateProperties::WATERLOGGED)
         {
             return true;

--- a/steel-registry/src/blocks/mod.rs
+++ b/steel-registry/src/blocks/mod.rs
@@ -3,6 +3,8 @@ pub mod block_state_ext;
 pub mod properties;
 pub mod shapes;
 
+use std::sync::OnceLock;
+
 use rustc_hash::FxHashMap;
 
 use crate::RegistryExt;
@@ -21,6 +23,8 @@ pub struct Block {
     pub collision_shape: ShapeFn,
     /// Function to get outline shape for a state offset
     pub outline_shape: ShapeFn,
+    /// Cached registry ID, set during registration for O(1) lookup on hot paths.
+    pub id: OnceLock<usize>,
 }
 
 impl std::fmt::Debug for Block {
@@ -52,6 +56,7 @@ impl Block {
             default_state_offset: 0,
             collision_shape: full_block_shape,
             outline_shape: full_block_shape,
+            id: OnceLock::new(),
         }
     }
 
@@ -174,6 +179,8 @@ impl BlockRegistry {
         let id = self.blocks_by_id.len();
         let base_state_id = self.next_state_id;
 
+        let cached = block.id.get_or_init(|| id);
+        assert_eq!(*cached, id, "block registered with conflicting id");
         self.blocks_by_key.insert(block.key.clone(), id);
         self.blocks_by_id.push(block);
         self.block_to_base_state.push(base_state_id);
@@ -409,7 +416,17 @@ impl BlockRegistry {
     }
 }
 
-crate::impl_registry!(BlockRegistry, Block, blocks_by_id, blocks_by_key, blocks);
+crate::impl_registry_ext!(BlockRegistry, Block, blocks_by_id, blocks_by_key);
+
+impl crate::RegistryEntry for Block {
+    fn key(&self) -> &Identifier {
+        &self.key
+    }
+
+    fn try_id(&self) -> Option<usize> {
+        self.id.get().copied()
+    }
+}
 crate::impl_tagged_registry!(BlockRegistry, blocks_by_key, "block");
 
 // Shape lookup methods

--- a/steel-registry/src/blocks/mod.rs
+++ b/steel-registry/src/blocks/mod.rs
@@ -193,17 +193,6 @@ impl BlockRegistry {
         id
     }
 
-    /// Replaces a block at a given index.
-    /// Returns true if the block was replaced and false if the block wasn't replaced
-    #[must_use]
-    pub fn replace(&mut self, block: BlockRef, id: usize) -> bool {
-        if id >= self.blocks_by_id.len() {
-            return false;
-        }
-        self.blocks_by_id[id] = block;
-        true
-    }
-
     #[must_use]
     pub fn get_base_state_id(&self, block: BlockRef) -> BlockStateId {
         let id = *self.blocks_by_key.get(&block.key).expect("Block not found");

--- a/steel-registry/src/cat_sound_variant.rs
+++ b/steel-registry/src/cat_sound_variant.rs
@@ -76,38 +76,15 @@ impl CatSoundVariantRegistry {
             allows_registering: true,
         }
     }
-
-    pub fn register(&mut self, cat_sound_variant: CatSoundVariantRef) -> usize {
-        assert!(
-            self.allows_registering,
-            "Cannot register cat sound variants after the registry has been frozen"
-        );
-
-        let id = self.cat_sound_variants_by_id.len();
-        self.cat_sound_variants_by_key
-            .insert(cat_sound_variant.key.clone(), id);
-        self.cat_sound_variants_by_id.push(cat_sound_variant);
-        id
-    }
-
-    /// Replaces a cat_sound_variant at a given index.
-    /// Returns true if the cat_sound_variant was replaced and false if the cat_sound_variant wasn't replaced
-    #[must_use]
-    pub fn replace(&mut self, cat_sound_variant: CatSoundVariantRef, id: usize) -> bool {
-        if id >= self.cat_sound_variants_by_id.len() {
-            return false;
-        }
-        self.cat_sound_variants_by_id[id] = cat_sound_variant;
-        true
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (usize, CatSoundVariantRef)> + '_ {
-        self.cat_sound_variants_by_id
-            .iter()
-            .enumerate()
-            .map(|(id, &variant)| (id, variant))
-    }
 }
+
+crate::impl_standard_methods!(
+    CatSoundVariantRegistry,
+    CatSoundVariantRef,
+    cat_sound_variants_by_id,
+    cat_sound_variants_by_key,
+    allows_registering
+);
 
 crate::impl_registry!(
     CatSoundVariantRegistry,
@@ -116,9 +93,3 @@ crate::impl_registry!(
     cat_sound_variants_by_key,
     cat_sound_variants
 );
-
-impl Default for CatSoundVariantRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
-}

--- a/steel-registry/src/cat_variant.rs
+++ b/steel-registry/src/cat_variant.rs
@@ -90,42 +90,6 @@ impl CatVariantRegistry {
             allows_registering: true,
         }
     }
-
-    pub fn register(&mut self, cat_variant: CatVariantRef) -> usize {
-        assert!(
-            self.allows_registering,
-            "Cannot register cat variants after the registry has been frozen"
-        );
-
-        let id = self.cat_variants_by_id.len();
-        self.cat_variants_by_key.insert(cat_variant.key.clone(), id);
-        self.cat_variants_by_id.push(cat_variant);
-        id
-    }
-
-    /// Replaces a cat_variant at a given index.
-    /// Returns true if the cat_variant was replaced and false if the cat_variant wasn't replaced
-    #[must_use]
-    pub fn replace(&mut self, cat_variant: CatVariantRef, id: usize) -> bool {
-        if id >= self.cat_variants_by_id.len() {
-            return false;
-        }
-        self.cat_variants_by_id[id] = cat_variant;
-        true
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (usize, CatVariantRef)> + '_ {
-        self.cat_variants_by_id
-            .iter()
-            .enumerate()
-            .map(|(id, &variant)| (id, variant))
-    }
-}
-
-impl Default for CatVariantRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 crate::impl_registry!(
@@ -134,4 +98,12 @@ crate::impl_registry!(
     cat_variants_by_id,
     cat_variants_by_key,
     cat_variants
+);
+
+crate::impl_standard_methods!(
+    CatVariantRegistry,
+    CatVariantRef,
+    cat_variants_by_id,
+    cat_variants_by_key,
+    allows_registering
 );

--- a/steel-registry/src/chat_type.rs
+++ b/steel-registry/src/chat_type.rs
@@ -96,43 +96,15 @@ impl ChatTypeRegistry {
             allows_registering: true,
         }
     }
-
-    pub fn register(&mut self, chat_type: ChatTypeRef) -> usize {
-        assert!(
-            self.allows_registering,
-            "Cannot register chat types after the registry has been frozen"
-        );
-
-        let id = self.chat_types_by_id.len();
-        self.chat_types_by_key.insert(chat_type.key.clone(), id);
-        self.chat_types_by_id.push(chat_type);
-        id
-    }
-
-    /// Replaces a chat_types at a given index.
-    /// Returns true if the chat_types was replaced and false if the chat_types wasn't replaced
-    #[must_use]
-    pub fn replace(&mut self, chat_types: ChatTypeRef, id: usize) -> bool {
-        if id >= self.chat_types_by_id.len() {
-            return false;
-        }
-        self.chat_types_by_id[id] = chat_types;
-        true
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (usize, ChatTypeRef)> + '_ {
-        self.chat_types_by_id
-            .iter()
-            .enumerate()
-            .map(|(id, &ct)| (id, ct))
-    }
 }
 
-impl Default for ChatTypeRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+crate::impl_standard_methods!(
+    ChatTypeRegistry,
+    ChatTypeRef,
+    chat_types_by_id,
+    chat_types_by_key,
+    allows_registering
+);
 
 crate::impl_registry!(
     ChatTypeRegistry,

--- a/steel-registry/src/chicken_sound_variant.rs
+++ b/steel-registry/src/chicken_sound_variant.rs
@@ -61,39 +61,15 @@ impl ChickenSoundVariantRegistry {
             allows_registering: true,
         }
     }
-
-    pub fn register(&mut self, chicken_sound_variant: ChickenSoundVariantRef) -> usize {
-        assert!(
-            self.allows_registering,
-            "Cannot register chicken sound variants after the registry has been frozen"
-        );
-
-        let id = self.chicken_sound_variants_by_id.len();
-        self.chicken_sound_variants_by_key
-            .insert(chicken_sound_variant.key.clone(), id);
-        self.chicken_sound_variants_by_id
-            .push(chicken_sound_variant);
-        id
-    }
-
-    /// Replaces a chicken_sound_variant at a given index.
-    /// Returns true if the chicken_sound_variant was replaced and false if the chicken_sound_variant wasn't replaced
-    #[must_use]
-    pub fn replace(&mut self, chicken_sound_variant: ChickenSoundVariantRef, id: usize) -> bool {
-        if id >= self.chicken_sound_variants_by_id.len() {
-            return false;
-        }
-        self.chicken_sound_variants_by_id[id] = chicken_sound_variant;
-        true
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (usize, ChickenSoundVariantRef)> + '_ {
-        self.chicken_sound_variants_by_id
-            .iter()
-            .enumerate()
-            .map(|(id, &variant)| (id, variant))
-    }
 }
+
+crate::impl_standard_methods!(
+    ChickenSoundVariantRegistry,
+    ChickenSoundVariantRef,
+    chicken_sound_variants_by_id,
+    chicken_sound_variants_by_key,
+    allows_registering
+);
 
 crate::impl_registry!(
     ChickenSoundVariantRegistry,
@@ -102,9 +78,3 @@ crate::impl_registry!(
     chicken_sound_variants_by_key,
     chicken_sound_variants
 );
-
-impl Default for ChickenSoundVariantRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
-}

--- a/steel-registry/src/chicken_variant.rs
+++ b/steel-registry/src/chicken_variant.rs
@@ -88,44 +88,15 @@ impl ChickenVariantRegistry {
             allows_registering: true,
         }
     }
-
-    pub fn register(&mut self, chicken_variant: ChickenVariantRef) -> usize {
-        assert!(
-            self.allows_registering,
-            "Cannot register chicken variants after the registry has been frozen"
-        );
-
-        let id = self.chicken_variants_by_id.len();
-        self.chicken_variants_by_key
-            .insert(chicken_variant.key.clone(), id);
-        self.chicken_variants_by_id.push(chicken_variant);
-        id
-    }
-
-    /// Replaces a chicken at a given index.
-    /// Returns true if the chicken was replaced and false if the chicken wasn't replaced
-    #[must_use]
-    pub fn replace(&mut self, chicken: ChickenVariantRef, id: usize) -> bool {
-        if id >= self.chicken_variants_by_id.len() {
-            return false;
-        }
-        self.chicken_variants_by_id[id] = chicken;
-        true
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (usize, ChickenVariantRef)> + '_ {
-        self.chicken_variants_by_id
-            .iter()
-            .enumerate()
-            .map(|(id, &variant)| (id, variant))
-    }
 }
 
-impl Default for ChickenVariantRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+crate::impl_standard_methods!(
+    ChickenVariantRegistry,
+    ChickenVariantRef,
+    chicken_variants_by_id,
+    chicken_variants_by_key,
+    allows_registering
+);
 
 crate::impl_registry!(
     ChickenVariantRegistry,

--- a/steel-registry/src/cow_sound_variant.rs
+++ b/steel-registry/src/cow_sound_variant.rs
@@ -46,38 +46,15 @@ impl CowSoundVariantRegistry {
             allows_registering: true,
         }
     }
-
-    pub fn register(&mut self, cow_sound_variant: CowSoundVariantRef) -> usize {
-        assert!(
-            self.allows_registering,
-            "Cannot register cow sound variants after the registry has been frozen"
-        );
-
-        let id = self.cow_sound_variants_by_id.len();
-        self.cow_sound_variants_by_key
-            .insert(cow_sound_variant.key.clone(), id);
-        self.cow_sound_variants_by_id.push(cow_sound_variant);
-        id
-    }
-
-    /// Replaces a cow_sound_variant at a given index.
-    /// Returns true if the cow_sound_variant was replaced and false if the cow_sound_variant wasn't replaced
-    #[must_use]
-    pub fn replace(&mut self, cow_sound_variant: CowSoundVariantRef, id: usize) -> bool {
-        if id >= self.cow_sound_variants_by_id.len() {
-            return false;
-        }
-        self.cow_sound_variants_by_id[id] = cow_sound_variant;
-        true
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (usize, CowSoundVariantRef)> + '_ {
-        self.cow_sound_variants_by_id
-            .iter()
-            .enumerate()
-            .map(|(id, &variant)| (id, variant))
-    }
 }
+
+crate::impl_standard_methods!(
+    CowSoundVariantRegistry,
+    CowSoundVariantRef,
+    cow_sound_variants_by_id,
+    cow_sound_variants_by_key,
+    allows_registering
+);
 
 crate::impl_registry!(
     CowSoundVariantRegistry,
@@ -86,9 +63,3 @@ crate::impl_registry!(
     cow_sound_variants_by_key,
     cow_sound_variants
 );
-
-impl Default for CowSoundVariantRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
-}

--- a/steel-registry/src/cow_variant.rs
+++ b/steel-registry/src/cow_variant.rs
@@ -90,43 +90,15 @@ impl CowVariantRegistry {
             allows_registering: true,
         }
     }
-
-    pub fn register(&mut self, cow_variant: CowVariantRef) -> usize {
-        assert!(
-            self.allows_registering,
-            "Cannot register cow variants after the registry has been frozen"
-        );
-
-        let id = self.cow_variants_by_id.len();
-        self.cow_variants_by_key.insert(cow_variant.key.clone(), id);
-        self.cow_variants_by_id.push(cow_variant);
-        id
-    }
-
-    /// Replaces a cow at a given index.
-    /// Returns true if the cow was replaced and false if the cow wasn't replaced
-    #[must_use]
-    pub fn replace(&mut self, cow: CowVariantRef, id: usize) -> bool {
-        if id >= self.cow_variants_by_id.len() {
-            return false;
-        }
-        self.cow_variants_by_id[id] = cow;
-        true
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (usize, CowVariantRef)> + '_ {
-        self.cow_variants_by_id
-            .iter()
-            .enumerate()
-            .map(|(id, &variant)| (id, variant))
-    }
 }
 
-impl Default for CowVariantRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+crate::impl_standard_methods!(
+    CowVariantRegistry,
+    CowVariantRef,
+    cow_variants_by_id,
+    cow_variants_by_key,
+    allows_registering
+);
 
 crate::impl_registry!(
     CowVariantRegistry,

--- a/steel-registry/src/damage_type.rs
+++ b/steel-registry/src/damage_type.rs
@@ -97,43 +97,15 @@ impl DamageTypeRegistry {
             tags: FxHashMap::default(),
         }
     }
-
-    pub fn register(&mut self, damage_type: DamageTypeRef) -> usize {
-        assert!(
-            self.allows_registering,
-            "Cannot register damage types after the registry has been frozen"
-        );
-
-        let id = self.damage_types_by_id.len();
-        self.damage_types_by_key.insert(damage_type.key.clone(), id);
-        self.damage_types_by_id.push(damage_type);
-        id
-    }
-
-    /// Replaces damage at a given index.
-    /// Returns true if the damage was replaced and false if the damage wasn't replaced
-    #[must_use]
-    pub fn replace(&mut self, damage: DamageTypeRef, id: usize) -> bool {
-        if id >= self.damage_types_by_id.len() {
-            return false;
-        }
-        self.damage_types_by_id[id] = damage;
-        true
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (usize, DamageTypeRef)> + '_ {
-        self.damage_types_by_id
-            .iter()
-            .enumerate()
-            .map(|(id, &dt)| (id, dt))
-    }
 }
 
-impl Default for DamageTypeRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+crate::impl_standard_methods!(
+    DamageTypeRegistry,
+    DamageTypeRef,
+    damage_types_by_id,
+    damage_types_by_key,
+    allows_registering
+);
 
 crate::impl_registry!(
     DamageTypeRegistry,

--- a/steel-registry/src/dialog.rs
+++ b/steel-registry/src/dialog.rs
@@ -77,37 +77,15 @@ impl DialogRegistry {
             allows_registering: true,
         }
     }
-
-    pub fn register(&mut self, dialog: DialogRef) -> usize {
-        assert!(
-            self.allows_registering,
-            "Cannot register dialogs after the registry has been frozen"
-        );
-
-        let id = self.dialogs_by_id.len();
-        self.dialogs_by_key.insert(dialog.key.clone(), id);
-        self.dialogs_by_id.push(dialog);
-        id
-    }
-
-    /// Replaces a dialog at a given index.
-    /// Returns true if the dialog was replaced and false if the dialog wasn't replaced
-    #[must_use]
-    pub fn replace(&mut self, dialog: DialogRef, id: usize) -> bool {
-        if id >= self.dialogs_by_id.len() {
-            return false;
-        }
-        self.dialogs_by_id[id] = dialog;
-        true
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (usize, DialogRef)> + '_ {
-        self.dialogs_by_id
-            .iter()
-            .enumerate()
-            .map(|(id, &dialog)| (id, dialog))
-    }
 }
+
+crate::impl_standard_methods!(
+    DialogRegistry,
+    DialogRef,
+    dialogs_by_id,
+    dialogs_by_key,
+    allows_registering
+);
 
 crate::impl_registry!(
     DialogRegistry,
@@ -117,9 +95,3 @@ crate::impl_registry!(
     dialogs
 );
 crate::impl_tagged_registry!(DialogRegistry, dialogs_by_key, "dialog");
-
-impl Default for DialogRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
-}

--- a/steel-registry/src/dimension_type.rs
+++ b/steel-registry/src/dimension_type.rs
@@ -309,48 +309,19 @@ impl DimensionTypeRegistry {
         }
     }
 
-    pub fn register(&mut self, dimension_type: DimensionTypeRef) -> usize {
-        assert!(
-            self.allows_registering,
-            "Cannot register dimension types after the registry has been frozen"
-        );
-
-        let id = self.dimension_types_by_id.len();
-        self.dimension_types_by_key
-            .insert(dimension_type.key.clone(), id);
-        self.dimension_types_by_id.push(dimension_type);
-        id
-    }
-
-    /// Replaces a dimension at a given index.
-    /// Returns true if the dimension was replaced and false if the dimension wasn't replaced
-    #[must_use]
-    pub fn replace(&mut self, dimension: DimensionTypeRef, id: usize) -> bool {
-        if id >= self.dimension_types_by_id.len() {
-            return false;
-        }
-        self.dimension_types_by_id[id] = dimension;
-        true
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (usize, DimensionTypeRef)> + '_ {
-        self.dimension_types_by_id
-            .iter()
-            .enumerate()
-            .map(|(id, &dt)| (id, dt))
-    }
-
     #[must_use]
     pub fn get_ids(&self) -> Vec<Identifier> {
         self.dimension_types_by_key.keys().cloned().collect()
     }
 }
 
-impl Default for DimensionTypeRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+crate::impl_standard_methods!(
+    DimensionTypeRegistry,
+    DimensionTypeRef,
+    dimension_types_by_id,
+    dimension_types_by_key,
+    allows_registering
+);
 
 crate::impl_registry!(
     DimensionTypeRegistry,

--- a/steel-registry/src/enchantment.rs
+++ b/steel-registry/src/enchantment.rs
@@ -173,37 +173,6 @@ impl EnchantmentRegistry {
             allows_registering: true,
         }
     }
-
-    pub fn register(&mut self, enchantment: EnchantmentRef) -> usize {
-        assert!(
-            self.allows_registering,
-            "Cannot register enchantments after the registry has been frozen"
-        );
-
-        let id = self.enchantments_by_id.len();
-        self.enchantments_by_key.insert(enchantment.key.clone(), id);
-        self.enchantments_by_id.push(enchantment);
-        id
-    }
-
-    #[must_use]
-    pub fn replace(&mut self, enchantment: EnchantmentRef, id: usize) -> bool {
-        if id >= self.enchantments_by_id.len() {
-            return false;
-        }
-        let old = self.enchantments_by_id[id];
-        self.enchantments_by_key.remove(&old.key);
-        self.enchantments_by_key.insert(enchantment.key.clone(), id);
-        self.enchantments_by_id[id] = enchantment;
-        true
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (usize, EnchantmentRef)> + '_ {
-        self.enchantments_by_id
-            .iter()
-            .enumerate()
-            .map(|(id, &ench)| (id, ench))
-    }
 }
 
 crate::impl_registry_ext!(
@@ -213,10 +182,12 @@ crate::impl_registry_ext!(
     enchantments_by_key
 );
 
-crate::impl_tagged_registry!(EnchantmentRegistry, enchantments_by_key, "enchantment");
+crate::impl_standard_methods!(
+    EnchantmentRegistry,
+    EnchantmentRef,
+    enchantments_by_id,
+    enchantments_by_key,
+    allows_registering
+);
 
-impl Default for EnchantmentRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+crate::impl_tagged_registry!(EnchantmentRegistry, enchantments_by_key, "enchantment");

--- a/steel-registry/src/entity_types.rs
+++ b/steel-registry/src/entity_types.rs
@@ -138,17 +138,6 @@ impl EntityTypeRegistry {
         self.types_by_id.push(entity_type);
     }
 
-    /// Replaces a entity_type at a given index.
-    /// Returns true if the entity_type was replaced and false if the entity_type wasn't replaced
-    #[must_use]
-    pub fn replace(&mut self, entity_type: EntityTypeRef, id: usize) -> bool {
-        if id >= self.types_by_id.len() {
-            return false;
-        }
-        self.types_by_id[id] = entity_type;
-        true
-    }
-
     pub fn iter(&self) -> impl Iterator<Item = (usize, EntityTypeRef)> + '_ {
         self.types_by_id
             .iter()

--- a/steel-registry/src/fluid/mod.rs
+++ b/steel-registry/src/fluid/mod.rs
@@ -5,7 +5,7 @@ use rustc_hash::FxHashMap;
 use steel_utils::Identifier;
 
 /// A fluid type definition (e.g., water, lava, empty).
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Fluid {
     /// The identifier for this fluid (e.g., "minecraft:water").
     pub key: Identifier,

--- a/steel-registry/src/fluid/mod.rs
+++ b/steel-registry/src/fluid/mod.rs
@@ -188,17 +188,6 @@ impl FluidRegistry {
         id
     }
 
-    /// Replaces a fluid at a given index.
-    /// Returns true if the fluid was replaced and false if the fluid wasn't replaced
-    #[must_use]
-    pub fn replace(&mut self, item: FluidRef, id: usize) -> bool {
-        if id >= self.fluids_by_id.len() {
-            return false;
-        }
-        self.fluids_by_id[id] = item;
-        true
-    }
-
     /// Iterates over all fluids with their IDs.
     pub fn iter(&self) -> impl Iterator<Item = (usize, FluidRef)> + '_ {
         self.fluids_by_id

--- a/steel-registry/src/frog_variant.rs
+++ b/steel-registry/src/frog_variant.rs
@@ -72,44 +72,15 @@ impl FrogVariantRegistry {
             allows_registering: true,
         }
     }
-
-    pub fn register(&mut self, frog_variant: FrogVariantRef) -> usize {
-        assert!(
-            self.allows_registering,
-            "Cannot register frog variants after the registry has been frozen"
-        );
-
-        let id = self.frog_variants_by_id.len();
-        self.frog_variants_by_key
-            .insert(frog_variant.key.clone(), id);
-        self.frog_variants_by_id.push(frog_variant);
-        id
-    }
-
-    /// Replaces a frog at a given index.
-    /// Returns true if the frog was replaced and false if the frog wasn't replaced
-    #[must_use]
-    pub fn replace(&mut self, frog: FrogVariantRef, id: usize) -> bool {
-        if id >= self.frog_variants_by_id.len() {
-            return false;
-        }
-        self.frog_variants_by_id[id] = frog;
-        true
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (usize, FrogVariantRef)> + '_ {
-        self.frog_variants_by_id
-            .iter()
-            .enumerate()
-            .map(|(id, &variant)| (id, variant))
-    }
 }
 
-impl Default for FrogVariantRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+crate::impl_standard_methods!(
+    FrogVariantRegistry,
+    FrogVariantRef,
+    frog_variants_by_id,
+    frog_variants_by_key,
+    allows_registering
+);
 
 crate::impl_registry!(
     FrogVariantRegistry,

--- a/steel-registry/src/game_rules.rs
+++ b/steel-registry/src/game_rules.rs
@@ -114,43 +114,15 @@ impl GameRuleRegistry {
             allows_registering: true,
         }
     }
-
-    pub fn register(&mut self, game_rule: GameRuleRef) -> usize {
-        assert!(
-            self.allows_registering,
-            "Cannot register game rules after the registry has been frozen"
-        );
-
-        let id = self.game_rules_by_id.len();
-        self.game_rules_by_key.insert(game_rule.key.clone(), id);
-        self.game_rules_by_id.push(game_rule);
-        id
-    }
-
-    /// Replaces a gamerule at a given index.
-    /// Returns true if the gamerule was replaced and false if the gamerule wasn't replaced
-    #[must_use]
-    pub fn replace(&mut self, gamerule: GameRuleRef, id: usize) -> bool {
-        if id >= self.game_rules_by_id.len() {
-            return false;
-        }
-        self.game_rules_by_id[id] = gamerule;
-        true
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (usize, GameRuleRef)> + '_ {
-        self.game_rules_by_id
-            .iter()
-            .enumerate()
-            .map(|(id, &gr)| (id, gr))
-    }
 }
 
-impl Default for GameRuleRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+crate::impl_standard_methods!(
+    GameRuleRegistry,
+    GameRuleRef,
+    game_rules_by_id,
+    game_rules_by_key,
+    allows_registering
+);
 
 crate::impl_registry!(
     GameRuleRegistry,

--- a/steel-registry/src/instrument.rs
+++ b/steel-registry/src/instrument.rs
@@ -47,43 +47,15 @@ impl InstrumentRegistry {
             allows_registering: true,
         }
     }
-
-    pub fn register(&mut self, instrument: InstrumentRef) -> usize {
-        assert!(
-            self.allows_registering,
-            "Cannot register instruments after the registry has been frozen"
-        );
-
-        let id = self.instruments_by_id.len();
-        self.instruments_by_key.insert(instrument.key.clone(), id);
-        self.instruments_by_id.push(instrument);
-        id
-    }
-
-    /// Replaces a instrument at a given index.
-    /// Returns true if the instrument was replaced and false if the instrument wasn't replaced
-    #[must_use]
-    pub fn replace(&mut self, instrument: InstrumentRef, id: usize) -> bool {
-        if id >= self.instruments_by_id.len() {
-            return false;
-        }
-        self.instruments_by_id[id] = instrument;
-        true
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (usize, InstrumentRef)> + '_ {
-        self.instruments_by_id
-            .iter()
-            .enumerate()
-            .map(|(id, &instrument)| (id, instrument))
-    }
 }
 
-impl Default for InstrumentRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+crate::impl_standard_methods!(
+    InstrumentRegistry,
+    InstrumentRef,
+    instruments_by_id,
+    instruments_by_key,
+    allows_registering
+);
 
 crate::impl_registry!(
     InstrumentRegistry,

--- a/steel-registry/src/items/mod.rs
+++ b/steel-registry/src/items/mod.rs
@@ -119,17 +119,6 @@ impl ItemRegistry {
         id
     }
 
-    /// Replaces a item at a given index.
-    /// Returns true if the item was replaced and false if the item wasn't replaced
-    #[must_use]
-    pub fn replace(&mut self, item: ItemRef, id: usize) -> bool {
-        if id >= self.items_by_id.len() {
-            return false;
-        }
-        self.items_by_id[id] = item;
-        true
-    }
-
     pub fn iter(&self) -> impl Iterator<Item = (usize, ItemRef)> + '_ {
         self.items_by_id
             .iter()

--- a/steel-registry/src/items/mod.rs
+++ b/steel-registry/src/items/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::OnceLock;
+
 use rustc_hash::FxHashMap;
 
 use steel_utils::Identifier;
@@ -16,6 +18,8 @@ pub struct Item {
     /// The item key returned when this item is used in crafting (e.g., "bucket" from milk_bucket).
     /// Stored as an Identifier to avoid circular reference issues during initialization.
     pub craft_remainder: Option<Identifier>,
+    /// Cached registry ID, set during registration for O(1) lookup on hot paths.
+    pub id: OnceLock<usize>,
 }
 
 impl std::fmt::Debug for Item {
@@ -31,6 +35,7 @@ impl Item {
             key: block.key.clone(),
             components: DataComponentMap::common_item_components(),
             craft_remainder: None,
+            id: OnceLock::new(),
         }
     }
 
@@ -40,6 +45,7 @@ impl Item {
             key: Identifier::vanilla_static(name),
             components: DataComponentMap::common_item_components(),
             craft_remainder: None,
+            id: OnceLock::new(),
         }
     }
 
@@ -113,6 +119,8 @@ impl ItemRegistry {
         );
 
         let id = self.items_by_id.len();
+        let cached = item.id.get_or_init(|| id);
+        assert_eq!(*cached, id, "item registered with conflicting id");
         self.items_by_key.insert(item.key.clone(), id);
         self.items_by_id.push(item);
 
@@ -127,5 +135,15 @@ impl ItemRegistry {
     }
 }
 
-crate::impl_registry!(ItemRegistry, Item, items_by_id, items_by_key, items);
+crate::impl_registry_ext!(ItemRegistry, Item, items_by_id, items_by_key);
 crate::impl_tagged_registry!(ItemRegistry, items_by_key, "item");
+
+impl crate::RegistryEntry for Item {
+    fn key(&self) -> &Identifier {
+        &self.key
+    }
+
+    fn try_id(&self) -> Option<usize> {
+        self.id.get().copied()
+    }
+}

--- a/steel-registry/src/jukebox_song.rs
+++ b/steel-registry/src/jukebox_song.rs
@@ -44,44 +44,15 @@ impl JukeboxSongRegistry {
             allows_registering: true,
         }
     }
-
-    pub fn register(&mut self, jukebox_song: JukeboxSongRef) -> usize {
-        assert!(
-            self.allows_registering,
-            "Cannot register jukebox songs after the registry has been frozen"
-        );
-
-        let id = self.jukebox_songs_by_id.len();
-        self.jukebox_songs_by_key
-            .insert(jukebox_song.key.clone(), id);
-        self.jukebox_songs_by_id.push(jukebox_song);
-        id
-    }
-
-    /// Replaces a song at a given index.
-    /// Returns true if the song was replaced and false if the song wasn't replaced
-    #[must_use]
-    pub fn replace(&mut self, song: JukeboxSongRef, id: usize) -> bool {
-        if id >= self.jukebox_songs_by_id.len() {
-            return false;
-        }
-        self.jukebox_songs_by_id[id] = song;
-        true
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (usize, JukeboxSongRef)> + '_ {
-        self.jukebox_songs_by_id
-            .iter()
-            .enumerate()
-            .map(|(id, &song)| (id, song))
-    }
 }
 
-impl Default for JukeboxSongRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+crate::impl_standard_methods!(
+    JukeboxSongRegistry,
+    JukeboxSongRef,
+    jukebox_songs_by_id,
+    jukebox_songs_by_key,
+    allows_registering
+);
 
 crate::impl_registry!(
     JukeboxSongRegistry,

--- a/steel-registry/src/lib.rs
+++ b/steel-registry/src/lib.rs
@@ -488,8 +488,12 @@ macro_rules! impl_standard_methods {
         impl $Registry {
             pub fn register(&mut self, entry: $Entry) -> usize {
                 assert!(
-                    !self.$allow_registering,
-                    "Cannot register $Entry after registry has been frozen"
+                    self.$allow_registering,
+                    concat!(
+                        "Cannot register ",
+                        stringify!($Entry),
+                        " after registry has been frozen"
+                    )
                 );
                 let id = self.$id_field.len();
                 self.$id_field.push(entry);

--- a/steel-registry/src/lib.rs
+++ b/steel-registry/src/lib.rs
@@ -481,6 +481,38 @@ macro_rules! impl_registry_entry {
     };
 }
 
+/// Implements the default register, replace, and iter methods in the registries
+#[macro_export]
+macro_rules! impl_standard_methods {
+    ($Registry:ty, $Entry:ty, $id_field:ident, $key_field:ident, $allow_registering:ident) => {
+        impl $Registry {
+            pub fn register(&mut self, entry: $Entry) -> usize {
+                assert!(
+                    !self.$allow_registering,
+                    "Cannot register $Entry after registry has been frozen"
+                );
+                let id = self.$id_field.len();
+                self.$id_field.push(entry);
+                self.$key_field.insert(entry.key.clone(), id);
+                id
+            }
+
+            pub fn iter(&self) -> impl Iterator<Item = (usize, $Entry)> + '_ {
+                self.$id_field
+                    .iter()
+                    .enumerate()
+                    .map(|(id, &entry)| (id, entry))
+            }
+        }
+
+        impl Default for $Registry {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
+    };
+}
+
 /// Implements both `RegistryExt` and `RegistryEntry` for a standard registry.
 #[macro_export]
 macro_rules! impl_registry {

--- a/steel-registry/src/loot_table.rs
+++ b/steel-registry/src/loot_table.rs
@@ -1879,17 +1879,6 @@ impl LootTableRegistry {
         id
     }
 
-    /// Replaces a table at a given index.
-    /// Returns true if the table was replaced and false if the table wasn't replaced
-    #[must_use]
-    pub fn replace(&mut self, table: LootTableRef, id: usize) -> bool {
-        if id >= self.tables_by_id.len() {
-            return false;
-        }
-        self.tables_by_id[id] = table;
-        true
-    }
-
     pub fn iter(&self) -> impl Iterator<Item = (usize, LootTableRef)> + '_ {
         self.tables_by_id
             .iter()

--- a/steel-registry/src/menu_type.rs
+++ b/steel-registry/src/menu_type.rs
@@ -26,43 +26,15 @@ impl MenuTypeRegistry {
             allows_registering: true,
         }
     }
-
-    pub fn register(&mut self, menu_type: MenuTypeRef) -> usize {
-        assert!(
-            self.allows_registering,
-            "Cannot register menu types after the registry has been frozen"
-        );
-
-        let id = self.menu_types_by_id.len();
-        self.menu_types_by_key.insert(menu_type.key.clone(), id);
-        self.menu_types_by_id.push(menu_type);
-        id
-    }
-
-    /// Replaces a menu_type at a given index.
-    /// Returns true if the menu_type was replaced and false if the menu_type wasn't replaced
-    #[must_use]
-    pub fn replace(&mut self, menu_type: MenuTypeRef, id: usize) -> bool {
-        if id >= self.menu_types_by_id.len() {
-            return false;
-        }
-        self.menu_types_by_id[id] = menu_type;
-        true
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (usize, MenuTypeRef)> + '_ {
-        self.menu_types_by_id
-            .iter()
-            .enumerate()
-            .map(|(id, &menu_type)| (id, menu_type))
-    }
 }
 
-impl Default for MenuTypeRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+crate::impl_standard_methods!(
+    MenuTypeRegistry,
+    MenuTypeRef,
+    menu_types_by_id,
+    menu_types_by_key,
+    allows_registering
+);
 
 crate::impl_registry!(
     MenuTypeRegistry,

--- a/steel-registry/src/painting_variant.rs
+++ b/steel-registry/src/painting_variant.rs
@@ -58,44 +58,15 @@ impl PaintingVariantRegistry {
             allows_registering: true,
         }
     }
-
-    pub fn register(&mut self, painting_variant: PaintingVariantRef) -> usize {
-        assert!(
-            self.allows_registering,
-            "Cannot register painting variants after the registry has been frozen"
-        );
-
-        let id = self.painting_variants_by_id.len();
-        self.painting_variants_by_key
-            .insert(painting_variant.key.clone(), id);
-        self.painting_variants_by_id.push(painting_variant);
-        id
-    }
-
-    /// Replaces a painting_variant at a given index.
-    /// Returns true if the painting_variant was replaced and false if the painting_variant wasn't replaced
-    #[must_use]
-    pub fn replace(&mut self, painting_variant: PaintingVariantRef, id: usize) -> bool {
-        if id >= self.painting_variants_by_id.len() {
-            return false;
-        }
-        self.painting_variants_by_id[id] = painting_variant;
-        true
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (usize, PaintingVariantRef)> + '_ {
-        self.painting_variants_by_id
-            .iter()
-            .enumerate()
-            .map(|(id, &variant)| (id, variant))
-    }
 }
 
-impl Default for PaintingVariantRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+crate::impl_standard_methods!(
+    PaintingVariantRegistry,
+    PaintingVariantRef,
+    painting_variants_by_id,
+    painting_variants_by_key,
+    allows_registering
+);
 
 crate::impl_registry!(
     PaintingVariantRegistry,

--- a/steel-registry/src/pig_sound_variant.rs
+++ b/steel-registry/src/pig_sound_variant.rs
@@ -62,38 +62,15 @@ impl PigSoundVariantRegistry {
             allows_registering: true,
         }
     }
-
-    pub fn register(&mut self, pig_sound_variant: PigSoundVariantRef) -> usize {
-        assert!(
-            self.allows_registering,
-            "Cannot register pig sound variants after the registry has been frozen"
-        );
-
-        let id = self.pig_sound_variants_by_id.len();
-        self.pig_sound_variants_by_key
-            .insert(pig_sound_variant.key.clone(), id);
-        self.pig_sound_variants_by_id.push(pig_sound_variant);
-        id
-    }
-
-    /// Replaces a pig_sound_variant at a given index.
-    /// Returns true if the pig_sound_variant was replaced and false if the pig_sound_variant wasn't replaced
-    #[must_use]
-    pub fn replace(&mut self, pig_sound_variant: PigSoundVariantRef, id: usize) -> bool {
-        if id >= self.pig_sound_variants_by_id.len() {
-            return false;
-        }
-        self.pig_sound_variants_by_id[id] = pig_sound_variant;
-        true
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (usize, PigSoundVariantRef)> + '_ {
-        self.pig_sound_variants_by_id
-            .iter()
-            .enumerate()
-            .map(|(id, &variant)| (id, variant))
-    }
 }
+
+crate::impl_standard_methods!(
+    PigSoundVariantRegistry,
+    PigSoundVariantRef,
+    pig_sound_variants_by_id,
+    pig_sound_variants_by_key,
+    allows_registering
+);
 
 crate::impl_registry!(
     PigSoundVariantRegistry,
@@ -102,9 +79,3 @@ crate::impl_registry!(
     pig_sound_variants_by_key,
     pig_sound_variants
 );
-
-impl Default for PigSoundVariantRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
-}

--- a/steel-registry/src/pig_variant.rs
+++ b/steel-registry/src/pig_variant.rs
@@ -88,43 +88,15 @@ impl PigVariantRegistry {
             allows_registering: true,
         }
     }
-
-    pub fn register(&mut self, pig_variant: PigVariantRef) -> usize {
-        assert!(
-            self.allows_registering,
-            "Cannot register pig variants after the registry has been frozen"
-        );
-
-        let id = self.pig_variants_by_id.len();
-        self.pig_variants_by_key.insert(pig_variant.key.clone(), id);
-        self.pig_variants_by_id.push(pig_variant);
-        id
-    }
-
-    /// Replaces a pig_variant at a given index.
-    /// Returns true if the pig_variant was replaced and false if the pig_variant wasn't replaced
-    #[must_use]
-    pub fn replace(&mut self, pig_variant: PigVariantRef, id: usize) -> bool {
-        if id >= self.pig_variants_by_id.len() {
-            return false;
-        }
-        self.pig_variants_by_id[id] = pig_variant;
-        true
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (usize, PigVariantRef)> + '_ {
-        self.pig_variants_by_id
-            .iter()
-            .enumerate()
-            .map(|(id, &variant)| (id, variant))
-    }
 }
 
-impl Default for PigVariantRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+crate::impl_standard_methods!(
+    PigVariantRegistry,
+    PigVariantRef,
+    pig_variants_by_id,
+    pig_variants_by_key,
+    allows_registering
+);
 
 crate::impl_registry!(
     PigVariantRegistry,

--- a/steel-registry/src/poi/mod.rs
+++ b/steel-registry/src/poi/mod.rs
@@ -11,7 +11,7 @@ use steel_utils::{BlockStateId, Identifier};
 ///
 /// Each type maps to specific block states and defines how many entities
 /// can claim it via tickets (e.g., a bed has 1 ticket for 1 villager).
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct PointOfInterestType {
     pub key: Identifier,
     pub block_state_ids: &'static [BlockStateId],

--- a/steel-registry/src/timeline.rs
+++ b/steel-registry/src/timeline.rs
@@ -140,37 +140,15 @@ impl TimelineRegistry {
             allows_registering: true,
         }
     }
-
-    pub fn register(&mut self, timeline: TimelineRef) -> usize {
-        assert!(
-            self.allows_registering,
-            "Cannot register timelines after the registry has been frozen"
-        );
-
-        let id = self.timelines_by_id.len();
-        self.timelines_by_key.insert(timeline.key.clone(), id);
-        self.timelines_by_id.push(timeline);
-        id
-    }
-
-    /// Replaces a timelines at a given index.
-    /// Returns true if the timeline was replaced and false if the timeline wasn't replaced
-    #[must_use]
-    pub fn replace(&mut self, timeline: TimelineRef, id: usize) -> bool {
-        if id >= self.timelines_by_id.len() {
-            return false;
-        }
-        self.timelines_by_id[id] = timeline;
-        true
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (usize, TimelineRef)> + '_ {
-        self.timelines_by_id
-            .iter()
-            .enumerate()
-            .map(|(id, &timeline)| (id, timeline))
-    }
 }
+
+crate::impl_standard_methods!(
+    TimelineRegistry,
+    TimelineRef,
+    timelines_by_id,
+    timelines_by_key,
+    allows_registering
+);
 
 crate::impl_registry!(
     TimelineRegistry,
@@ -180,9 +158,3 @@ crate::impl_registry!(
     timelines
 );
 crate::impl_tagged_registry!(TimelineRegistry, timelines_by_key, "timeline");
-
-impl Default for TimelineRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
-}

--- a/steel-registry/src/trim_material.rs
+++ b/steel-registry/src/trim_material.rs
@@ -57,43 +57,15 @@ impl TrimMaterialRegistry {
             allows_registering: true,
         }
     }
-
-    pub fn register(&mut self, trim_material: TrimMaterialRef, key: Identifier) -> usize {
-        assert!(
-            self.allows_registering,
-            "Cannot register trim materials after the registry has been frozen"
-        );
-
-        let id = self.trim_materials_by_id.len();
-        self.trim_materials_by_key.insert(key, id);
-        self.trim_materials_by_id.push(trim_material);
-        id
-    }
-
-    /// Replaces a trim_material at a given index.
-    /// Returns true if the trim_material was replaced and false if the trim_material wasn't replaced
-    #[must_use]
-    pub fn replace(&mut self, trim_material: TrimMaterialRef, id: usize) -> bool {
-        if id >= self.trim_materials_by_id.len() {
-            return false;
-        }
-        self.trim_materials_by_id[id] = trim_material;
-        true
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (usize, TrimMaterialRef)> + '_ {
-        self.trim_materials_by_id
-            .iter()
-            .enumerate()
-            .map(|(id, &material)| (id, material))
-    }
 }
 
-impl Default for TrimMaterialRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+crate::impl_standard_methods!(
+    TrimMaterialRegistry,
+    TrimMaterialRef,
+    trim_materials_by_id,
+    trim_materials_by_key,
+    allows_registering
+);
 
 crate::impl_registry!(
     TrimMaterialRegistry,

--- a/steel-registry/src/trim_pattern.rs
+++ b/steel-registry/src/trim_pattern.rs
@@ -42,44 +42,15 @@ impl TrimPatternRegistry {
             allows_registering: true,
         }
     }
-
-    pub fn register(&mut self, trim_pattern: TrimPatternRef) -> usize {
-        assert!(
-            self.allows_registering,
-            "Cannot register trim patterns after the registry has been frozen"
-        );
-
-        let id = self.trim_patterns_by_id.len();
-        self.trim_patterns_by_key
-            .insert(trim_pattern.key.clone(), id);
-        self.trim_patterns_by_id.push(trim_pattern);
-        id
-    }
-
-    /// Replaces a trim_pattern at a given index.
-    /// Returns true if the trim_pattern was replaced and false if the trim_pattern wasn't replaced
-    #[must_use]
-    pub fn replace(&mut self, trim_pattern: TrimPatternRef, id: usize) -> bool {
-        if id >= self.trim_patterns_by_id.len() {
-            return false;
-        }
-        self.trim_patterns_by_id[id] = trim_pattern;
-        true
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (usize, TrimPatternRef)> + '_ {
-        self.trim_patterns_by_id
-            .iter()
-            .enumerate()
-            .map(|(id, &pattern)| (id, pattern))
-    }
 }
 
-impl Default for TrimPatternRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+crate::impl_standard_methods!(
+    TrimPatternRegistry,
+    TrimPatternRef,
+    trim_patterns_by_id,
+    trim_patterns_by_key,
+    allows_registering
+);
 
 crate::impl_registry!(
     TrimPatternRegistry,

--- a/steel-registry/src/wolf_sound_variant.rs
+++ b/steel-registry/src/wolf_sound_variant.rs
@@ -71,44 +71,15 @@ impl WolfSoundVariantRegistry {
             allows_registering: true,
         }
     }
-
-    pub fn register(&mut self, wolf_sound_variant: WolfSoundVariantRef) -> usize {
-        assert!(
-            self.allows_registering,
-            "Cannot register wolf sound variants after the registry has been frozen"
-        );
-
-        let id = self.wolf_sound_variants_by_id.len();
-        self.wolf_sound_variants_by_key
-            .insert(wolf_sound_variant.key.clone(), id);
-        self.wolf_sound_variants_by_id.push(wolf_sound_variant);
-        id
-    }
-
-    /// Replaces a wolf_sound_variant at a given index.
-    /// Returns true if the wolf_sound_variant was replaced and false if the wolf_sound_variant wasn't replaced
-    #[must_use]
-    pub fn replace(&mut self, wolf_sound_variant: WolfSoundVariantRef, id: usize) -> bool {
-        if id >= self.wolf_sound_variants_by_id.len() {
-            return false;
-        }
-        self.wolf_sound_variants_by_id[id] = wolf_sound_variant;
-        true
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (usize, WolfSoundVariantRef)> + '_ {
-        self.wolf_sound_variants_by_id
-            .iter()
-            .enumerate()
-            .map(|(id, &variant)| (id, variant))
-    }
 }
 
-impl Default for WolfSoundVariantRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+crate::impl_standard_methods!(
+    WolfSoundVariantRegistry,
+    WolfSoundVariantRef,
+    wolf_sound_variants_by_id,
+    wolf_sound_variants_by_key,
+    allows_registering
+);
 
 crate::impl_registry!(
     WolfSoundVariantRegistry,

--- a/steel-registry/src/wolf_variant.rs
+++ b/steel-registry/src/wolf_variant.rs
@@ -94,44 +94,15 @@ impl WolfVariantRegistry {
             allows_registering: true,
         }
     }
-
-    pub fn register(&mut self, wolf_variant: WolfVariantRef) -> usize {
-        assert!(
-            self.allows_registering,
-            "Cannot register wolf variants after the registry has been frozen"
-        );
-
-        let id = self.wolf_variants_by_id.len();
-        self.wolf_variants_by_key
-            .insert(wolf_variant.key.clone(), id);
-        self.wolf_variants_by_id.push(wolf_variant);
-        id
-    }
-
-    /// Replaces a wolf_variant at a given index.
-    /// Returns true if the wolf_variant was replaced and false if the wolf_variant wasn't replaced
-    #[must_use]
-    pub fn replace(&mut self, wolf_variant: WolfVariantRef, id: usize) -> bool {
-        if id >= self.wolf_variants_by_id.len() {
-            return false;
-        }
-        self.wolf_variants_by_id[id] = wolf_variant;
-        true
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (usize, WolfVariantRef)> + '_ {
-        self.wolf_variants_by_id
-            .iter()
-            .enumerate()
-            .map(|(id, &variant)| (id, variant))
-    }
 }
 
-impl Default for WolfVariantRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+crate::impl_standard_methods!(
+    WolfVariantRegistry,
+    WolfVariantRef,
+    wolf_variants_by_id,
+    wolf_variants_by_key,
+    allows_registering
+);
 
 crate::impl_registry!(
     WolfVariantRegistry,

--- a/steel-registry/src/world_clock.rs
+++ b/steel-registry/src/world_clock.rs
@@ -34,37 +34,15 @@ impl WorldClockRegistry {
             allows_registering: true,
         }
     }
-
-    pub fn register(&mut self, world_clock: WorldClockRef) -> usize {
-        assert!(
-            self.allows_registering,
-            "Cannot register world_clocks after the registry has been frozen"
-        );
-
-        let id = self.world_clocks_by_id.len();
-        self.world_clocks_by_key.insert(world_clock.key.clone(), id);
-        self.world_clocks_by_id.push(world_clock);
-        id
-    }
-
-    /// Replaces a world_clocks at a given index.
-    /// Returns true if the world_clock was replaced and false if the world_clock wasn't replaced
-    #[must_use]
-    pub fn replace(&mut self, world_clock: WorldClockRef, id: usize) -> bool {
-        if id >= self.world_clocks_by_id.len() {
-            return false;
-        }
-        self.world_clocks_by_id[id] = world_clock;
-        true
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (usize, WorldClockRef)> + '_ {
-        self.world_clocks_by_id
-            .iter()
-            .enumerate()
-            .map(|(id, &world_clock)| (id, world_clock))
-    }
 }
+
+crate::impl_standard_methods!(
+    WorldClockRegistry,
+    WorldClockRef,
+    world_clocks_by_id,
+    world_clocks_by_key,
+    allows_registering
+);
 
 crate::impl_registry!(
     WorldClockRegistry,
@@ -75,9 +53,3 @@ crate::impl_registry!(
 );
 
 crate::impl_tagged_registry!(WorldClockRegistry, world_clocks_by_key, "World Clock");
-
-impl Default for WorldClockRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
-}

--- a/steel-registry/src/zombie_nautilus_variant.rs
+++ b/steel-registry/src/zombie_nautilus_variant.rs
@@ -76,49 +76,15 @@ impl ZombieNautilusVariantRegistry {
             allows_registering: true,
         }
     }
-
-    pub fn register(&mut self, zombie_nautilus_variant: ZombieNautilusVariantRef) -> usize {
-        assert!(
-            self.allows_registering,
-            "Cannot register zombie nautilus variants after the registry has been frozen"
-        );
-
-        let id = self.zombie_nautilus_variants_by_id.len();
-        self.zombie_nautilus_variants_by_key
-            .insert(zombie_nautilus_variant.key.clone(), id);
-        self.zombie_nautilus_variants_by_id
-            .push(zombie_nautilus_variant);
-        id
-    }
-
-    /// Replaces a zombie_nautilus_variant at a given index.
-    /// Returns true if the zombie_nautilus_variant was replaced and false if the zombie_nautilus_variant wasn't replaced
-    #[must_use]
-    pub fn replace(
-        &mut self,
-        zombie_nautilus_variant: ZombieNautilusVariantRef,
-        id: usize,
-    ) -> bool {
-        if id >= self.zombie_nautilus_variants_by_id.len() {
-            return false;
-        }
-        self.zombie_nautilus_variants_by_id[id] = zombie_nautilus_variant;
-        true
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (usize, ZombieNautilusVariantRef)> + '_ {
-        self.zombie_nautilus_variants_by_id
-            .iter()
-            .enumerate()
-            .map(|(id, &variant)| (id, variant))
-    }
 }
 
-impl Default for ZombieNautilusVariantRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+crate::impl_standard_methods!(
+    ZombieNautilusVariantRegistry,
+    ZombieNautilusVariantRef,
+    zombie_nautilus_variants_by_id,
+    zombie_nautilus_variants_by_key,
+    allows_registering
+);
 
 crate::impl_registry!(
     ZombieNautilusVariantRegistry,


### PR DESCRIPTION
What was done:
- unify the register function for biome and trim material
- moved register, replace and iter() and the default trait into a macro
- removed replace function from all registries, so currently mod support is not possible!!!

so all normal registries, should be now even smaller file size and quicker to add and remove the possibility to add errors, because of a faulty implementation.