### PR TITLE
add flint feature

### DIFF
--- a/steel-core/Cargo.toml
+++ b/steel-core/Cargo.toml
@@ -10,6 +10,7 @@ build = "build/build.rs"
 #default = ["stand-alone"]
 stand-alone = []
 slow_chunk_gen = []
+flint = []
 
 [dependencies]
 # Internal crates

--- a/steel-core/src/behavior/block.rs
+++ b/steel-core/src/behavior/block.rs
@@ -33,6 +33,14 @@ pub struct PickupResult {
 /// - Player interactions
 /// - State changes
 pub trait BlockBehavior: Send + Sync {
+    /// Returns the Rust type name of the concrete behavior implementation.
+    #[cfg(feature = "flint")]
+    #[must_use]
+    #[expect(clippy::absolute_paths, reason = "easier for features")]
+    fn type_name(&self) -> &'static str {
+        std::any::type_name::<Self>()
+    }
+
     /// Called when a player uses an empty bucket on this block.
     ///
     /// Should:
@@ -471,6 +479,13 @@ pub struct BlockBehaviorRegistry {
 }
 
 impl BlockBehaviorRegistry {
+    /// Get all behaviors.
+    #[cfg(feature = "flint")]
+    #[must_use]
+    pub fn get_behaviors(&self) -> &[Box<dyn BlockBehavior>] {
+        &self.behaviors
+    }
+
     /// Creates a new behavior registry with default behaviors for all blocks.
     #[must_use]
     pub fn new() -> Self {

--- a/steel-core/src/behavior/item.rs
+++ b/steel-core/src/behavior/item.rs
@@ -13,6 +13,14 @@ use crate::behavior::{InteractionResult, UseItemContext, UseOnContext};
 /// - Use in air
 /// - etc.
 pub trait ItemBehavior: Send + Sync {
+    /// Returns the Rust type name of the concrete behavior implementation.
+    #[cfg(feature = "flint")]
+    #[must_use]
+    #[expect(clippy::absolute_paths, reason = "easier for features")]
+    fn type_name(&self) -> &'static str {
+        std::any::type_name::<Self>()
+    }
+
     /// Called when this item is used on a block.
     fn use_on(&self, _context: &mut UseOnContext) -> InteractionResult {
         InteractionResult::Pass
@@ -63,6 +71,13 @@ impl ItemBehaviorRegistry {
     #[must_use]
     pub fn get_behavior_by_id(&self, id: usize) -> Option<&dyn ItemBehavior> {
         self.behaviors.get(id).map(AsRef::as_ref)
+    }
+
+    /// Get all behaviors.
+    #[cfg(feature = "flint")]
+    #[must_use]
+    pub fn get_behaviors(&self) -> &[Box<dyn ItemBehavior>] {
+        &self.behaviors
     }
 }
 


### PR DESCRIPTION
This adds 4 methods, which allows flint to query all implemented blocks and items