### PR TITLE
chore: bump typos to 1.48

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Spell Check
-        uses: crate-ci/typos@v1.39.0
+        uses: crate-ci/typos@v1.48.0
 
       - name: Format
         run: cargo fmt --all --check

--- a/_typos.toml
+++ b/_typos.toml
@@ -15,6 +15,8 @@ interruptable = "interruptable"
 neighbour = "neighbour"
 # Vanilla stronghold piece-type IDs (shs, shsd, shrc, ...).
 shs = "shs"
+# Vanilla carver tag name (minecraft:overworld_carver_replaceables).
+replaceables = "replaceables"
 
 [default]
 locale = "en-us"


### PR DESCRIPTION
This makes local typos installations not fail on new typos in upstream.