### PR TITLE
add more permission to clear

### DIFF
--- a/steel-core/src/command/builtins/clear.rs
+++ b/steel-core/src/command/builtins/clear.rs
@@ -15,11 +15,10 @@ use super::super::{
     registration::CommandRegistration,
     target_permission::{can_target_player, player_target_access},
 };
-use crate::permission::PermissionKey;
+use crate::permission::{PermissionKey, PermissionKeyError};
 use crate::{entity::Entity as _, player::Player};
 
-pub(super) fn registration()
--> Result<CommandRegistration<CommandSource>, crate::permission::PermissionKeyError> {
+pub(super) fn registration() -> Result<CommandRegistration<CommandSource>, PermissionKeyError> {
     let root = PermissionKey::parse("minecraft.command.clear")?;
     Ok(
         CommandRegistration::new(Identifier::vanilla_static("clear"), |_| command())
@@ -155,7 +154,7 @@ fn clear_players(
     Ok(count)
 }
 
-fn invalid_permission(error: crate::permission::PermissionKeyError) -> CommandSyntaxError {
+fn invalid_permission(error: PermissionKeyError) -> CommandSyntaxError {
     CommandSyntaxError::dynamic(format!("Invalid clear target permission: {error}"))
 }
 

--- a/steel-core/src/command/builtins/clear.rs
+++ b/steel-core/src/command/builtins/clear.rs
@@ -13,11 +13,18 @@ use super::super::{
         literal,
     },
     registration::CommandRegistration,
+    target_permission::{can_target_player, player_target_access},
 };
+use crate::permission::PermissionKey;
 use crate::{entity::Entity as _, player::Player};
 
-pub(super) fn registration() -> CommandRegistration<CommandSource> {
-    CommandRegistration::new(Identifier::vanilla_static("clear"), |_| command())
+pub(super) fn registration()
+-> Result<CommandRegistration<CommandSource>, crate::permission::PermissionKeyError> {
+    let root = PermissionKey::parse("minecraft.command.clear")?;
+    Ok(
+        CommandRegistration::new(Identifier::vanilla_static("clear"), |_| command())
+            .permission(player_target_access(&root)),
+    )
 }
 
 fn command() -> CommandNodeBuilder<CommandSource, SteelCommandRuntime> {
@@ -84,6 +91,16 @@ fn clear_players(
     predicate: &dyn Fn(&ItemStack) -> bool,
     max_count: i32,
 ) -> Result<i32, CommandSyntaxError> {
+    let root = PermissionKey::parse("minecraft.command.clear").map_err(invalid_permission)?;
+    for target in targets {
+        if !can_target_player(context.source(), &root, target).map_err(invalid_permission)? {
+            return Err(CommandSyntaxError::dynamic(format!(
+                "You do not have permission to clear {}",
+                target.plain_text_name()
+            )));
+        }
+    }
+
     let mut count = 0;
     for target in targets {
         count += target.clear_or_count_matching_items(predicate, max_count);
@@ -138,6 +155,10 @@ fn clear_players(
     Ok(count)
 }
 
+fn invalid_permission(error: crate::permission::PermissionKeyError) -> CommandSyntaxError {
+    CommandSyntaxError::dynamic(format!("Invalid clear target permission: {error}"))
+}
+
 const fn matches_any_item(_stack: &ItemStack) -> bool {
     true
 }
@@ -150,6 +171,8 @@ fn missing_argument(name: &str) -> CommandSyntaxError {
 
 #[cfg(test)]
 mod tests {
+    use crate::command::target_permission::{group_permission, self_permission};
+    use crate::permission::{PermissionEntry, PermissionSet};
     use steel_registry::test_support::init_test_registry;
 
     use super::super::create_dispatcher;
@@ -218,5 +241,25 @@ mod tests {
             dispatcher.node(max_count),
             Some(node) if node.is_executable()
         ));
+    }
+
+    #[test]
+    fn clear_target_permissions_are_scoped_under_the_command_root() {
+        let root = PermissionKey::parse("minecraft.command.clear")
+            .expect("built-in permission should parse");
+        let self_permission = self_permission(&root).expect("self target permission should build");
+        let user_permission =
+            group_permission(&root, "user").expect("group target permission should build");
+
+        let self_only = PermissionSet::from_entries([PermissionEntry::allow(
+            PermissionKey::parse("minecraft.command.clear.self")
+                .expect("test permission should parse"),
+        )]);
+        assert!(self_only.allows(&self_permission));
+        assert!(!self_only.allows(&user_permission));
+
+        let all_clear = PermissionSet::from_entries([PermissionEntry::allow(root)]);
+        assert!(all_clear.allows(&self_permission));
+        assert!(all_clear.allows(&user_permission));
     }
 }

--- a/steel-core/src/command/builtins/gamemode.rs
+++ b/steel-core/src/command/builtins/gamemode.rs
@@ -17,9 +17,7 @@ use super::super::{
 };
 use crate::command::sender::CommandSender;
 use crate::entity::Entity;
-use crate::permission::{
-    PermissionContext, PermissionExpr, PermissionKey, PermissionKeyError, PermissionSegment,
-};
+use crate::permission::{PermissionContext, PermissionExpr, PermissionKey, PermissionKeyError};
 use crate::player::Player;
 use crate::server::Server;
 use crate::world::World;
@@ -216,8 +214,7 @@ fn visible_permission() -> Result<PermissionExpr, PermissionKeyError> {
 
 fn game_mode_permission(game_mode: GameType) -> Result<PermissionExpr, PermissionKeyError> {
     let root = PermissionKey::parse("minecraft.command.gamemode")?;
-    let segment = PermissionSegment::parse(game_mode.name())?;
-    let mode = root.child(&segment)?;
+    let mode = root.child(game_mode.name())?;
     Ok(PermissionExpr::scoped_key(root, mode))
 }
 

--- a/steel-core/src/command/builtins/mod.rs
+++ b/steel-core/src/command/builtins/mod.rs
@@ -55,7 +55,12 @@ pub(crate) fn create_registered_dispatcher(
     builder.declare_permission(perms::MANAGE_ALL_PERMISSION)?;
     builder.declare_permission(perms::GROUP_ALL_PERMISSION)?;
     builder.declare_permission(perms::METADATA_PERMISSION)?;
-    builder.register(clear::registration())?;
+    builder.register(clear::registration().map_err(|source| {
+        CommandRegistrationError::InvalidExplicitPermission {
+            id: steel_utils::Identifier::vanilla_static("clear"),
+            source,
+        }
+    })?)?;
     builder.register(operator::deop_registration())?;
     builder.register(difficulty::registration())?;
     builder.register(domain::registration())?;

--- a/steel-core/src/command/mod.rs
+++ b/steel-core/src/command/mod.rs
@@ -10,6 +10,7 @@ mod registration;
 mod request_queue;
 pub mod sender;
 pub(crate) mod storage;
+mod target_permission;
 
 pub use api::{
     CommandArgument, CommandArgumentParser, CommandContext, CommandError, CommandNode,

--- a/steel-core/src/command/registration.rs
+++ b/steel-core/src/command/registration.rs
@@ -433,14 +433,7 @@ fn derived_subcommand_permission(
 ) -> Result<PermissionKey, CommandRegistrationError> {
     let mut permission = root.clone();
     for segment in path {
-        let segment = PermissionSegment::parse(segment.to_string()).map_err(|source| {
-            CommandRegistrationError::InvalidSubcommandPermissionPath {
-                id: id.clone(),
-                path: display_permission_path(path),
-                source,
-            }
-        })?;
-        permission = permission.child(&segment).map_err(|source| {
+        permission = permission.child(segment).map_err(|source| {
             CommandRegistrationError::InvalidSubcommandPermissionPath {
                 id: id.clone(),
                 path: display_permission_path(path),
@@ -515,6 +508,9 @@ fn collect_permission_keys(expression: &PermissionExpr, keys: &mut BTreeSet<Perm
         PermissionExpr::ScopedKey { parent, key } => {
             keys.insert(parent.clone());
             keys.insert(key.clone());
+        }
+        PermissionExpr::AnyDescendant(parent) => {
+            keys.insert(parent.clone());
         }
         PermissionExpr::All(expressions) | PermissionExpr::Any(expressions) => {
             for expression in expressions {

--- a/steel-core/src/command/target_permission.rs
+++ b/steel-core/src/command/target_permission.rs
@@ -1,0 +1,58 @@
+//! Permission checks for commands that operate on player targets.
+
+use crate::{
+    command::execution::{CommandPermissionSource, CommandSource},
+    permission::{PermissionExpr, PermissionKey, PermissionKeyError},
+    player::Player,
+};
+
+pub(crate) fn player_target_access(root: &PermissionKey) -> PermissionExpr {
+    PermissionExpr::key(root.clone()) | PermissionExpr::any_descendant(root.clone())
+}
+
+/// Requires every effective target group, so additional groups protect a player.
+pub(crate) fn can_target_player(
+    source: &CommandSource,
+    root: &PermissionKey,
+    target: &Player,
+) -> Result<bool, PermissionKeyError> {
+    if source
+        .player()
+        .is_some_and(|player| player.gameprofile.id == target.gameprofile.id)
+        && source.has_permission(&self_permission(root)?)
+    {
+        return Ok(true);
+    }
+
+    let assigned = source
+        .server()
+        .player_permission_state(target.gameprofile.id)
+        .unwrap_or_default();
+    let groups = source
+        .server()
+        .permission_groups
+        .effective_group_names(assigned.groups());
+    if groups.is_empty() {
+        return Ok(false);
+    }
+    for group in groups {
+        if !source.has_permission(&group_permission(root, &group)?) {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+pub(crate) fn self_permission(root: &PermissionKey) -> Result<PermissionExpr, PermissionKeyError> {
+    let key = root.child("self")?;
+    Ok(PermissionExpr::scoped_key(root.clone(), key))
+}
+
+pub(crate) fn group_permission(
+    root: &PermissionKey,
+    group: &str,
+) -> Result<PermissionExpr, PermissionKeyError> {
+    let group_root = root.child("group")?;
+    let key = group_root.child(group)?;
+    Ok(PermissionExpr::scoped_key(root.clone(), key))
+}

--- a/steel-core/src/permission/expression.rs
+++ b/steel-core/src/permission/expression.rs
@@ -14,6 +14,8 @@ pub enum PermissionExpr {
         /// Specific child permission being checked.
         key: PermissionKey,
     },
+    /// Allows when at least one configured descendant of this key allows.
+    AnyDescendant(PermissionKey),
     /// Requires every nested expression to allow.
     All(Vec<Self>),
     /// Requires at least one nested expression to allow.
@@ -31,6 +33,12 @@ impl PermissionExpr {
     #[must_use]
     pub const fn scoped_key(parent: PermissionKey, key: PermissionKey) -> Self {
         Self::ScopedKey { parent, key }
+    }
+
+    /// Creates a dynamic check for any allowed child below `parent`.
+    #[must_use]
+    pub const fn any_descendant(parent: PermissionKey) -> Self {
+        Self::AnyDescendant(parent)
     }
 }
 

--- a/steel-core/src/permission/group_tests.rs
+++ b/steel-core/src/permission/group_tests.rs
@@ -283,6 +283,22 @@ fn default_groups_apply_and_unknown_assignments_are_ignored() {
 }
 
 #[test]
+fn effective_group_names_include_defaults_assignments_and_inheritance() {
+    let mut config = PermissionGroupsConfig::default();
+    let mut moderator = PermissionGroupConfig::default();
+    moderator.inherits.push("default".to_owned());
+    config.groups.insert("moderator".to_owned(), moderator);
+
+    let groups = groups(config);
+    assert_eq!(
+        groups.effective_group_names(&["moderator".to_owned()]),
+        ["default".to_owned(), "moderator".to_owned()]
+            .into_iter()
+            .collect()
+    );
+}
+
+#[test]
 fn groups_config_round_trips_through_toml() {
     let config = PermissionGroupsConfig::default();
     let serialized = match toml::to_string(&config) {

--- a/steel-core/src/permission/groups.rs
+++ b/steel-core/src/permission/groups.rs
@@ -135,6 +135,32 @@ impl PermissionGroups {
         self.groups.contains_key(group)
     }
 
+    /// Returns default, assigned, and inherited groups that contribute to a subject.
+    #[must_use]
+    pub fn effective_group_names(&self, assigned_groups: &[String]) -> BTreeSet<String> {
+        let mut effective = BTreeSet::new();
+        for group in &self.default_groups {
+            self.append_group_name(group, &mut effective);
+        }
+        for group in assigned_groups {
+            self.append_group_name(group, &mut effective);
+        }
+        effective
+    }
+
+    fn append_group_name(&self, group_name: &str, effective: &mut BTreeSet<String>) {
+        if !effective.insert(group_name.to_owned()) {
+            return;
+        }
+        let Some(group) = self.groups.get(group_name) else {
+            effective.remove(group_name);
+            return;
+        };
+        for parent in &group.inherits {
+            self.append_group_name(parent, effective);
+        }
+    }
+
     /// Builds effective permissions from defaults, assigned groups, and subject overrides.
     ///
     /// Unknown assigned groups have no effect. Each inherited group contributes at most once.

--- a/steel-core/src/permission/key.rs
+++ b/steel-core/src/permission/key.rs
@@ -68,7 +68,8 @@ impl PermissionKey {
     /// # Errors
     ///
     /// Returns an error when this key ends in a wildcard.
-    pub fn child(&self, segment: &PermissionSegment) -> Result<Self, PermissionKeyError> {
+    pub fn child(&self, segment: impl AsRef<str>) -> Result<Self, PermissionKeyError> {
+        let segment = PermissionSegment::parse(segment.as_ref())?;
         Self::parse(format!("{}.{}", self.0, segment.as_str()))
     }
 
@@ -135,6 +136,12 @@ impl PermissionSegment {
     #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
+    }
+}
+
+impl AsRef<str> for PermissionSegment {
+    fn as_ref(&self) -> &str {
+        self.as_str()
     }
 }
 

--- a/steel-core/src/permission/manager.rs
+++ b/steel-core/src/permission/manager.rs
@@ -1,4 +1,4 @@
-use std::{error::Error, fmt, sync::Arc};
+use std::{collections::BTreeSet, error::Error, fmt, sync::Arc};
 
 use futures::future::BoxFuture;
 use steel_utils::locks::{AsyncMutex, SyncRwLock};
@@ -108,6 +108,15 @@ impl PermissionGroupManager {
     #[must_use]
     pub fn group_names(&self) -> Vec<String> {
         self.state.read().groups.groups().keys().cloned().collect()
+    }
+
+    /// Returns every configured group that contributes to a subject.
+    #[must_use]
+    pub fn effective_group_names(&self, assigned_groups: &[String]) -> BTreeSet<String> {
+        self.state
+            .read()
+            .groups
+            .effective_group_names(assigned_groups)
     }
 
     /// Builds an effective permission set from the current group snapshot.

--- a/steel-core/src/permission/set.rs
+++ b/steel-core/src/permission/set.rs
@@ -308,8 +308,37 @@ impl PermissionSet {
             PermissionExpr::ScopedKey { parent, key } => {
                 self.resolve_scoped_key_in(parent, key, context)
             }
+            PermissionExpr::AnyDescendant(parent) => {
+                self.resolve_any_descendant_in(parent, context)
+            }
             PermissionExpr::All(children) => resolve_all(children, self, context),
             PermissionExpr::Any(children) => resolve_any(children, self, context),
+        }
+    }
+
+    fn resolve_any_descendant_in(
+        &self,
+        parent: &PermissionKey,
+        context: &PermissionContext,
+    ) -> Option<PermissionState> {
+        let mut saw_deny = false;
+        let mut saw_unset = false;
+        for entry in &self.entries {
+            if entry.key() == parent || !parent.scopes(entry.key()) {
+                continue;
+            }
+            match self.resolve_key_in(entry.key(), context) {
+                Some(PermissionState::Allow) => return Some(PermissionState::Allow),
+                Some(PermissionState::Deny) => saw_deny = true,
+                None => saw_unset = true,
+            }
+        }
+        if saw_unset {
+            None
+        } else if saw_deny {
+            Some(PermissionState::Deny)
+        } else {
+            None
         }
     }
 

--- a/steel-core/src/permission/tests.rs
+++ b/steel-core/src/permission/tests.rs
@@ -378,6 +378,31 @@ fn expression_all_and_any_preserve_unset_state() {
 }
 
 #[test]
+fn any_descendant_discovers_dynamic_child_permissions() {
+    let root = key("minecraft.command.clear");
+    let expression = PermissionExpr::any_descendant(root.clone());
+
+    let self_only =
+        PermissionSet::from_entries([PermissionEntry::allow(key("minecraft.command.clear.self"))]);
+    assert_eq!(self_only.resolve(&expression), Some(PermissionState::Allow));
+
+    let denied_group = PermissionSet::from_entries([PermissionEntry::deny(key(
+        "minecraft.command.clear.group.op",
+    ))]);
+    assert_eq!(
+        denied_group.resolve(&expression),
+        Some(PermissionState::Deny)
+    );
+
+    let root_only = PermissionSet::from_entries([PermissionEntry::allow(root)]);
+    assert_eq!(root_only.resolve(&expression), None);
+
+    let unrelated =
+        PermissionSet::from_entries([PermissionEntry::allow(key("minecraft.command.kill.self"))]);
+    assert_eq!(unrelated.resolve(&expression), None);
+}
+
+#[test]
 fn deny_wins_a_complete_tie() {
     let give = key("minecraft.command.give");
     let permissions = PermissionSet::from_entries([


### PR DESCRIPTION
like mentionned in the other I add the ability to add more permission to clear so

- minecraft.command.clear — clear any player.
- minecraft.command.clear.self — clear only yourself.
- minecraft.command.clear.group.<group> — clear players belonging to that group.

All effective target groups count, including default, assigned, and inherited groups. Permission is required for every effective group, so access to default does not permit clearing a player who is also op.

All selected targets are checked before inventories are changed, preventing partial execution.

more example:
- minecraft.command.clear.* — grants all target-scoped clear permissions.
- minecraft.command.clear.group.* — grants access to every group, but not .self.
- minecraft.command.clear.group.admin — grants only the admin group.
- minecraft.command.clear — remains the broad grant for every clear target.