### PR TITLE
feat: mob complexity reduction

### DIFF
--- a/steel-core/src/behavior/blocks/building/powder_snow_block.rs
+++ b/steel-core/src/behavior/blocks/building/powder_snow_block.rs
@@ -4,7 +4,10 @@ use glam::DVec3;
 use steel_macros::block_behavior;
 use steel_registry::blocks::{BlockRef, block_state_ext::BlockStateExt as _, shapes::VoxelShape};
 use steel_registry::sound_event::SoundEventRef;
-use steel_registry::{vanilla_entities, vanilla_game_rules};
+use steel_registry::vanilla_entity_type_tags::EntityTypeTag;
+use steel_registry::{
+    REGISTRY, TaggedRegistryExt, vanilla_entities, vanilla_game_rules, vanilla_items,
+};
 use steel_utils::{BlockLocalAabb, BlockPos, BlockStateId};
 
 use crate::{
@@ -13,7 +16,8 @@ use crate::{
         EntityFallOnContext,
     },
     entity::ai::path::PathComputationType,
-    entity::{Entity, InsideBlockEffectCollector, InsideBlockEffectType, LivingEntity},
+    entity::{Entity, InsideBlockEffectCollector, InsideBlockEffectType},
+    inventory::equipment::EquipmentSlot,
     world::{LevelReader, World},
 };
 
@@ -40,6 +44,25 @@ impl PowderSnowBlock {
     #[must_use]
     pub const fn new(block: BlockRef) -> Self {
         Self { block }
+    }
+
+    /// Returns vanilla `PowderSnowBlock.canEntityWalkOnPowderSnow`.
+    pub(crate) fn can_entity_walk_on_powder_snow<E: Entity + ?Sized>(entity: &E) -> bool {
+        if REGISTRY.entity_types.is_in_tag(
+            entity.entity_type(),
+            &EntityTypeTag::POWDER_SNOW_WALKABLE_MOBS,
+        ) {
+            return true;
+        }
+
+        let Some(living) = entity.as_living_entity() else {
+            return false;
+        };
+        let mut has_leather_boots = false;
+        living.with_equipment_slot(EquipmentSlot::Feet, &mut |item_stack| {
+            has_leather_boots = item_stack.is(&vanilla_items::LEATHER_BOOTS);
+        });
+        has_leather_boots
     }
 
     #[must_use]
@@ -93,17 +116,13 @@ impl BlockBehavior for PowderSnowBlock {
         pos: BlockPos,
         entity: &dyn Entity,
     ) -> VoxelShape {
-        let can_walk_on_powder_snow = entity.as_living_entity().map_or_else(
-            || entity.default_can_walk_on_powder_snow(),
-            LivingEntity::can_walk_on_powder_snow,
-        );
         let collision_shape = self.get_collision_shape(
             state,
             world,
             pos,
             BlockCollisionContext::entity(entity.position().y, entity.is_descending())
                 .with_fall_distance(entity.fall_distance())
-                .with_can_walk_on_powder_snow(can_walk_on_powder_snow)
+                .with_can_walk_on_powder_snow(Self::can_entity_walk_on_powder_snow(entity))
                 .with_falling_block(entity.entity_type() == &vanilla_entities::FALLING_BLOCK),
         );
         if collision_shape.is_empty() {

--- a/steel-core/src/behavior/blocks/building/powder_snow_block.rs
+++ b/steel-core/src/behavior/blocks/building/powder_snow_block.rs
@@ -13,7 +13,7 @@ use crate::{
         EntityFallOnContext,
     },
     entity::ai::path::PathComputationType,
-    entity::{Entity, InsideBlockEffectCollector, InsideBlockEffectType},
+    entity::{Entity, InsideBlockEffectCollector, InsideBlockEffectType, LivingEntity},
     world::{LevelReader, World},
 };
 
@@ -93,13 +93,17 @@ impl BlockBehavior for PowderSnowBlock {
         pos: BlockPos,
         entity: &dyn Entity,
     ) -> VoxelShape {
+        let can_walk_on_powder_snow = entity.as_living_entity().map_or_else(
+            || entity.default_can_walk_on_powder_snow(),
+            LivingEntity::can_walk_on_powder_snow,
+        );
         let collision_shape = self.get_collision_shape(
             state,
             world,
             pos,
             BlockCollisionContext::entity(entity.position().y, entity.is_descending())
                 .with_fall_distance(entity.fall_distance())
-                .with_can_walk_on_powder_snow(entity.can_walk_on_powder_snow())
+                .with_can_walk_on_powder_snow(can_walk_on_powder_snow)
                 .with_falling_block(entity.entity_type() == &vanilla_entities::FALLING_BLOCK),
         );
         if collision_shape.is_empty() {

--- a/steel-core/src/entity/ageable.rs
+++ b/steel-core/src/entity/ageable.rs
@@ -132,7 +132,9 @@ pub trait AgeableMob: Mob {
     fn set_synced_baby(&self, baby: bool);
 
     /// Hook called after the baby/adult boundary changes.
-    fn age_boundary_changed(&self, _baby: bool) {}
+    fn age_boundary_changed(&self, _baby: bool) {
+        self.refresh_dimensions();
+    }
 
     /// Returns vanilla `AgeableMob.getBabyStartAge`.
     fn get_baby_start_age(&self) -> i32 {

--- a/steel-core/src/entity/entities/pig/mod.rs
+++ b/steel-core/src/entity/entities/pig/mod.rs
@@ -19,8 +19,8 @@ use steel_registry::sound_event::SoundEventRef;
 use steel_registry::vanilla_entity_data::PigEntityData;
 use steel_registry::vanilla_item_tags::ItemTag;
 use steel_registry::{
-    REGISTRY, RegistryExt, TaggedRegistryExt, sound_events, vanilla_attributes, vanilla_items,
-    vanilla_pig_sound_variants, vanilla_pig_variants,
+    REGISTRY, RegistryExt, RegistryReference, TaggedRegistryExt, sound_events, vanilla_attributes,
+    vanilla_items,
 };
 use steel_utils::locks::SyncMutex;
 use steel_utils::random::legacy_random::LegacyRandom;
@@ -140,89 +140,45 @@ impl PigEntity {
         }
     }
 
-    /// Returns the current pig variant registry ID stored in synced data.
-    #[must_use]
-    pub fn variant_id(&self) -> i32 {
-        *self.entity_data.lock().variant.get()
-    }
-
     /// Sets the current pig variant by registry entry.
     pub fn set_variant(&self, variant: PigVariantRef) {
-        let Some(id) = REGISTRY.pig_variants.id_from_key(&variant.key) else {
-            log::error!("pig variant {} is not registered", variant.key);
-            return;
-        };
-        self.set_variant_id_from_usize(id);
+        self.entity_data
+            .lock()
+            .variant
+            .set(RegistryReference::new(variant));
     }
 
-    /// Returns the current pig variant, falling back to vanilla's default holder.
+    /// Returns the current pig variant.
     #[must_use]
     pub fn variant(&self) -> PigVariantRef {
-        let id = self.variant_id();
-        if let Ok(id) = usize::try_from(id)
-            && let Some(variant) = REGISTRY.pig_variants.by_id(id)
-        {
-            return variant;
-        }
-
-        &vanilla_pig_variants::TEMPERATE
-    }
-
-    /// Returns the current pig sound variant registry ID stored in synced data.
-    #[must_use]
-    pub fn sound_variant_id(&self) -> i32 {
-        *self.entity_data.lock().sound_variant.get()
+        self.entity_data.lock().variant.get().value()
     }
 
     /// Sets the current pig sound variant by registry entry.
     pub fn set_sound_variant(&self, sound_variant: PigSoundVariantRef) {
-        let Some(id) = REGISTRY.pig_sound_variants.id_from_key(&sound_variant.key) else {
-            log::error!("pig sound variant {} is not registered", sound_variant.key);
-            return;
-        };
-        self.set_sound_variant_id_from_usize(id);
+        self.entity_data
+            .lock()
+            .sound_variant
+            .set(RegistryReference::new(sound_variant));
     }
 
-    /// Returns the current pig sound variant, falling back to vanilla classic.
+    /// Returns the current pig sound variant.
     #[must_use]
     pub fn sound_variant(&self) -> PigSoundVariantRef {
-        let id = self.sound_variant_id();
-        if let Ok(id) = usize::try_from(id)
-            && let Some(sound_variant) = REGISTRY.pig_sound_variants.by_id(id)
-        {
-            return sound_variant;
-        }
-
-        &vanilla_pig_sound_variants::CLASSIC
-    }
-
-    fn set_variant_id_from_usize(&self, id: usize) {
-        let Ok(id) = i32::try_from(id) else {
-            log::error!("pig variant id {id} does not fit synced-data i32");
-            return;
-        };
-        self.entity_data.lock().variant.set(id);
-    }
-
-    fn set_sound_variant_id_from_usize(&self, id: usize) {
-        let Ok(id) = i32::try_from(id) else {
-            log::error!("pig sound variant id {id} does not fit synced-data i32");
-            return;
-        };
-        self.entity_data.lock().sound_variant.set(id);
+        self.entity_data.lock().sound_variant.get().value()
     }
 
     fn set_variant_by_key(&self, key: &Identifier) -> bool {
-        let Some(id) = REGISTRY.pig_variants.id_from_key(key) else {
+        let Some(variant) = REGISTRY.pig_variants.by_key(key) else {
             return false;
         };
-        self.set_variant_id_from_usize(id);
+        self.set_variant(variant);
         true
     }
 
     fn set_sound_variant_by_key(&self, key: &Identifier) {
-        if let Some(id) = REGISTRY.pig_sound_variants.id_from_key(key) {
-            self.set_sound_variant_id_from_usize(id);
+        if let Some(sound_variant) = REGISTRY.pig_sound_variants.by_key(key) {
+            self.set_sound_variant(sound_variant);
         }
     }
 
@@ -233,40 +189,6 @@ impl PigEntity {
         } else {
             &sound_variant.adult_sounds
         }
-    }
-
-    /// Returns whether this pig has a saddle equipped.
-    #[must_use]
-    pub fn is_saddled(&self) -> bool {
-        LivingEntity::has_item_in_slot(self, EquipmentSlot::Saddle)
-    }
-
-    /// Returns whether this pig can currently use the saddle equipment slot.
-    #[must_use]
-    pub fn can_use_saddle_slot(&self) -> bool {
-        Entity::is_alive(self) && !AgeableMob::is_baby(self)
-    }
-
-    /// Returns whether item-based steering is currently boosting.
-    #[must_use]
-    pub fn is_boosting(&self) -> bool {
-        self.steering.lock().is_boosting()
-    }
-
-    /// Returns the current elapsed boost time.
-    #[must_use]
-    pub fn elapsed_boost_time(&self) -> i32 {
-        self.steering.lock().boost_time()
-    }
-
-    /// Returns vanilla pig ridden speed.
-    #[must_use]
-    pub fn ridden_speed(&self) -> f32 {
-        let movement_speed = self
-            .attributes()
-            .lock()
-            .required_value(vanilla_attributes::MOVEMENT_SPEED) as f32;
-        movement_speed * 0.225 * ItemSteerable::boost_factor(self)
     }
 
     fn set_ridden_rotation(&self, controller_yaw: f32, controller_pitch: f32) {
@@ -406,7 +328,7 @@ impl LivingEntity for PigEntity {
     }
 
     fn can_use_slot(&self, slot: EquipmentSlot) -> bool {
-        slot != EquipmentSlot::Saddle || self.can_use_saddle_slot()
+        slot != EquipmentSlot::Saddle || (Entity::is_alive(self) && !AgeableMob::is_baby(self))
     }
 
     fn can_dispenser_equip_into_slot(&self, slot: EquipmentSlot) -> bool {
@@ -428,7 +350,11 @@ impl LivingEntity for PigEntity {
     }
 
     fn ridden_speed(&self, _controller: &Player) -> f32 {
-        PigEntity::ridden_speed(self)
+        let movement_speed = self
+            .attributes()
+            .lock()
+            .required_value(vanilla_attributes::MOVEMENT_SPEED) as f32;
+        movement_speed * 0.225 * ItemSteerable::boost_factor(self)
     }
 }
 

--- a/steel-core/src/entity/entities/pig/mod.rs
+++ b/steel-core/src/entity/entities/pig/mod.rs
@@ -36,7 +36,7 @@ use crate::entity::damage::DamageSource;
 use crate::entity::{
     AgeableMob, AgeableMobBase, Animal, AnimalBase, Entity, EntityBase, EntityBaseLoad, EntityPose,
     EntitySpawnReason, EntitySyncedData, ItemBasedSteering, ItemSteerable, LivingEntity,
-    LivingEntityBase, Mob, MobBase, PathfinderMob, SharedEntity, SpawnGroupData,
+    LivingEntityBase, Mob, MobBase, MoveResult, PathfinderMob, SharedEntity, SpawnGroupData,
 };
 use crate::inventory::equipment::EquipmentSlot;
 use crate::player::Player;
@@ -236,6 +236,10 @@ impl Entity for PigEntity {
         self.entity_type
     }
 
+    fn base_tick(&self) {
+        Mob::base_tick_mob(self);
+    }
+
     fn dimensions_for_pose(&self, _pose: EntityPose) -> EntityDimensions {
         let scale = LivingEntity::get_scale(self);
         if AgeableMob::is_baby(self) {
@@ -339,6 +343,10 @@ impl LivingEntity for PigEntity {
         (slot == EquipmentSlot::Saddle).then_some(&sound_events::ENTITY_PIG_SADDLE)
     }
 
+    fn server_ai_step(&self) {
+        Mob::mob_server_ai_step(self);
+    }
+
     fn tick_ridden(&self, controller: &Player, _ridden_input: DVec3) {
         let (yaw, pitch) = controller.rotation();
         self.set_ridden_rotation(yaw, pitch);
@@ -355,6 +363,13 @@ impl LivingEntity for PigEntity {
             .lock()
             .required_value(vanilla_attributes::MOVEMENT_SPEED) as f32;
         movement_speed * 0.225 * ItemSteerable::boost_factor(self)
+    }
+
+    fn ai_step(&self) -> Option<MoveResult> {
+        let result = self.default_ai_step();
+        AgeableMob::tick_ageable_mob(self);
+        Animal::tick_animal_love(self);
+        result
     }
 }
 
@@ -435,6 +450,18 @@ impl ItemSteerable for PigEntity {
 impl Mob for PigEntity {
     fn mob_base(&self) -> &MobBase {
         &self.mob_base
+    }
+
+    fn tick_goal_selectors(&self) {
+        PathfinderMob::tick_pathfinder_goal_selectors(self);
+    }
+
+    fn tick_path_navigation(&self) {
+        PathfinderMob::tick_pathfinder_path_navigation(self);
+    }
+
+    fn custom_server_ai_step(&self) {
+        Animal::custom_server_ai_step_animal(self);
     }
 
     fn ambient_sound(&self) -> Option<SoundEventRef> {

--- a/steel-core/src/entity/entities/pig/mod.rs
+++ b/steel-core/src/entity/entities/pig/mod.rs
@@ -9,7 +9,6 @@ use glam::DVec3;
 use simdnbt::borrow::NbtCompound as BorrowedNbtCompoundView;
 use simdnbt::owned::NbtCompound;
 use steel_macros::entity_behavior;
-use steel_protocol::packets::game::{AttributeSnapshot, EquipmentSlotItem, SoundSource};
 use steel_registry::entity_type::{
     EntityAttachmentPoint, EntityAttachments, EntityDimensions, EntityTypeRef,
 };
@@ -37,11 +36,9 @@ use crate::entity::damage::DamageSource;
 use crate::entity::{
     AgeableMob, AgeableMobBase, Animal, AnimalBase, Entity, EntityBase, EntityBaseLoad, EntityPose,
     EntitySpawnReason, EntitySyncedData, ItemBasedSteering, ItemSteerable, LivingEntity,
-    LivingEntityBase, Mob, MobBase, MobEffectSyncChange, PathfinderMob, SharedEntity,
-    SpawnGroupData,
+    LivingEntityBase, Mob, MobBase, PathfinderMob, SharedEntity, SpawnGroupData,
 };
 use crate::inventory::equipment::EquipmentSlot;
-use crate::physics::MoveResult;
 use crate::player::Player;
 use crate::world::World;
 
@@ -143,50 +140,6 @@ impl PigEntity {
         }
     }
 
-    /// Returns the vanilla age counter. Negative values are babies.
-    #[must_use]
-    pub fn get_age(&self) -> i32 {
-        AgeableMob::get_age(self)
-    }
-
-    /// Sets the vanilla age counter and updates the synchronized baby flag.
-    pub fn set_age(&self, age: i32) {
-        AgeableMob::set_age(self, age);
-    }
-
-    /// Returns whether this pig is a baby.
-    #[must_use]
-    pub fn is_baby(&self) -> bool {
-        AgeableMob::is_baby(self)
-    }
-
-    /// Sets the vanilla baby state using the `AgeableMob` start age.
-    pub fn set_baby(&self, baby: bool) {
-        AgeableMob::set_baby(self, baby);
-    }
-
-    /// Returns vanilla `AgeableMob.forcedAge`.
-    #[must_use]
-    pub fn forced_age(&self) -> i32 {
-        AgeableMob::forced_age(self)
-    }
-
-    /// Sets vanilla `AgeableMob.forcedAge`.
-    pub fn set_forced_age(&self, forced_age: i32) {
-        AgeableMob::set_forced_age(self, forced_age);
-    }
-
-    /// Returns the synchronized vanilla age-lock flag.
-    #[must_use]
-    pub fn is_age_locked(&self) -> bool {
-        AgeableMob::is_age_locked(self)
-    }
-
-    /// Sets the synchronized vanilla age-lock flag.
-    pub fn set_age_locked(&self, age_locked: bool) {
-        AgeableMob::set_age_locked(self, age_locked);
-    }
-
     /// Returns the current pig variant registry ID stored in synced data.
     #[must_use]
     pub fn variant_id(&self) -> i32 {
@@ -275,7 +228,7 @@ impl PigEntity {
 
     fn current_sound_set(&self) -> &'static PigAge {
         let sound_variant = self.sound_variant();
-        if self.is_baby() {
+        if AgeableMob::is_baby(self) {
             &sound_variant.baby_sounds
         } else {
             &sound_variant.adult_sounds
@@ -291,13 +244,7 @@ impl PigEntity {
     /// Returns whether this pig can currently use the saddle equipment slot.
     #[must_use]
     pub fn can_use_saddle_slot(&self) -> bool {
-        Entity::is_alive(self) && !self.is_baby()
-    }
-
-    /// Returns the synced vanilla `DATA_BOOST_TIME` value.
-    #[must_use]
-    pub fn boost_time_total(&self) -> i32 {
-        ItemSteerable::boost_time_total(self)
+        Entity::is_alive(self) && !AgeableMob::is_baby(self)
     }
 
     /// Returns whether item-based steering is currently boosting.
@@ -310,11 +257,6 @@ impl PigEntity {
     #[must_use]
     pub fn elapsed_boost_time(&self) -> i32 {
         self.steering.lock().boost_time()
-    }
-
-    /// Advances the active item-based steering boost.
-    pub fn tick_boost(&self) {
-        ItemSteerable::tick_boost(self);
     }
 
     /// Returns vanilla pig ridden speed.
@@ -372,54 +314,15 @@ impl Entity for PigEntity {
         self.entity_type
     }
 
-    fn base_tick(&self) {
-        Mob::base_tick_mob(self);
-    }
-
     fn dimensions_for_pose(&self, _pose: EntityPose) -> EntityDimensions {
         let scale = LivingEntity::get_scale(self);
-        if self.is_baby() {
+        if AgeableMob::is_baby(self) {
             PIG_BABY_DIMENSIONS.scale(scale)
         } else if self.entity_type.fixed {
             self.entity_type.dimensions
         } else {
             self.entity_type.dimensions.scale(scale)
         }
-    }
-
-    fn tick(&self) {
-        self.default_tick();
-        self.living_base.decrement_invulnerable_time();
-        self.tick_mob_effects();
-        self.detect_equipment_updates();
-
-        if self.is_dead_or_dying() {
-            LivingEntity::tick_death(self);
-            self.tick_living_state();
-            return;
-        }
-
-        if !self.is_removed() {
-            self.ai_step();
-        }
-
-        self.tick_living_state();
-    }
-
-    fn check_despawn(&self) {
-        Mob::check_mob_despawn(self);
-    }
-
-    fn is_alive(&self) -> bool {
-        !self.is_removed() && self.get_health() > 0.0
-    }
-
-    fn is_pickable(&self) -> bool {
-        !self.is_removed()
-    }
-
-    fn is_pushable(&self) -> bool {
-        Entity::is_alive(self) && !self.is_spectator() && !self.on_climbable()
     }
 
     fn controlling_passenger(&self) -> Option<SharedEntity> {
@@ -437,22 +340,6 @@ impl Entity for PigEntity {
         self.controlling_passenger_mob()
     }
 
-    fn is_effective_ai(&self) -> bool {
-        self.is_server_driven_movement() && !self.is_no_ai()
-    }
-
-    fn get_default_gravity(&self) -> f64 {
-        LivingEntity::get_attribute_gravity(self)
-    }
-
-    fn can_freeze(&self) -> bool {
-        self.default_living_can_freeze()
-    }
-
-    fn can_walk_on_powder_snow(&self) -> bool {
-        self.default_living_can_walk_on_powder_snow()
-    }
-
     fn synced_data(&self) -> Option<&dyn EntitySyncedData> {
         Some(&self.entity_data)
     }
@@ -461,52 +348,8 @@ impl Entity for PigEntity {
         self.update_dirty_mob_effect_entity_data();
     }
 
-    fn pack_syncable_attributes(&self) -> Vec<AttributeSnapshot> {
-        self.attributes().lock().syncable_snapshots()
-    }
-
-    fn drain_dirty_syncable_attributes(&self) -> Vec<AttributeSnapshot> {
-        self.attributes().lock().drain_dirty_sync()
-    }
-
-    fn drain_dirty_mob_effects(&self) -> Vec<MobEffectSyncChange> {
-        self.living_base.drain_dirty_mob_effects()
-    }
-
-    fn pack_all_equipment(&self) -> Vec<EquipmentSlotItem> {
-        self.pack_living_equipment()
-    }
-
-    fn drain_dirty_equipment(&self) -> Vec<EquipmentSlotItem> {
-        self.drain_dirty_living_equipment()
-    }
-
-    fn max_up_step(&self) -> f32 {
-        self.attributes()
-            .lock()
-            .get_value(vanilla_attributes::STEP_HEIGHT)
-            .unwrap_or(0.6) as f32
-    }
-
-    fn sound_source(&self) -> SoundSource {
-        SoundSource::Neutral
-    }
-
     fn play_step_sound(&self, _pos: BlockPos, _block_state: BlockStateId) {
         self.play_sound(self.current_sound_set().step_sound, 0.15, 1.0);
-    }
-
-    fn hurt(&self, world: &World, source: &DamageSource, amount: f32) -> bool {
-        LivingEntity::hurt_server(self, world, source, amount)
-    }
-
-    fn interact(
-        &self,
-        player: &Player,
-        hand: InteractionHand,
-        location: DVec3,
-    ) -> InteractionResult {
-        Mob::interact_mob(self, player, hand, location)
     }
 
     fn save_additional(&self, nbt: &mut NbtCompound) {
@@ -554,10 +397,6 @@ impl LivingEntity for PigEntity {
             .set(clamped);
     }
 
-    fn is_baby(&self) -> bool {
-        AgeableMob::is_baby(self)
-    }
-
     fn hurt_sound(&self, _source: &DamageSource) -> Option<SoundEventRef> {
         Some(self.current_sound_set().hurt_sound)
     }
@@ -578,14 +417,10 @@ impl LivingEntity for PigEntity {
         (slot == EquipmentSlot::Saddle).then_some(&sound_events::ENTITY_PIG_SADDLE)
     }
 
-    fn server_ai_step(&self) {
-        Mob::mob_server_ai_step(self);
-    }
-
     fn tick_ridden(&self, controller: &Player, _ridden_input: DVec3) {
         let (yaw, pitch) = controller.rotation();
         self.set_ridden_rotation(yaw, pitch);
-        self.tick_boost();
+        ItemSteerable::tick_boost(self);
     }
 
     fn ridden_input(&self, _controller: &Player, _self_input: DVec3) -> DVec3 {
@@ -594,18 +429,6 @@ impl LivingEntity for PigEntity {
 
     fn ridden_speed(&self, _controller: &Player) -> f32 {
         PigEntity::ridden_speed(self)
-    }
-
-    fn before_actually_hurt(&self, _source: &DamageSource, _amount: f32) {
-        Animal::reset_love(self);
-    }
-
-    fn ai_step(&self) -> Option<MoveResult> {
-        let result = self.default_ai_step();
-
-        AgeableMob::tick_ageable_mob(self);
-        Animal::tick_animal_love(self);
-        result
     }
 }
 
@@ -628,10 +451,6 @@ impl AgeableMob for PigEntity {
 
     fn set_synced_baby(&self, baby: bool) {
         self.entity_data.lock().ageable_mob_mut().baby.set(baby);
-    }
-
-    fn age_boundary_changed(&self, _baby: bool) {
-        self.refresh_dimensions();
     }
 }
 
@@ -692,24 +511,8 @@ impl Mob for PigEntity {
         &self.mob_base
     }
 
-    fn tick_goal_selectors(&self) {
-        PathfinderMob::tick_pathfinder_goal_selectors(self);
-    }
-
-    fn tick_path_navigation(&self) {
-        PathfinderMob::tick_pathfinder_path_navigation(self);
-    }
-
-    fn custom_server_ai_step(&self) {
-        Animal::custom_server_ai_step_animal(self);
-    }
-
     fn ambient_sound(&self) -> Option<SoundEventRef> {
         Some(self.current_sound_set().ambient_sound)
-    }
-
-    fn remove_when_far_away(&self, dist_sqr: f64) -> bool {
-        Animal::remove_when_far_away_animal(self, dist_sqr)
     }
 
     fn finalize_spawn(

--- a/steel-core/src/entity/entities/pig/tests/ai_age.rs
+++ b/steel-core/src/entity/entities/pig/tests/ai_age.rs
@@ -121,11 +121,11 @@ fn pig_age_updates_synchronized_baby_flag_on_boundary() {
     let pig = PigEntity::new(&vanilla_entities::PIG, 1, DVec3::ZERO, Weak::new());
 
     pig.set_age(-1);
-    assert!(pig.is_baby());
+    assert!(AgeableMob::is_baby(&pig));
     assert!(*pig.entity_data.lock().ageable_mob().baby.get());
 
     pig.set_age(0);
-    assert!(!pig.is_baby());
+    assert!(!AgeableMob::is_baby(&pig));
     assert!(!*pig.entity_data.lock().ageable_mob().baby.get());
 }
 

--- a/steel-core/src/entity/entities/pig/tests/animal_lifecycle.rs
+++ b/steel-core/src/entity/entities/pig/tests/animal_lifecycle.rs
@@ -146,7 +146,7 @@ fn pig_death_tick_removes_after_vanilla_death_duration() {
     pig.set_health(0.0);
 
     for _ in 0..DEATH_DURATION {
-        pig.tick();
+        LivingEntity::tick_living_entity(&pig);
     }
 
     assert_eq!(pig.removal_reason(), Some(RemovalReason::Killed));

--- a/steel-core/src/entity/entities/pig/tests/core.rs
+++ b/steel-core/src/entity/entities/pig/tests/core.rs
@@ -119,8 +119,11 @@ fn pig_item_steerable_boost_updates_synced_total_once() {
     let boost_time_total = pig.boost_time_total();
 
     assert!((140..=980).contains(&boost_time_total));
-    assert!(pig.is_boosting());
-    assert_eq!(pig.elapsed_boost_time(), 0);
+    {
+        let steering = pig.item_based_steering().lock();
+        assert!(steering.is_boosting());
+        assert_eq!(steering.boost_time(), 0);
+    }
     assert!(!ItemSteerable::boost(&pig));
     assert_eq!(pig.boost_time_total(), boost_time_total);
 }
@@ -129,15 +132,25 @@ fn pig_item_steerable_boost_updates_synced_total_once() {
 fn pig_ridden_speed_uses_item_steering_boost_factor() {
     init_test_registry();
 
-    let pig = PigEntity::new(&vanilla_entities::PIG, 1, DVec3::ZERO, Weak::new());
+    let world = fresh_test_world("pig_ridden_speed");
+    let pig = PigEntity::new(
+        &vanilla_entities::PIG,
+        1,
+        DVec3::ZERO,
+        Arc::downgrade(&world),
+    );
+    let controller = TestPlayerBuilder::new(world, Uuid::from_u128(2), "Controller", 2).build();
     let base_ridden_speed = 0.25_f32 * 0.225;
 
-    assert_eq!(pig.ridden_speed().to_bits(), base_ridden_speed.to_bits());
+    assert_eq!(
+        LivingEntity::ridden_speed(&pig, &controller).to_bits(),
+        base_ridden_speed.to_bits()
+    );
 
     assert!(ItemSteerable::boost(&pig));
     pig.tick_boost();
 
-    assert!(pig.ridden_speed() > base_ridden_speed);
+    assert!(LivingEntity::ridden_speed(&pig, &controller) > base_ridden_speed);
 }
 
 #[test]
@@ -270,6 +283,12 @@ fn pig_saddled_state_reads_saddle_equipment() {
 
     let pig = PigEntity::new(&vanilla_entities::PIG, 1, DVec3::ZERO, Weak::new());
 
+    assert!(!pig.is_saddled());
+
+    pig.living_base.equipment().lock().set(
+        EquipmentSlot::Saddle,
+        ItemStack::new(&vanilla_items::CARROT),
+    );
     assert!(!pig.is_saddled());
 
     pig.living_base.equipment().lock().set(

--- a/steel-core/src/entity/entities/pig/tests/mod.rs
+++ b/steel-core/src/entity/entities/pig/tests/mod.rs
@@ -5,7 +5,10 @@ use simdnbt::borrow::read_compound as read_borrowed_compound;
 use simdnbt::owned::NbtTag;
 use steel_registry::entity_type::EntityAttachment;
 use steel_registry::test_support::init_test_registry;
-use steel_registry::{vanilla_blocks, vanilla_damage_types, vanilla_entities, vanilla_items};
+use steel_registry::{
+    vanilla_blocks, vanilla_damage_types, vanilla_entities, vanilla_items,
+    vanilla_pig_sound_variants, vanilla_pig_variants,
+};
 use steel_utils::UuidExt;
 use uuid::Uuid;
 
@@ -17,7 +20,7 @@ use crate::entity::entities::LeashFenceKnotEntity;
 use crate::entity::mob::LeashAttachment;
 use crate::entity::{Animal, DEATH_DURATION, ItemSteerable, RemovalReason, SharedEntity};
 use crate::inventory::equipment::EquipmentSlot;
-use crate::test_support::test_world;
+use crate::test_support::{TestPlayerBuilder, fresh_test_world, test_world};
 use crate::world::LevelReader;
 
 use super::*;

--- a/steel-core/src/entity/entity/mod.rs
+++ b/steel-core/src/entity/entity/mod.rs
@@ -315,7 +315,8 @@ pub trait Entity: EntityEventSource + ErasedType + Send + Sync + 'static {
     /// Mirrors vanilla `Entity.isPickable`. Base entities are not pickable unless
     /// a concrete entity type opts in.
     fn is_pickable(&self) -> bool {
-        false
+        self.as_living_entity()
+            .is_some_and(|living| !living.is_removed())
     }
 
     /// Returns whether this entity can be attacked.
@@ -338,7 +339,10 @@ pub trait Entity: EntityEventSource + ErasedType + Send + Sync + 'static {
     /// Mirrors vanilla `Entity.isPushable`. Base entities are not pushable unless
     /// a concrete entity type opts in.
     fn is_pushable(&self) -> bool {
-        false
+        let Some(living) = self.as_living_entity() else {
+            return false;
+        };
+        Entity::is_alive(living) && !living.is_spectator() && !living.on_climbable()
     }
 
     /// Returns whether vanilla fluid currents can push this entity.
@@ -844,11 +848,11 @@ pub trait Entity: EntityEventSource + ErasedType + Send + Sync + 'static {
     /// Called every game tick when the entity is in a ticked chunk.
     ///
     /// Use `self.level()` to access the world for physics, block queries, etc.
-    /// The caller handles post-tick dirty data sync.
-    ///
-    /// Steel keeps the fallback empty because many vanilla subclasses override
-    /// tick without calling `super.tick()`.
-    fn tick(&self) {}
+    fn tick(&self) {
+        if let Some(living) = self.as_living_entity() {
+            living.tick_living_entity();
+        }
+    }
 
     /// Called every game tick while this entity is riding another entity.
     ///
@@ -866,7 +870,13 @@ pub trait Entity: EntityEventSource + ErasedType + Send + Sync + 'static {
     /// This intentionally stays separate from `tick()` because several vanilla
     /// subclasses override tick without calling `super.tick()`.
     fn base_tick(&self) {
-        self.entity_base_tick();
+        if let Some(mob) = self.as_mob() {
+            mob.base_tick_mob();
+        } else if let Some(living) = self.as_living_entity() {
+            living.base_tick_living_entity();
+        } else {
+            self.entity_base_tick();
+        }
     }
 
     /// Runs vanilla `Entity.handlePortal` behavior currently implemented by Steel.
@@ -968,7 +978,11 @@ pub trait Entity: EntityEventSource + ErasedType + Send + Sync + 'static {
     }
 
     /// Runs vanilla pre-tick despawn checks.
-    fn check_despawn(&self) {}
+    fn check_despawn(&self) {
+        if let Some(mob) = self.as_mob() {
+            mob.check_mob_despawn();
+        }
+    }
 
     /// Applies an inside-block effect queued by vanilla's step-based collector.
     fn apply_inside_block_effect(&self, effect_type: InsideBlockEffectType) {
@@ -1027,7 +1041,9 @@ pub trait Entity: EntityEventSource + ErasedType + Send + Sync + 'static {
     /// Mirrors vanilla `ServerEntity.sendPairingData`, which sends all syncable
     /// living attributes after the add-entity and metadata packets.
     fn pack_syncable_attributes(&self) -> Vec<AttributeSnapshot> {
-        Vec::new()
+        self.as_living_entity().map_or_else(Vec::new, |living| {
+            living.attributes().lock().syncable_snapshots()
+        })
     }
 
     /// Drains syncable dirty attributes for per-tick tracking updates.
@@ -1035,22 +1051,28 @@ pub trait Entity: EntityEventSource + ErasedType + Send + Sync + 'static {
     /// Mirrors vanilla `ServerEntity.sendDirtyEntityData`, which sends dirty
     /// living attributes after dirty entity data.
     fn drain_dirty_syncable_attributes(&self) -> Vec<AttributeSnapshot> {
-        Vec::new()
+        self.as_living_entity().map_or_else(Vec::new, |living| {
+            living.attributes().lock().drain_dirty_sync()
+        })
     }
 
     /// Drains dirty mob-effect packet changes for vanilla recipients.
     fn drain_dirty_mob_effects(&self) -> Vec<MobEffectSyncChange> {
-        Vec::new()
+        self.as_living_entity().map_or_else(Vec::new, |living| {
+            living.living_base().drain_dirty_mob_effects()
+        })
     }
 
     /// Packs non-empty equipment slots for initial spawn pairing.
     fn pack_all_equipment(&self) -> Vec<EquipmentSlotItem> {
-        Vec::new()
+        self.as_living_entity()
+            .map_or_else(Vec::new, LivingEntity::pack_living_equipment)
     }
 
     /// Drains equipment slots that changed since the last tracker sync.
     fn drain_dirty_equipment(&self) -> Vec<EquipmentSlotItem> {
-        Vec::new()
+        self.as_living_entity()
+            .map_or_else(Vec::new, LivingEntity::drain_dirty_living_equipment)
     }
 
     /// Returns true if the entity has been marked for removal.
@@ -1060,7 +1082,10 @@ pub trait Entity: EntityEventSource + ErasedType + Send + Sync + 'static {
 
     /// Returns whether this entity is alive for vanilla generic entity checks.
     fn is_alive(&self) -> bool {
-        !self.is_removed()
+        let Some(living) = self.as_living_entity() else {
+            return !self.is_removed();
+        };
+        !living.is_removed() && living.get_health() > 0.0
     }
 
     /// Marks this entity as waiting for a prepared world change.
@@ -1341,6 +1366,9 @@ pub trait Entity: EntityEventSource + ErasedType + Send + Sync + 'static {
         hand: InteractionHand,
         location: DVec3,
     ) -> InteractionResult {
+        if let Some(mob) = self.as_mob() {
+            return mob.interact_mob(player, hand, location);
+        }
         self.interact_entity(player, hand, location)
     }
 
@@ -1523,6 +1551,18 @@ pub trait Entity: EntityEventSource + ErasedType + Send + Sync + 'static {
         try_as_dyn::<Self, dyn Animal>(self)
     }
 
+    /// Returns true for entities that implement vanilla ageable-mob behavior.
+    fn is_ageable_mob(&self) -> bool {
+        self.as_ageable_mob().is_some()
+    }
+
+    /// Returns this entity as an ageable mob when it has ageable behavior.
+    ///
+    /// Mirrors vanilla's frequent `instanceof AgeableMob` branches.
+    fn as_ageable_mob(&self) -> Option<&dyn AgeableMob> {
+        try_as_dyn::<Self, dyn AgeableMob>(self)
+    }
+
     /// Returns true for entities that implement vanilla item-steered boosts.
     fn is_item_steerable(&self) -> bool {
         self.as_item_steerable().is_some()
@@ -1565,7 +1605,10 @@ pub trait Entity: EntityEventSource + ErasedType + Send + Sync + 'static {
 
     /// Returns true when vanilla allows this side to run entity AI/travel logic.
     fn is_effective_ai(&self) -> bool {
-        self.is_server_driven_movement()
+        let Some(mob) = self.as_mob() else {
+            return self.is_server_driven_movement();
+        };
+        mob.is_server_driven_movement() && !mob.is_no_ai()
     }
 
     /// Returns true when vanilla landing bounce should be suppressed.
@@ -1652,7 +1695,10 @@ pub trait Entity: EntityEventSource + ErasedType + Send + Sync + 'static {
 
     /// Returns whether this entity can walk on powder snow.
     fn can_walk_on_powder_snow(&self) -> bool {
-        self.default_can_walk_on_powder_snow()
+        self.as_living_entity().map_or_else(
+            || self.default_can_walk_on_powder_snow(),
+            LivingEntity::default_living_can_walk_on_powder_snow,
+        )
     }
 
     /// Returns whether vanilla excludes this vehicle from floating kicks.
@@ -2019,7 +2065,10 @@ pub trait Entity: EntityEventSource + ErasedType + Send + Sync + 'static {
 
     /// Returns whether this entity may accumulate frozen ticks.
     fn can_freeze(&self) -> bool {
-        self.default_can_freeze()
+        self.as_living_entity().map_or_else(
+            || self.default_can_freeze(),
+            LivingEntity::default_living_can_freeze,
+        )
     }
 
     /// Returns vanilla `getTicksRequiredToFreeze`.
@@ -3035,7 +3084,13 @@ pub trait Entity: EntityEventSource + ErasedType + Send + Sync + 'static {
 
     /// Maximum height this entity can step up during normal movement.
     fn max_up_step(&self) -> f32 {
-        0.0
+        self.as_living_entity().map_or(0.0, |living| {
+            living
+                .attributes()
+                .lock()
+                .get_value(vanilla_attributes::STEP_HEIGHT)
+                .unwrap_or(0.6) as f32
+        })
     }
 
     /// Whether movement should apply player-style sneak edge prevention.
@@ -3050,7 +3105,8 @@ pub trait Entity: EntityEventSource + ErasedType + Send + Sync + 'static {
     /// Override this to specify entity-specific gravity.
     /// Vanilla values: `ItemEntity` = 0.04, `LivingEntity` = 0.08
     fn get_default_gravity(&self) -> f64 {
-        0.0
+        self.as_living_entity()
+            .map_or(0.0, LivingEntity::get_attribute_gravity)
     }
 
     /// Returns true if gravity is disabled for this entity.
@@ -3459,18 +3515,11 @@ pub trait Entity: EntityEventSource + ErasedType + Send + Sync + 'static {
     fn load_additional(&self, _nbt: BorrowedNbtCompoundView<'_, '_>) {}
 
     /// Applies damage to this entity.
-    ///
-    /// Vanilla: `Entity.hurtServer()` — overridden by `LivingEntity` (complex
-    /// armor/effects/invulnerability logic) and `ItemEntity` (health decrement
-    /// and discard). `world` must preserve vanilla's explicit `ServerLevel`
-    /// argument rather than being inferred from the target. Default returns
-    /// `false` (entity ignores damage).
-    #[expect(
-        unused_variables,
-        reason = "default trait impl; parameters used by overrides"
-    )]
     fn hurt(&self, world: &World, source: &DamageSource, amount: f32) -> bool {
-        false
+        let Some(living) = self.as_living_entity() else {
+            return false;
+        };
+        living.hurt_server(world, source, amount)
     }
 }
 

--- a/steel-core/src/entity/entity/mod.rs
+++ b/steel-core/src/entity/entity/mod.rs
@@ -848,24 +848,28 @@ pub trait Entity: EntityEventSource + ErasedType + Send + Sync + 'static {
     /// Called every game tick when the entity is in a ticked chunk.
     ///
     /// Use `self.level()` to access the world for physics, block queries, etc.
-    /// The caller handles living-entity dispatch and post-tick dirty data sync.
+    /// The caller handles post-tick dirty data sync.
     ///
-    /// Steel keeps the fallback empty because many vanilla subclasses override
-    /// tick without calling `super.tick()`.
-    fn tick(&self) {}
+    /// The default dispatches vanilla living behavior without requiring every
+    /// living implementation to repeat an `Entity::tick` forwarding method.
+    /// Non-living entities with custom tick behavior override this directly.
+    fn tick(&self) {
+        if let Some(living) = self.as_living_entity() {
+            living.tick_living_entity();
+        }
+    }
 
     /// Called every game tick while this entity is riding another entity.
     ///
     /// Mirrors vanilla `Entity.rideTick`.
     fn ride_tick(&self) {
         self.set_velocity(DVec3::ZERO);
-        if let Some(living) = self.as_living_entity() {
-            living.tick_living_entity();
-        } else {
-            self.tick();
-        }
+        self.tick();
         if let Some(vehicle) = self.vehicle() {
             vehicle.position_rider(self.as_entity_event_source());
+        }
+        if let Some(living) = self.as_living_entity() {
+            living.reset_fall_distance();
         }
     }
 
@@ -1642,14 +1646,6 @@ pub trait Entity: EntityEventSource + ErasedType + Send + Sync + 'static {
         if let Some(synced_data) = self.synced_data() {
             synced_data.set_fall_flying(fall_flying);
         }
-    }
-
-    /// Returns vanilla `PowderSnowBlock.canEntityWalkOnPowderSnow`.
-    fn default_can_walk_on_powder_snow(&self) -> bool {
-        REGISTRY.entity_types.is_in_tag(
-            self.entity_type(),
-            &EntityTypeTag::POWDER_SNOW_WALKABLE_MOBS,
-        )
     }
 
     /// Returns whether vanilla excludes this vehicle from floating kicks.

--- a/steel-core/src/entity/entity/mod.rs
+++ b/steel-core/src/entity/entity/mod.rs
@@ -848,18 +848,22 @@ pub trait Entity: EntityEventSource + ErasedType + Send + Sync + 'static {
     /// Called every game tick when the entity is in a ticked chunk.
     ///
     /// Use `self.level()` to access the world for physics, block queries, etc.
-    fn tick(&self) {
-        if let Some(living) = self.as_living_entity() {
-            living.tick_living_entity();
-        }
-    }
+    /// The caller handles living-entity dispatch and post-tick dirty data sync.
+    ///
+    /// Steel keeps the fallback empty because many vanilla subclasses override
+    /// tick without calling `super.tick()`.
+    fn tick(&self) {}
 
     /// Called every game tick while this entity is riding another entity.
     ///
     /// Mirrors vanilla `Entity.rideTick`.
     fn ride_tick(&self) {
         self.set_velocity(DVec3::ZERO);
-        self.tick();
+        if let Some(living) = self.as_living_entity() {
+            living.tick_living_entity();
+        } else {
+            self.tick();
+        }
         if let Some(vehicle) = self.vehicle() {
             vehicle.position_rider(self.as_entity_event_source());
         }
@@ -870,13 +874,7 @@ pub trait Entity: EntityEventSource + ErasedType + Send + Sync + 'static {
     /// This intentionally stays separate from `tick()` because several vanilla
     /// subclasses override tick without calling `super.tick()`.
     fn base_tick(&self) {
-        if let Some(mob) = self.as_mob() {
-            mob.base_tick_mob();
-        } else if let Some(living) = self.as_living_entity() {
-            living.base_tick_living_entity();
-        } else {
-            self.entity_base_tick();
-        }
+        self.entity_base_tick();
     }
 
     /// Runs vanilla `Entity.handlePortal` behavior currently implemented by Steel.

--- a/steel-core/src/entity/entity/mod.rs
+++ b/steel-core/src/entity/entity/mod.rs
@@ -1036,45 +1036,6 @@ pub trait Entity: EntityEventSource + ErasedType + Send + Sync + 'static {
     /// Mirrors vanilla `Entity.updateDataBeforeSync`.
     fn update_data_before_sync(&self) {}
 
-    /// Packs syncable attributes for initial spawn pairing.
-    ///
-    /// Mirrors vanilla `ServerEntity.sendPairingData`, which sends all syncable
-    /// living attributes after the add-entity and metadata packets.
-    fn pack_syncable_attributes(&self) -> Vec<AttributeSnapshot> {
-        self.as_living_entity().map_or_else(Vec::new, |living| {
-            living.attributes().lock().syncable_snapshots()
-        })
-    }
-
-    /// Drains syncable dirty attributes for per-tick tracking updates.
-    ///
-    /// Mirrors vanilla `ServerEntity.sendDirtyEntityData`, which sends dirty
-    /// living attributes after dirty entity data.
-    fn drain_dirty_syncable_attributes(&self) -> Vec<AttributeSnapshot> {
-        self.as_living_entity().map_or_else(Vec::new, |living| {
-            living.attributes().lock().drain_dirty_sync()
-        })
-    }
-
-    /// Drains dirty mob-effect packet changes for vanilla recipients.
-    fn drain_dirty_mob_effects(&self) -> Vec<MobEffectSyncChange> {
-        self.as_living_entity().map_or_else(Vec::new, |living| {
-            living.living_base().drain_dirty_mob_effects()
-        })
-    }
-
-    /// Packs non-empty equipment slots for initial spawn pairing.
-    fn pack_all_equipment(&self) -> Vec<EquipmentSlotItem> {
-        self.as_living_entity()
-            .map_or_else(Vec::new, LivingEntity::pack_living_equipment)
-    }
-
-    /// Drains equipment slots that changed since the last tracker sync.
-    fn drain_dirty_equipment(&self) -> Vec<EquipmentSlotItem> {
-        self.as_living_entity()
-            .map_or_else(Vec::new, LivingEntity::drain_dirty_living_equipment)
-    }
-
     /// Returns true if the entity has been marked for removal.
     fn is_removed(&self) -> bool {
         self.base().is_removed()
@@ -1690,14 +1651,6 @@ pub trait Entity: EntityEventSource + ErasedType + Send + Sync + 'static {
         REGISTRY.entity_types.is_in_tag(
             self.entity_type(),
             &EntityTypeTag::POWDER_SNOW_WALKABLE_MOBS,
-        )
-    }
-
-    /// Returns whether this entity can walk on powder snow.
-    fn can_walk_on_powder_snow(&self) -> bool {
-        self.as_living_entity().map_or_else(
-            || self.default_can_walk_on_powder_snow(),
-            LivingEntity::default_living_can_walk_on_powder_snow,
         )
     }
 

--- a/steel-core/src/entity/living_entity.rs
+++ b/steel-core/src/entity/living_entity.rs
@@ -123,6 +123,37 @@ pub trait LivingEntity: Entity {
         self.living_base().attributes()
     }
 
+    /// Packs syncable attributes for initial spawn pairing.
+    ///
+    /// Mirrors vanilla `ServerEntity.sendPairingData`, which sends all syncable
+    /// living attributes after the add-entity and metadata packets.
+    fn pack_syncable_attributes(&self) -> Vec<AttributeSnapshot> {
+        self.attributes().lock().syncable_snapshots()
+    }
+
+    /// Drains syncable dirty attributes for per-tick tracking updates.
+    ///
+    /// Mirrors vanilla `ServerEntity.sendDirtyEntityData`, which sends dirty
+    /// living attributes after dirty entity data.
+    fn drain_dirty_syncable_attributes(&self) -> Vec<AttributeSnapshot> {
+        self.attributes().lock().drain_dirty_sync()
+    }
+
+    /// Drains dirty mob-effect packet changes for vanilla recipients.
+    fn drain_dirty_mob_effects(&self) -> Vec<MobEffectSyncChange> {
+        self.living_base().drain_dirty_mob_effects()
+    }
+
+    /// Packs non-empty equipment slots for initial spawn pairing.
+    fn pack_all_equipment(&self) -> Vec<EquipmentSlotItem> {
+        self.pack_living_equipment()
+    }
+
+    /// Drains equipment slots that changed since the last tracker sync.
+    fn drain_dirty_equipment(&self) -> Vec<EquipmentSlotItem> {
+        self.drain_dirty_living_equipment()
+    }
+
     /// Appends vanilla-shaped living state used by command NBT predicates.
     fn save_command_nbt(&self, nbt: &mut NbtCompound) {
         nbt.insert("Health", self.get_health());
@@ -1719,7 +1750,7 @@ pub trait LivingEntity: Entity {
     }
 
     /// Returns vanilla `PowderSnowBlock.canEntityWalkOnPowderSnow()` for living entities.
-    fn default_living_can_walk_on_powder_snow(&self) -> bool {
+    fn can_walk_on_powder_snow(&self) -> bool {
         if self.default_can_walk_on_powder_snow() {
             return true;
         }

--- a/steel-core/src/entity/living_entity.rs
+++ b/steel-core/src/entity/living_entity.rs
@@ -1764,8 +1764,7 @@ pub trait LivingEntity: Entity {
 
     /// Runs vanilla `LivingEntity.tick`.
     ///
-    /// Concrete living entities reach this through the `Entity::tick` default
-    /// routing.
+    /// Entity ticking call sites dispatch living entities here directly.
     fn tick_living_entity(&self) {
         self.default_tick();
         self.living_base().decrement_invulnerable_time();
@@ -2001,11 +2000,7 @@ pub trait LivingEntity: Entity {
     }
 
     /// Server AI hook called from vanilla `LivingEntity.aiStep()`.
-    fn server_ai_step(&self) {
-        if let Some(mob) = self.as_mob() {
-            mob.mob_server_ai_step();
-        }
-    }
+    fn server_ai_step(&self) {}
 
     /// Returns vanilla `LivingEntity.getJumpBoostPower()`.
     fn get_jump_boost_power(&self) -> f32 {
@@ -2187,14 +2182,7 @@ pub trait LivingEntity: Entity {
 
     /// Mirrors vanilla `LivingEntity.aiStep()`.
     fn ai_step(&self) -> Option<MoveResult> {
-        let result = self.default_ai_step();
-        if let Some(ageable) = self.as_ageable_mob() {
-            ageable.tick_ageable_mob();
-        }
-        if let Some(animal) = self.as_animal() {
-            animal.tick_animal_love();
-        }
-        result
+        self.default_ai_step()
     }
 
     /// Mirrors vanilla `LivingEntity.pushEntities()`.

--- a/steel-core/src/entity/living_entity.rs
+++ b/steel-core/src/entity/living_entity.rs
@@ -243,7 +243,7 @@ pub trait LivingEntity: Entity {
 
     /// Returns vanilla `LivingEntity.isBaby()`.
     fn is_baby(&self) -> bool {
-        false
+        self.as_ageable_mob().is_some_and(AgeableMob::is_baby)
     }
 
     /// Returns vanilla `LivingEntity.getSoundVolume`.
@@ -614,7 +614,11 @@ pub trait LivingEntity: Entity {
     }
 
     /// Hook before applying damage after vanilla reductions.
-    fn before_actually_hurt(&self, _source: &DamageSource, _amount: f32) {}
+    fn before_actually_hurt(&self, _source: &DamageSource, _amount: f32) {
+        if let Some(animal) = self.as_animal() {
+            animal.reset_love();
+        }
+    }
 
     /// Damages equipment that participates in vanilla armor absorption.
     fn hurt_armor(&self, _source: &DamageSource, _damage: f32) {}
@@ -1727,6 +1731,29 @@ pub trait LivingEntity: Entity {
         has_leather_boots
     }
 
+    /// Runs vanilla `LivingEntity.tick`.
+    ///
+    /// Concrete living entities reach this through the `Entity::tick` default
+    /// routing.
+    fn tick_living_entity(&self) {
+        self.default_tick();
+        self.living_base().decrement_invulnerable_time();
+        self.tick_mob_effects();
+        self.detect_equipment_updates();
+
+        if self.is_dead_or_dying() {
+            self.tick_death();
+            self.tick_living_state();
+            return;
+        }
+
+        if !self.is_removed() {
+            self.ai_step();
+        }
+
+        self.tick_living_state();
+    }
+
     /// Ticks living-entity counters after movement.
     fn tick_living_state(&self) {
         if let Some(mob) = self.as_mob() {
@@ -1943,7 +1970,11 @@ pub trait LivingEntity: Entity {
     }
 
     /// Server AI hook called from vanilla `LivingEntity.aiStep()`.
-    fn server_ai_step(&self) {}
+    fn server_ai_step(&self) {
+        if let Some(mob) = self.as_mob() {
+            mob.mob_server_ai_step();
+        }
+    }
 
     /// Returns vanilla `LivingEntity.getJumpBoostPower()`.
     fn get_jump_boost_power(&self) -> f32 {
@@ -2125,7 +2156,14 @@ pub trait LivingEntity: Entity {
 
     /// Mirrors vanilla `LivingEntity.aiStep()`.
     fn ai_step(&self) -> Option<MoveResult> {
-        self.default_ai_step()
+        let result = self.default_ai_step();
+        if let Some(ageable) = self.as_ageable_mob() {
+            ageable.tick_ageable_mob();
+        }
+        if let Some(animal) = self.as_animal() {
+            animal.tick_animal_love();
+        }
+        result
     }
 
     /// Mirrors vanilla `LivingEntity.pushEntities()`.

--- a/steel-core/src/entity/living_entity.rs
+++ b/steel-core/src/entity/living_entity.rs
@@ -1749,22 +1749,9 @@ pub trait LivingEntity: Entity {
         }
     }
 
-    /// Returns vanilla `PowderSnowBlock.canEntityWalkOnPowderSnow()` for living entities.
-    fn can_walk_on_powder_snow(&self) -> bool {
-        if self.default_can_walk_on_powder_snow() {
-            return true;
-        }
-
-        let mut has_leather_boots = false;
-        self.with_equipment_slot(EquipmentSlot::Feet, &mut |item_stack| {
-            has_leather_boots = item_stack.is(&vanilla_items::LEATHER_BOOTS);
-        });
-        has_leather_boots
-    }
-
     /// Runs vanilla `LivingEntity.tick`.
     ///
-    /// Entity ticking call sites dispatch living entities here directly.
+    /// The default `Entity::tick` dispatches living entities here.
     fn tick_living_entity(&self) {
         self.default_tick();
         self.living_base().decrement_invulnerable_time();
@@ -2346,7 +2333,9 @@ pub trait LivingEntity: Entity {
         let result = self.move_entity(MoverType::SelfMovement, self.velocity())?;
         let mut movement = self.velocity();
         if (result.horizontal_collision || self.is_jumping())
-            && (self.on_climbable() || self.was_in_powder_snow() && self.can_walk_on_powder_snow())
+            && (self.on_climbable()
+                || self.was_in_powder_snow()
+                    && PowderSnowBlock::can_entity_walk_on_powder_snow(self))
         {
             movement.y = 0.2;
         }

--- a/steel-core/src/entity/manager/mod.rs
+++ b/steel-core/src/entity/manager/mod.rs
@@ -1470,7 +1470,11 @@ impl WorldEntityManager {
     ) {
         snapshot_old_pos_and_rot_for_tick(entity.as_ref());
         entity.advance_tick_count();
-        entity.tick();
+        if let Some(living) = entity.as_living_entity() {
+            living.tick_living_entity();
+        } else {
+            entity.tick();
+        }
         self.mark_dirty_after_tick(entity, dirty_chunks);
         self.tick_vehicle_passengers_with_ticked(entity.as_ref(), ticked_entities, dirty_chunks);
     }

--- a/steel-core/src/entity/manager/mod.rs
+++ b/steel-core/src/entity/manager/mod.rs
@@ -1470,11 +1470,7 @@ impl WorldEntityManager {
     ) {
         snapshot_old_pos_and_rot_for_tick(entity.as_ref());
         entity.advance_tick_count();
-        if let Some(living) = entity.as_living_entity() {
-            living.tick_living_entity();
-        } else {
-            entity.tick();
-        }
+        entity.tick();
         self.mark_dirty_after_tick(entity, dirty_chunks);
         self.tick_vehicle_passengers_with_ticked(entity.as_ref(), ticked_entities, dirty_chunks);
     }

--- a/steel-core/src/entity/mob/mod.rs
+++ b/steel-core/src/entity/mob/mod.rs
@@ -336,6 +336,15 @@ pub trait Mob: LivingEntity {
 
     fn set_mob_flags(&self, flags: i8);
 
+    /// Returns vanilla `Mob.isSaddled`.
+    fn is_saddled(&self) -> bool {
+        let mut is_saddled = false;
+        self.with_equipment_slot(EquipmentSlot::Saddle, &mut |item_stack| {
+            is_saddled = self.is_equippable_in_slot(item_stack, EquipmentSlot::Saddle);
+        });
+        is_saddled
+    }
+
     fn custom_server_ai_step(&self) {
         if let Some(animal) = self.as_animal() {
             animal.custom_server_ai_step_animal();

--- a/steel-core/src/entity/mob/mod.rs
+++ b/steel-core/src/entity/mob/mod.rs
@@ -336,9 +336,27 @@ pub trait Mob: LivingEntity {
 
     fn set_mob_flags(&self, flags: i8);
 
-    fn custom_server_ai_step(&self) {}
+    fn custom_server_ai_step(&self) {
+        if let Some(animal) = self.as_animal() {
+            animal.custom_server_ai_step_animal();
+        }
+    }
 
-    fn tick_goal_selectors(&self) {}
+    fn tick_goal_selectors(&self) {
+        let Some(pathfinder) = self.as_pathfinder_mob() else {
+            return;
+        };
+        let id_based_tick_count = self.tick_count().wrapping_add(self.id());
+        let mut target_selector = self.mob_base().target_selector().lock();
+        let mut goal_selector = self.mob_base().goal_selector().lock();
+        if id_based_tick_count % 2 != 0 && self.tick_count() > 1 {
+            target_selector.tick_running_goals(pathfinder, false);
+            goal_selector.tick_running_goals(pathfinder, false);
+        } else {
+            target_selector.tick(pathfinder);
+            goal_selector.tick(pathfinder);
+        }
+    }
 
     fn xp_reward(&self) -> i32 {
         self.mob_base().xp_reward()
@@ -526,8 +544,9 @@ pub trait Mob: LivingEntity {
         // TODO: Apply USE_REMAINDER components once item use-remainder support exists.
     }
 
-    fn remove_when_far_away(&self, _dist_sqr: f64) -> bool {
-        true
+    fn remove_when_far_away(&self, dist_sqr: f64) -> bool {
+        self.as_animal()
+            .is_none_or(|animal| animal.remove_when_far_away_animal(dist_sqr))
     }
 
     fn requires_custom_persistence(&self) -> bool {
@@ -1370,6 +1389,11 @@ pub trait Mob: LivingEntity {
     }
 
     fn tick_path_navigation(&self) {
+        if let Some(pathfinder) = self.as_pathfinder_mob() {
+            pathfinder.tick_pathfinder_path_navigation();
+            return;
+        }
+
         let Some(world) = self.level() else {
             return;
         };

--- a/steel-core/src/entity/mob/mod.rs
+++ b/steel-core/src/entity/mob/mod.rs
@@ -345,27 +345,9 @@ pub trait Mob: LivingEntity {
         is_saddled
     }
 
-    fn custom_server_ai_step(&self) {
-        if let Some(animal) = self.as_animal() {
-            animal.custom_server_ai_step_animal();
-        }
-    }
+    fn custom_server_ai_step(&self) {}
 
-    fn tick_goal_selectors(&self) {
-        let Some(pathfinder) = self.as_pathfinder_mob() else {
-            return;
-        };
-        let id_based_tick_count = self.tick_count().wrapping_add(self.id());
-        let mut target_selector = self.mob_base().target_selector().lock();
-        let mut goal_selector = self.mob_base().goal_selector().lock();
-        if id_based_tick_count % 2 != 0 && self.tick_count() > 1 {
-            target_selector.tick_running_goals(pathfinder, false);
-            goal_selector.tick_running_goals(pathfinder, false);
-        } else {
-            target_selector.tick(pathfinder);
-            goal_selector.tick(pathfinder);
-        }
-    }
+    fn tick_goal_selectors(&self) {}
 
     fn xp_reward(&self) -> i32 {
         self.mob_base().xp_reward()
@@ -1398,11 +1380,6 @@ pub trait Mob: LivingEntity {
     }
 
     fn tick_path_navigation(&self) {
-        if let Some(pathfinder) = self.as_pathfinder_mob() {
-            pathfinder.tick_pathfinder_path_navigation();
-            return;
-        }
-
         let Some(world) = self.level() else {
             return;
         };

--- a/steel-core/src/entity/mob/pathfinder.rs
+++ b/steel-core/src/entity/mob/pathfinder.rs
@@ -154,26 +154,6 @@ pub trait PathfinderMob: Mob {
         tick_path_navigation_target(self, &world, game_time, self.can_update_path());
     }
 
-    fn tick_pathfinder_goal_selectors(&self)
-    where
-        Self: Sized,
-    {
-        let id_based_tick_count = self.tick_count().wrapping_add(self.id());
-        if id_based_tick_count % 2 != 0 && self.tick_count() > 1 {
-            self.mob_base()
-                .target_selector()
-                .lock()
-                .tick_running_goals(self, false);
-            self.mob_base()
-                .goal_selector()
-                .lock()
-                .tick_running_goals(self, false);
-        } else {
-            self.mob_base().target_selector().lock().tick(self);
-            self.mob_base().goal_selector().lock().tick(self);
-        }
-    }
-
     fn is_stable_destination(&self, pos: BlockPos) -> bool {
         self.level()
             .is_some_and(|world| world.get_block_state(pos.below()).is_solid_render())

--- a/steel-core/src/entity/mob/pathfinder.rs
+++ b/steel-core/src/entity/mob/pathfinder.rs
@@ -154,6 +154,22 @@ pub trait PathfinderMob: Mob {
         tick_path_navigation_target(self, &world, game_time, self.can_update_path());
     }
 
+    fn tick_pathfinder_goal_selectors(&self)
+    where
+        Self: Sized,
+    {
+        let id_based_tick_count = self.tick_count().wrapping_add(self.id());
+        let mut target_selector = self.mob_base().target_selector().lock();
+        let mut goal_selector = self.mob_base().goal_selector().lock();
+        if id_based_tick_count % 2 != 0 && self.tick_count() > 1 {
+            target_selector.tick_running_goals(self, false);
+            goal_selector.tick_running_goals(self, false);
+        } else {
+            target_selector.tick(self);
+            goal_selector.tick(self);
+        }
+    }
+
     fn is_stable_destination(&self, pos: BlockPos) -> bool {
         self.level()
             .is_some_and(|world| world.get_block_state(pos.below()).is_solid_render())

--- a/steel-core/src/entity/mod.rs
+++ b/steel-core/src/entity/mod.rs
@@ -60,7 +60,7 @@ use uuid::Uuid;
 
 use crate::behavior::{
     BLOCK_BEHAVIORS, BlockCollisionContext, EntityFallOnContext, EntityLandingContext,
-    FLUID_BEHAVIORS, InteractionResult,
+    FLUID_BEHAVIORS, InteractionResult, blocks::PowderSnowBlock,
 };
 use crate::chunk_saver::ChunkStorage;
 use crate::entity::attribute::{AttributeMap, AttributeModifier, AttributeModifierOperation};
@@ -458,15 +458,11 @@ fn collided_with_fluid(
 }
 
 fn physics_state_for_move(entity: &dyn Entity) -> EntityPhysicsState {
-    let can_walk_on_powder_snow = entity.as_living_entity().map_or_else(
-        || entity.default_can_walk_on_powder_snow(),
-        LivingEntity::can_walk_on_powder_snow,
-    );
     entity.base().physics_state(base::EntityPhysicsStateInput {
         max_up_step: entity.max_up_step(),
         backs_off_from_edge: entity.backs_off_from_edge(),
         descending: entity.is_descending(),
-        can_walk_on_powder_snow,
+        can_walk_on_powder_snow: PowderSnowBlock::can_entity_walk_on_powder_snow(entity),
         is_falling_block: entity.entity_type() == &vanilla_entities::FALLING_BLOCK,
     })
 }

--- a/steel-core/src/entity/mod.rs
+++ b/steel-core/src/entity/mod.rs
@@ -458,11 +458,15 @@ fn collided_with_fluid(
 }
 
 fn physics_state_for_move(entity: &dyn Entity) -> EntityPhysicsState {
+    let can_walk_on_powder_snow = entity.as_living_entity().map_or_else(
+        || entity.default_can_walk_on_powder_snow(),
+        LivingEntity::can_walk_on_powder_snow,
+    );
     entity.base().physics_state(base::EntityPhysicsStateInput {
         max_up_step: entity.max_up_step(),
         backs_off_from_edge: entity.backs_off_from_edge(),
         descending: entity.is_descending(),
-        can_walk_on_powder_snow: entity.can_walk_on_powder_snow(),
+        can_walk_on_powder_snow,
         is_falling_block: entity.entity_type() == &vanilla_entities::FALLING_BLOCK,
     })
 }

--- a/steel-core/src/entity/tests/equipment_and_freezing.rs
+++ b/steel-core/src/entity/tests/equipment_and_freezing.rs
@@ -237,14 +237,14 @@ fn living_powder_snow_walkability_uses_feet_equipment() {
     init_test_registry();
     let entity = LivingFluidTestEntity::new(0.0, 0.0, true);
 
-    assert!(!entity.default_living_can_walk_on_powder_snow());
+    assert!(!entity.can_walk_on_powder_snow());
 
     entity.equip(
         EquipmentSlot::Feet,
         ItemStack::new(&vanilla_items::LEATHER_BOOTS),
     );
 
-    assert!(entity.default_living_can_walk_on_powder_snow());
+    assert!(entity.can_walk_on_powder_snow());
 }
 
 #[test]
@@ -256,7 +256,7 @@ fn living_powder_snow_walkability_ignores_non_feet_equipment() {
         ItemStack::new(&vanilla_items::LEATHER_BOOTS),
     );
 
-    assert!(!entity.default_living_can_walk_on_powder_snow());
+    assert!(!entity.can_walk_on_powder_snow());
 }
 
 #[test]

--- a/steel-core/src/entity/tests/equipment_and_freezing.rs
+++ b/steel-core/src/entity/tests/equipment_and_freezing.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::behavior::blocks::PowderSnowBlock;
 
 #[test]
 fn can_glide_using_matches_vanilla_component_gate() {
@@ -237,14 +238,14 @@ fn living_powder_snow_walkability_uses_feet_equipment() {
     init_test_registry();
     let entity = LivingFluidTestEntity::new(0.0, 0.0, true);
 
-    assert!(!entity.can_walk_on_powder_snow());
+    assert!(!PowderSnowBlock::can_entity_walk_on_powder_snow(&entity));
 
     entity.equip(
         EquipmentSlot::Feet,
         ItemStack::new(&vanilla_items::LEATHER_BOOTS),
     );
 
-    assert!(entity.can_walk_on_powder_snow());
+    assert!(PowderSnowBlock::can_entity_walk_on_powder_snow(&entity));
 }
 
 #[test]
@@ -256,7 +257,7 @@ fn living_powder_snow_walkability_ignores_non_feet_equipment() {
         ItemStack::new(&vanilla_items::LEATHER_BOOTS),
     );
 
-    assert!(!entity.can_walk_on_powder_snow());
+    assert!(!PowderSnowBlock::can_entity_walk_on_powder_snow(&entity));
 }
 
 #[test]

--- a/steel-core/src/entity/tests/living_state.rs
+++ b/steel-core/src/entity/tests/living_state.rs
@@ -1,6 +1,18 @@
 use super::*;
 
 #[test]
+fn default_entity_tick_dispatches_living_tick() {
+    init_test_registry();
+
+    let entity = LivingFluidTestEntity::new(0.0, 0.0, true).with_health(0.0);
+    let entity_ref: &dyn Entity = &entity;
+
+    entity_ref.tick();
+
+    assert_eq!(entity.living_base().death_time(), 1);
+}
+
+#[test]
 fn living_tick_state_decrements_last_hurt_by_player_memory() {
     init_test_registry();
 

--- a/steel-core/src/entity/tests/riding_and_leashes.rs
+++ b/steel-core/src/entity/tests/riding_and_leashes.rs
@@ -1,6 +1,19 @@
 use super::*;
 
 #[test]
+fn living_ride_tick_resets_fall_distance() {
+    init_test_registry();
+
+    let entity = LivingFluidTestEntity::new(0.0, 0.0, true);
+    entity.set_fall_distance(7.0);
+    let entity_ref: &dyn Entity = &entity;
+
+    entity_ref.ride_tick();
+
+    assert_f64_close(entity.fall_distance(), 0.0);
+}
+
+#[test]
 fn default_below_world_hook_discards_entity() {
     let entity = PushableTestEntity::shared(1, DVec3::ZERO);
 

--- a/steel-core/src/entity/tracker/mod.rs
+++ b/steel-core/src/entity/tracker/mod.rs
@@ -420,38 +420,40 @@ impl EntityTracker {
             if let Some(dirty_entity_data) = dirty_entity_data {
                 entity_data_to_broadcast.push((entity_id, dirty_entity_data));
             }
-            let dirty_attributes = entity.drain_dirty_syncable_attributes();
-            if !dirty_attributes.is_empty() {
-                attributes_to_broadcast.push((entity_id, dirty_attributes));
-            }
-            let dirty_mob_effects = entity.drain_dirty_mob_effects();
-            if !dirty_mob_effects.is_empty() {
-                let mut recipient_ids = FxHashSet::default();
-                if entity.entity_type() == &vanilla_entities::PLAYER
-                    && get_player(entity_id).is_some()
-                {
-                    recipient_ids.insert(entity_id);
+            if let Some(living) = entity.as_living_entity() {
+                let dirty_attributes = living.drain_dirty_syncable_attributes();
+                if !dirty_attributes.is_empty() {
+                    attributes_to_broadcast.push((entity_id, dirty_attributes));
                 }
-                for passenger in entity.passengers() {
-                    let passenger_id = passenger.id();
-                    if passenger.entity_type() == &vanilla_entities::PLAYER
-                        && get_player(passenger_id).is_some()
+                let dirty_mob_effects = living.drain_dirty_mob_effects();
+                if !dirty_mob_effects.is_empty() {
+                    let mut recipient_ids = FxHashSet::default();
+                    if entity.entity_type() == &vanilla_entities::PLAYER
+                        && get_player(entity_id).is_some()
                     {
-                        recipient_ids.insert(passenger_id);
+                        recipient_ids.insert(entity_id);
+                    }
+                    for passenger in entity.passengers() {
+                        let passenger_id = passenger.id();
+                        if passenger.entity_type() == &vanilla_entities::PLAYER
+                            && get_player(passenger_id).is_some()
+                        {
+                            recipient_ids.insert(passenger_id);
+                        }
+                    }
+                    for recipient_id in recipient_ids {
+                        for change in &dirty_mob_effects {
+                            mob_effect_packets_to_send.push((
+                                recipient_id,
+                                change.packet(entity_id, recipient_id == entity_id),
+                            ));
+                        }
                     }
                 }
-                for recipient_id in recipient_ids {
-                    for change in &dirty_mob_effects {
-                        mob_effect_packets_to_send.push((
-                            recipient_id,
-                            change.packet(entity_id, recipient_id == entity_id),
-                        ));
-                    }
+                let dirty_equipment = living.drain_dirty_equipment();
+                if !dirty_equipment.is_empty() {
+                    equipment_to_broadcast.push((entity_id, dirty_equipment));
                 }
-            }
-            let dirty_equipment = entity.drain_dirty_equipment();
-            if !dirty_equipment.is_empty() {
-                equipment_to_broadcast.push((entity_id, dirty_equipment));
             }
 
             let leash_holder_id = leash_holder_id(entity.as_ref());
@@ -863,6 +865,16 @@ impl EntitySpawnPairing {
         let y_rot = to_angle_byte(yaw);
         let head_y_rot = to_angle_byte(head_yaw);
 
+        let (attributes, equipment) = entity.as_living_entity().map_or_else(
+            || (Vec::new(), Vec::new()),
+            |living| {
+                (
+                    living.pack_syncable_attributes(),
+                    living.pack_all_equipment(),
+                )
+            },
+        );
+
         Self {
             spawn_packet: CAddEntity {
                 id: entity.id(),
@@ -876,8 +888,8 @@ impl EntitySpawnPairing {
                 data: entity.spawn_data(),
             },
             entity_data: entity.pack_all_entity_data(),
-            attributes: entity.pack_syncable_attributes(),
-            equipment: entity.pack_all_equipment(),
+            attributes,
+            equipment,
             passenger_packets,
             entity_link_packet: leash_holder_id(entity.as_ref())
                 .map(|holder_id| CSetEntityLink::new(entity.id(), holder_id)),

--- a/steel-core/src/entity/tracker/tests/mod.rs
+++ b/steel-core/src/entity/tracker/tests/mod.rs
@@ -10,7 +10,7 @@ use steel_utils::BlockPos;
 
 use super::*;
 use crate::entity::{
-    EntityBase, Mob,
+    EntityBase, LivingEntity, LivingEntityBase, Mob,
     entities::{LeashFenceKnotEntity, PigEntity},
 };
 use crate::inventory::equipment::EquipmentSlot;
@@ -18,6 +18,7 @@ use crate::inventory::equipment::EquipmentSlot;
 struct PairingTestEntity {
     base: EntityBase,
     entity_type: EntityTypeRef,
+    living_base: LivingEntityBase,
     attributes: Vec<AttributeSnapshot>,
     dirty_attributes: SyncMutex<Vec<AttributeSnapshot>>,
     equipment: SyncMutex<Vec<EquipmentSlotItem>>,
@@ -39,6 +40,7 @@ impl PairingTestEntity {
         Arc::new(Self {
             base: EntityBase::new(id, DVec3::ZERO, entity_type.dimensions, Weak::new()),
             entity_type,
+            living_base: LivingEntityBase::new(&vanilla_entities::PIG),
             attributes,
             dirty_attributes: SyncMutex::new(Vec::new()),
             equipment: SyncMutex::new(Vec::new()),
@@ -88,22 +90,6 @@ impl Entity for PairingTestEntity {
         self.entity_type
     }
 
-    fn pack_syncable_attributes(&self) -> Vec<AttributeSnapshot> {
-        self.attributes.clone()
-    }
-
-    fn drain_dirty_syncable_attributes(&self) -> Vec<AttributeSnapshot> {
-        mem::take(&mut *self.dirty_attributes.lock())
-    }
-
-    fn pack_all_equipment(&self) -> Vec<EquipmentSlotItem> {
-        self.equipment.lock().clone()
-    }
-
-    fn drain_dirty_equipment(&self) -> Vec<EquipmentSlotItem> {
-        mem::take(&mut *self.dirty_equipment.lock())
-    }
-
     fn vehicle(&self) -> Option<SharedEntity> {
         self.vehicle.lock().as_ref().and_then(Weak::upgrade)
     }
@@ -118,6 +104,34 @@ impl Entity for PairingTestEntity {
             true
         });
         live_passengers
+    }
+}
+
+impl LivingEntity for PairingTestEntity {
+    fn living_base(&self) -> &LivingEntityBase {
+        &self.living_base
+    }
+
+    fn get_health(&self) -> f32 {
+        20.0
+    }
+
+    fn set_health(&self, _health: f32) {}
+
+    fn pack_syncable_attributes(&self) -> Vec<AttributeSnapshot> {
+        self.attributes.clone()
+    }
+
+    fn drain_dirty_syncable_attributes(&self) -> Vec<AttributeSnapshot> {
+        mem::take(&mut *self.dirty_attributes.lock())
+    }
+
+    fn pack_all_equipment(&self) -> Vec<EquipmentSlotItem> {
+        self.equipment.lock().clone()
+    }
+
+    fn drain_dirty_equipment(&self) -> Vec<EquipmentSlotItem> {
+        mem::take(&mut *self.dirty_equipment.lock())
     }
 }
 

--- a/steel-core/src/physics/collision.rs
+++ b/steel-core/src/physics/collision.rs
@@ -6,8 +6,10 @@ use glam::DVec3;
 use steel_registry::{blocks::block_state_ext::BlockStateExt, vanilla_blocks, vanilla_entities};
 use steel_utils::{BlockLocalAabb, BlockPos, BlockStateId, WorldAabb};
 
-use crate::behavior::{BLOCK_BEHAVIORS, BlockCollisionBoxes, BlockCollisionContext};
-use crate::entity::{Entity, LivingEntity};
+use crate::behavior::{
+    BLOCK_BEHAVIORS, BlockCollisionBoxes, BlockCollisionContext, blocks::PowderSnowBlock,
+};
+use crate::entity::Entity;
 use crate::physics::COLLISION_EPSILON;
 use crate::physics::shapes::join_is_not_empty;
 use crate::world::World;
@@ -267,13 +269,11 @@ impl<'a> WorldCollisionProvider<'a> {
         };
 
         if let Some(source) = self.source {
-            let can_walk_on_powder_snow = source.as_living_entity().map_or_else(
-                || source.default_can_walk_on_powder_snow(),
-                LivingEntity::can_walk_on_powder_snow,
-            );
             context
                 .with_fall_distance(source.fall_distance())
-                .with_can_walk_on_powder_snow(can_walk_on_powder_snow)
+                .with_can_walk_on_powder_snow(PowderSnowBlock::can_entity_walk_on_powder_snow(
+                    source,
+                ))
                 .with_falling_block(source.entity_type() == &vanilla_entities::FALLING_BLOCK)
         } else {
             context

--- a/steel-core/src/physics/collision.rs
+++ b/steel-core/src/physics/collision.rs
@@ -7,7 +7,7 @@ use steel_registry::{blocks::block_state_ext::BlockStateExt, vanilla_blocks, van
 use steel_utils::{BlockLocalAabb, BlockPos, BlockStateId, WorldAabb};
 
 use crate::behavior::{BLOCK_BEHAVIORS, BlockCollisionBoxes, BlockCollisionContext};
-use crate::entity::Entity;
+use crate::entity::{Entity, LivingEntity};
 use crate::physics::COLLISION_EPSILON;
 use crate::physics::shapes::join_is_not_empty;
 use crate::world::World;
@@ -267,9 +267,13 @@ impl<'a> WorldCollisionProvider<'a> {
         };
 
         if let Some(source) = self.source {
+            let can_walk_on_powder_snow = source.as_living_entity().map_or_else(
+                || source.default_can_walk_on_powder_snow(),
+                LivingEntity::can_walk_on_powder_snow,
+            );
             context
                 .with_fall_distance(source.fall_distance())
-                .with_can_walk_on_powder_snow(source.can_walk_on_powder_snow())
+                .with_can_walk_on_powder_snow(can_walk_on_powder_snow)
                 .with_falling_block(source.entity_type() == &vanilla_entities::FALLING_BLOCK)
         } else {
             context

--- a/steel-core/src/player/entity_state.rs
+++ b/steel-core/src/player/entity_state.rs
@@ -7,7 +7,7 @@ use steel_registry::entity_type::{EntityAttachmentPoint, EntityAttachments, Enti
 use steel_utils::WorldAabb;
 use steel_utils::types::GameType;
 
-use crate::behavior::BlockCollisionContext;
+use crate::behavior::{BlockCollisionContext, blocks::PowderSnowBlock};
 use crate::entity::{Entity, EntitySyncedData, LivingEntity};
 use crate::physics::{CollisionWorld, WorldCollisionProvider};
 use crate::player::Player;
@@ -103,7 +103,9 @@ impl Player {
                 .bounding_box_for_pose(pose)
                 .deflate(POSE_COLLISION_EPSILON),
             BlockCollisionContext::entity(self.position().y, self.is_descending())
-                .with_can_walk_on_powder_snow(self.can_walk_on_powder_snow()),
+                .with_can_walk_on_powder_snow(PowderSnowBlock::can_entity_walk_on_powder_snow(
+                    self,
+                )),
         )
     }
 

--- a/steel-core/src/player/game_mode/player_methods.rs
+++ b/steel-core/src/player/game_mode/player_methods.rs
@@ -6,6 +6,7 @@ use super::{
     LivingEntity, Player, SSpectatorAction, WorldAabb, WorldCollisionProvider,
     player_can_change_difficulty, shapes, vanilla_attributes,
 };
+use crate::behavior::blocks::PowderSnowBlock;
 
 impl Player {
     /// Sets the player's game mode and notifies the client.
@@ -79,7 +80,9 @@ impl Player {
         let collision_context =
             BlockCollisionContext::entity(self.position().y, self.is_descending())
                 .with_fall_distance(self.fall_distance())
-                .with_can_walk_on_powder_snow(self.can_walk_on_powder_snow());
+                .with_can_walk_on_powder_snow(PowderSnowBlock::can_entity_walk_on_powder_snow(
+                    self,
+                ));
 
         if collision_world.has_collision_with_context(&bounding_box, collision_context) {
             return false;

--- a/steel-core/src/player/mod.rs
+++ b/steel-core/src/player/mod.rs
@@ -1192,10 +1192,6 @@ impl Entity for Player {
         }
     }
 
-    fn tick(&self) {
-        Player::tick(self);
-    }
-
     fn fall_sounds(&self) -> (SoundEventRef, SoundEventRef) {
         (
             &sound_events::ENTITY_PLAYER_SMALL_FALL,
@@ -1432,6 +1428,10 @@ const fn protocol_look_at_anchor(anchor: EntityAnchor) -> LookAtAnchor {
 }
 
 impl LivingEntity for Player {
+    fn tick_living_entity(&self) {
+        Player::tick(self);
+    }
+
     fn get_health(&self) -> f32 {
         *self.entity_data.lock().living_entity().health.get()
     }

--- a/steel-core/src/player/mod.rs
+++ b/steel-core/src/player/mod.rs
@@ -46,9 +46,8 @@ pub use profile::{
 use simdnbt::owned::{NbtCompound, NbtList, NbtTag};
 use std::sync::{Arc, Weak};
 use steel_protocol::packets::game::{
-    AttributeSnapshot, CEntityEvent, CPlayerCombatKill, CPlayerLookAt, CRespawn,
-    CSetDefaultSpawnPosition, CSetHealth, CSetHeldSlot, CSetPassengers, ClientCommandAction,
-    EquipmentSlotItem, LookAtAnchor, RelativeMovement, SoundSource,
+    CEntityEvent, CPlayerCombatKill, CPlayerLookAt, CRespawn, CSetDefaultSpawnPosition, CSetHealth,
+    CSetHeldSlot, CSetPassengers, ClientCommandAction, LookAtAnchor, RelativeMovement, SoundSource,
 };
 use steel_protocol::packets::game::{CLevelEvent, CSetEntityData, CSetExperience};
 use steel_registry::blocks::block_state_ext::BlockStateExt as _;
@@ -1334,26 +1333,6 @@ impl Entity for Player {
         self.update_dirty_mob_effect_entity_data();
     }
 
-    fn pack_syncable_attributes(&self) -> Vec<AttributeSnapshot> {
-        self.attributes().lock().syncable_snapshots()
-    }
-
-    fn drain_dirty_syncable_attributes(&self) -> Vec<AttributeSnapshot> {
-        self.attributes().lock().drain_dirty_sync()
-    }
-
-    fn drain_dirty_mob_effects(&self) -> Vec<MobEffectSyncChange> {
-        self.living_base.drain_dirty_mob_effects()
-    }
-
-    fn pack_all_equipment(&self) -> Vec<EquipmentSlotItem> {
-        self.pack_living_equipment()
-    }
-
-    fn drain_dirty_equipment(&self) -> Vec<EquipmentSlotItem> {
-        self.drain_dirty_living_equipment()
-    }
-
     fn max_up_step(&self) -> f32 {
         self.attributes()
             .lock()
@@ -1371,10 +1350,6 @@ impl Entity for Player {
 
     fn is_crouching(&self) -> bool {
         Player::is_crouching(self)
-    }
-
-    fn can_walk_on_powder_snow(&self) -> bool {
-        self.default_living_can_walk_on_powder_snow()
     }
 
     fn may_interact(&self, world: &World, pos: BlockPos) -> bool {

--- a/steel-core/src/player/tests.rs
+++ b/steel-core/src/player/tests.rs
@@ -719,7 +719,7 @@ fn equipping_player_target_uses_inventory_equipment_storage() {
     );
     LivingEntity::detect_equipment_updates(target.as_ref());
     assert_eq!(
-        Entity::drain_dirty_equipment(target.as_ref()),
+        LivingEntity::drain_dirty_equipment(target.as_ref()),
         vec![EquipmentSlotItem {
             slot: EquipmentSlot::Head,
             item_stack: helmet,
@@ -762,14 +762,14 @@ fn living_tick_detects_raw_inventory_equipment_mutation() {
         );
     }
     assert_eq!(
-        Entity::drain_dirty_equipment(player.as_ref()),
+        LivingEntity::drain_dirty_equipment(player.as_ref()),
         vec![EquipmentSlotItem {
             slot: EquipmentSlot::Head,
             item_stack: ItemStack::new(&vanilla_items::DIAMOND_HELMET),
         }]
     );
     LivingEntity::detect_equipment_updates(player.as_ref());
-    assert!(Entity::drain_dirty_equipment(player.as_ref()).is_empty());
+    assert!(LivingEntity::drain_dirty_equipment(player.as_ref()).is_empty());
 }
 
 #[test]
@@ -791,7 +791,7 @@ fn death_respawn_redetects_unchanged_kept_equipment() {
 
     LivingEntity::detect_equipment_updates(player.as_ref());
     assert_eq!(
-        Entity::drain_dirty_equipment(player.as_ref()),
+        LivingEntity::drain_dirty_equipment(player.as_ref()),
         vec![EquipmentSlotItem {
             slot: EquipmentSlot::Head,
             item_stack: helmet.clone(),
@@ -831,7 +831,7 @@ fn death_respawn_redetects_unchanged_kept_equipment() {
         );
     }
     assert_eq!(
-        Entity::drain_dirty_equipment(player.as_ref()),
+        LivingEntity::drain_dirty_equipment(player.as_ref()),
         vec![EquipmentSlotItem {
             slot: EquipmentSlot::Head,
             item_stack: helmet,
@@ -839,7 +839,7 @@ fn death_respawn_redetects_unchanged_kept_equipment() {
     );
 
     LivingEntity::detect_equipment_updates(player.as_ref());
-    assert!(Entity::drain_dirty_equipment(player.as_ref()).is_empty());
+    assert!(LivingEntity::drain_dirty_equipment(player.as_ref()).is_empty());
 }
 
 #[test]
@@ -860,7 +860,7 @@ fn death_respawn_discards_stale_pending_equipment_change() {
     LivingEntity::detect_equipment_updates(player.as_ref());
 
     assert!(
-        Entity::drain_dirty_equipment(player.as_ref()).is_empty(),
+        LivingEntity::drain_dirty_equipment(player.as_ref()).is_empty(),
         "respawn must not emit equipment queued by the removed living entity"
     );
 }
@@ -877,7 +877,7 @@ fn equipment_detection_tracks_selected_main_hand() {
 
     LivingEntity::detect_equipment_updates(player.as_ref());
     assert_eq!(
-        Entity::drain_dirty_equipment(player.as_ref()),
+        LivingEntity::drain_dirty_equipment(player.as_ref()),
         vec![EquipmentSlotItem {
             slot: EquipmentSlot::MainHand,
             item_stack: ItemStack::new(&vanilla_items::STICK),
@@ -887,7 +887,7 @@ fn equipment_detection_tracks_selected_main_hand() {
     player.inventory.lock().set_selected_slot(1);
     LivingEntity::detect_equipment_updates(player.as_ref());
     assert_eq!(
-        Entity::drain_dirty_equipment(player.as_ref()),
+        LivingEntity::drain_dirty_equipment(player.as_ref()),
         vec![EquipmentSlotItem {
             slot: EquipmentSlot::MainHand,
             item_stack: ItemStack::new(&vanilla_items::OAK_LOG),
@@ -905,13 +905,13 @@ fn equipment_detection_suppresses_exact_hand_swap_packet() {
         inventory.set_offhand_item(ItemStack::new(&vanilla_items::SHIELD));
     }
     LivingEntity::detect_equipment_updates(player.as_ref());
-    let initial = Entity::drain_dirty_equipment(player.as_ref());
+    let initial = LivingEntity::drain_dirty_equipment(player.as_ref());
     assert_eq!(initial.len(), 2);
 
     assert!(player.inventory.lock().swap_hands());
     LivingEntity::detect_equipment_updates(player.as_ref());
 
-    assert!(Entity::drain_dirty_equipment(player.as_ref()).is_empty());
+    assert!(LivingEntity::drain_dirty_equipment(player.as_ref()).is_empty());
 }
 
 #[test]
@@ -931,7 +931,7 @@ fn equipment_detection_coalesces_before_tracker_drain() {
     LivingEntity::detect_equipment_updates(player.as_ref());
 
     assert_eq!(
-        Entity::drain_dirty_equipment(player.as_ref()),
+        LivingEntity::drain_dirty_equipment(player.as_ref()),
         vec![EquipmentSlotItem {
             slot: EquipmentSlot::Head,
             item_stack: ItemStack::new(&vanilla_items::DIAMOND_HELMET),

--- a/steel-registry/build/entity_data.rs
+++ b/steel-registry/build/entity_data.rs
@@ -5,7 +5,6 @@
 
 use std::fs;
 
-use crate::generator_functions::vanilla_variant_id;
 use heck::{ToShoutySnakeCase, ToSnakeCase, ToUpperCamelCase};
 use proc_macro2::{Ident, Literal, Span, TokenStream};
 use quote::quote;
@@ -87,52 +86,91 @@ struct LayerDefinition {
     fields: Vec<SynchedDataEntry>,
 }
 
-/// Maps a serializer name to (Rust type, `EntityData` variant, vanilla serializer ID).
-fn serializer_info(serializer: &str) -> Option<(&'static str, &'static str, i32)> {
+/// Maps a serializer name to its Rust type and `EntityData` variant.
+fn serializer_info(serializer: &str) -> Option<(&'static str, &'static str)> {
     Some(match serializer {
-        "byte" => ("i8", "Byte", 0),
-        "int" => ("i32", "Int", 1),
-        "long" => ("i64", "Long", 2),
-        "float" => ("f32", "Float", 3),
-        "string" => ("String", "String", 4),
-        "component" => ("Box<TextComponent>", "Component", 5),
-        "optional_component" => ("Option<Box<TextComponent>>", "OptionalComponent", 6),
-        "item_stack" => ("ItemStack", "ItemStack", 7),
-        "boolean" => ("bool", "Boolean", 8),
-        "rotations" => ("Rotations", "Rotations", 9),
-        "block_pos" => ("BlockPos", "BlockPos", 10),
-        "optional_block_pos" => ("Option<BlockPos>", "OptionalBlockPos", 11),
-        "direction" => ("Direction", "Direction", 12),
-        "optional_living_entity_reference" => ("Option<Uuid>", "OptionalLivingEntityRef", 13),
-        "block_state" => ("BlockStateId", "BlockState", 14),
-        "optional_block_state" => ("Option<BlockStateId>", "OptionalBlockState", 15),
-        "particle" => ("ParticleData", "Particle", 16),
-        "particles" => ("ParticleList", "Particles", 17),
-        "villager_data" => ("VillagerData", "VillagerData", 18),
-        "optional_unsigned_int" => ("Option<u32>", "OptionalUnsignedInt", 19),
-        "pose" => ("EntityPose", "Pose", 20),
-        "cat_variant" => ("i32", "CatVariant", 21),
-        "cat_sound_variant" => ("i32", "CatSoundVariant", 22),
-        "cow_variant" => ("i32", "CowVariant", 23),
-        "cow_sound_variant" => ("i32", "CowSoundVariant", 24),
-        "wolf_variant" => ("i32", "WolfVariant", 25),
-        "wolf_sound_variant" => ("i32", "WolfSoundVariant", 26),
-        "frog_variant" => ("i32", "FrogVariant", 27),
-        "pig_variant" => ("i32", "PigVariant", 28),
-        "pig_sound_variant" => ("i32", "PigSoundVariant", 29),
-        "chicken_variant" => ("i32", "ChickenVariant", 30),
-        "chicken_sound_variant" => ("i32", "ChickenSoundVariant", 31),
-        "zombie_nautilus_variant" => ("i32", "ZombieNautilusVariant", 32),
-        "optional_global_pos" => ("Option<GlobalPos>", "OptionalGlobalPos", 33),
-        "painting_variant" => ("i32", "PaintingVariant", 34),
-        "sniffer_state" => ("SnifferState", "SnifferState", 35),
-        "armadillo_state" => ("ArmadilloState", "ArmadilloState", 36),
-        "copper_golem_state" => ("i32", "CopperGolemState", 37),
-        "weathering_copper_state" => ("i32", "WeatheringCopperState", 38),
-        "vector3" => ("Vector3f", "Vector3", 39),
-        "quaternion" => ("Quaternionf", "Quaternion", 40),
-        "resolvable_profile" => ("ResolvableProfile", "ResolvableProfile", 41),
-        "humanoid_arm" => ("HumanoidArm", "HumanoidArm", 42),
+        "byte" => ("i8", "Byte"),
+        "int" => ("i32", "Int"),
+        "long" => ("i64", "Long"),
+        "float" => ("f32", "Float"),
+        "string" => ("String", "String"),
+        "component" => ("Box<TextComponent>", "Component"),
+        "optional_component" => ("Option<Box<TextComponent>>", "OptionalComponent"),
+        "item_stack" => ("ItemStack", "ItemStack"),
+        "boolean" => ("bool", "Boolean"),
+        "rotations" => ("Rotations", "Rotations"),
+        "block_pos" => ("BlockPos", "BlockPos"),
+        "optional_block_pos" => ("Option<BlockPos>", "OptionalBlockPos"),
+        "direction" => ("Direction", "Direction"),
+        "optional_living_entity_reference" => ("Option<Uuid>", "OptionalLivingEntityRef"),
+        "block_state" => ("BlockStateId", "BlockState"),
+        "optional_block_state" => ("Option<BlockStateId>", "OptionalBlockState"),
+        "particle" => ("ParticleData", "Particle"),
+        "particles" => ("ParticleList", "Particles"),
+        "villager_data" => ("VillagerData", "VillagerData"),
+        "optional_unsigned_int" => ("Option<u32>", "OptionalUnsignedInt"),
+        "pose" => ("EntityPose", "Pose"),
+        "cat_variant" => (
+            "RegistryReference<crate::cat_variant::CatVariant>",
+            "CatVariant",
+        ),
+        "cat_sound_variant" => (
+            "RegistryReference<crate::cat_sound_variant::CatSoundVariant>",
+            "CatSoundVariant",
+        ),
+        "cow_variant" => (
+            "RegistryReference<crate::cow_variant::CowVariant>",
+            "CowVariant",
+        ),
+        "cow_sound_variant" => (
+            "RegistryReference<crate::cow_sound_variant::CowSoundVariant>",
+            "CowSoundVariant",
+        ),
+        "wolf_variant" => (
+            "RegistryReference<crate::wolf_variant::WolfVariant>",
+            "WolfVariant",
+        ),
+        "wolf_sound_variant" => (
+            "RegistryReference<crate::wolf_sound_variant::WolfSoundVariant>",
+            "WolfSoundVariant",
+        ),
+        "frog_variant" => (
+            "RegistryReference<crate::frog_variant::FrogVariant>",
+            "FrogVariant",
+        ),
+        "pig_variant" => (
+            "RegistryReference<crate::pig_variant::PigVariant>",
+            "PigVariant",
+        ),
+        "pig_sound_variant" => (
+            "RegistryReference<crate::pig_sound_variant::PigSoundVariant>",
+            "PigSoundVariant",
+        ),
+        "chicken_variant" => (
+            "RegistryReference<crate::chicken_variant::ChickenVariant>",
+            "ChickenVariant",
+        ),
+        "chicken_sound_variant" => (
+            "RegistryReference<crate::chicken_sound_variant::ChickenSoundVariant>",
+            "ChickenSoundVariant",
+        ),
+        "zombie_nautilus_variant" => (
+            "RegistryReference<crate::zombie_nautilus_variant::ZombieNautilusVariant>",
+            "ZombieNautilusVariant",
+        ),
+        "optional_global_pos" => ("Option<GlobalPos>", "OptionalGlobalPos"),
+        "painting_variant" => (
+            "RegistryReference<crate::painting_variant::PaintingVariant>",
+            "PaintingVariant",
+        ),
+        "sniffer_state" => ("SnifferState", "SnifferState"),
+        "armadillo_state" => ("ArmadilloState", "ArmadilloState"),
+        "copper_golem_state" => ("i32", "CopperGolemState"),
+        "weathering_copper_state" => ("i32", "WeatheringCopperState"),
+        "vector3" => ("Vector3f", "Vector3"),
+        "quaternion" => ("Quaternionf", "Quaternion"),
+        "resolvable_profile" => ("ResolvableProfile", "ResolvableProfile"),
+        "humanoid_arm" => ("HumanoidArm", "HumanoidArm"),
         _ => return None,
     })
 }
@@ -245,13 +283,9 @@ fn optional_none_expr(serializer: &str, default: &Value) -> TokenStream {
 }
 
 fn variant_registry_default_expr(module: &str, default: &Value, serializer: &str) -> TokenStream {
-    let default = required_string(default, serializer);
-    let subdir = module
-        .strip_prefix("vanilla_")
-        .and_then(|name| name.strip_suffix('s'))
-        .unwrap_or_else(|| panic!("Unsupported registry default module: {module}"));
-    let id = Literal::i32_unsuffixed(vanilla_variant_id(subdir, default) as i32);
-    quote! { #id }
+    let module_ident = Ident::new(module, Span::call_site());
+    let variant_ident = key_ident(default, serializer);
+    quote! { RegistryReference::new(&crate::#module_ident::#variant_ident) }
 }
 
 #[derive(Deserialize)]
@@ -571,7 +605,7 @@ fn default_value_expr(serializer: &str, default: &Value) -> TokenStream {
 
 /// Generate the `EntityData` conversion expression for packing.
 fn entity_data_expr(serializer: &str, field_ident: &Ident) -> TokenStream {
-    let (_, variant, _) = serializer_info(serializer)
+    let (_, variant) = serializer_info(serializer)
         .unwrap_or_else(|| panic!("Unknown entity data serializer: {serializer}"));
     let variant_ident = Ident::new(variant, Span::call_site());
 
@@ -911,6 +945,34 @@ fn entity_has_living_entity_data(entity: &EntityEntry) -> bool {
         .any(|layer| !layer.fields.is_empty() && layer.simple_name == "LivingEntity")
 }
 
+fn validate_serializer_ids(layers: &[LayerDefinition]) {
+    let mut ids_by_serializer = FxHashMap::default();
+    let mut serializers_by_id = FxHashMap::default();
+
+    for layer in layers {
+        for field in &layer.fields {
+            if let Some(existing_id) =
+                ids_by_serializer.insert(&field.serializer, field.serializer_id)
+            {
+                assert_eq!(
+                    existing_id, field.serializer_id,
+                    "Entity data serializer '{}' uses both IDs {existing_id} and {} in extracted data",
+                    field.serializer, field.serializer_id
+                );
+            }
+            if let Some(existing_serializer) =
+                serializers_by_id.insert(field.serializer_id, &field.serializer)
+            {
+                assert_eq!(
+                    existing_serializer, &field.serializer,
+                    "Entity data serializer ID {} is used by both '{existing_serializer}' and '{}' in extracted data",
+                    field.serializer_id, field.serializer
+                );
+            }
+        }
+    }
+}
+
 pub(crate) fn build() -> TokenStream {
     println!("cargo:rerun-if-changed=build_assets/entities.json");
 
@@ -920,6 +982,7 @@ pub(crate) fn build() -> TokenStream {
     let entities: Vec<EntityEntry> = serde_json::from_str(&content)
         .unwrap_or_else(|e| panic!("Failed to parse entities.json: {e}"));
     let layers = collect_layers(&entities);
+    validate_serializer_ids(&layers);
     let layer_indices: FxHashMap<_, _> = layers
         .iter()
         .enumerate()
@@ -960,7 +1023,7 @@ pub(crate) fn build() -> TokenStream {
         use steel_utils::{ArgbColor, BlockStateId, random::Random};
         use text_components::TextComponent;
         use uuid::Uuid;
-        use crate::{RegistryEntry, RegistryExt};
+        use crate::{RegistryEntry, RegistryExt, RegistryReference};
 
         /// Common access to the vanilla synchronized entity data root layer.
         pub trait VanillaEntityData {
@@ -1043,23 +1106,12 @@ pub(crate) fn build() -> TokenStream {
         }
 
         for data in &layer.fields {
-            let (rust_type, _, expected_serializer_id) = serializer_info(&data.serializer)
-                .unwrap_or_else(|| {
-                    panic!(
-                        "Unknown serializer '{}' for entity data layer '{}' field '{}'",
-                        data.serializer, layer.simple_name, data.name
-                    )
-                });
-            assert_eq!(
-                data.serializer_id,
-                expected_serializer_id,
-                "Serializer '{}' for entity data layer '{}' field '{}' has id {}, expected {}",
-                data.serializer,
-                layer.simple_name,
-                data.name,
-                data.serializer_id,
-                expected_serializer_id
-            );
+            let (rust_type, _) = serializer_info(&data.serializer).unwrap_or_else(|| {
+                panic!(
+                    "Unknown serializer '{}' for entity data layer '{}' field '{}'",
+                    data.serializer, layer.simple_name, data.name
+                )
+            });
 
             let field_name = sanitize_field_name(&data.name);
             let field_ident = Ident::new(&field_name, Span::call_site());

--- a/steel-registry/build/generator_functions.rs
+++ b/steel-registry/build/generator_functions.rs
@@ -5,6 +5,8 @@ use heck::ToShoutySnakeCase;
 use proc_macro2::TokenStream;
 use proc_macro2::{Ident, Span};
 use quote::quote;
+use rustc_hash::FxHashMap;
+use serde::Deserialize;
 use std::fs;
 use steel_utils::Identifier;
 
@@ -190,11 +192,11 @@ pub fn read_variants_from_dir<T: serde::de::DeserializeOwned>(subdir: &str) -> V
             .unwrap_or_else(|e| panic!("Failed to parse {name}: {e}"));
         out.push((name, value));
     }
-    let order = vanilla_variant_order(subdir);
+    let order = extracted_variant_order(subdir);
     out.sort_by_key(|(name, _)| {
         order
             .iter()
-            .position(|ordered| *ordered == name)
+            .position(|ordered| ordered == name)
             .unwrap_or_else(|| panic!("Unknown vanilla {subdir} variant in extracted data: {name}"))
     });
     assert_eq!(
@@ -207,95 +209,32 @@ pub fn read_variants_from_dir<T: serde::de::DeserializeOwned>(subdir: &str) -> V
     out
 }
 
-pub fn vanilla_variant_id(subdir: &str, key: &str) -> usize {
-    let path = key.strip_prefix("minecraft:").unwrap_or(key);
-    vanilla_variant_order(subdir)
-        .iter()
-        .position(|ordered| *ordered == path)
-        .unwrap_or_else(|| panic!("Unknown vanilla {subdir} variant default: {key}"))
+#[derive(Deserialize)]
+struct ExtractedVariantRegistryEntry {
+    id: usize,
+    key: String,
 }
 
-fn vanilla_variant_order(subdir: &str) -> &'static [&'static str] {
-    match subdir {
-        "cat_variant" => &[
-            "tabby",
-            "black",
-            "red",
-            "siamese",
-            "british_shorthair",
-            "calico",
-            "persian",
-            "ragdoll",
-            "white",
-            "jellie",
-            "all_black",
-        ],
-        "cat_sound_variant" => &["classic", "royal"],
-        "cow_variant" => &["temperate", "warm", "cold"],
-        "cow_sound_variant" => &["classic", "moody"],
-        "wolf_variant" => &[
-            "pale", "spotted", "snowy", "black", "ashen", "rusty", "woods", "chestnut", "striped",
-        ],
-        "wolf_sound_variant" => &["classic", "puglin", "sad", "angry", "grumpy", "big", "cute"],
-        "frog_variant" => &["temperate", "warm", "cold"],
-        "pig_variant" => &["temperate", "warm", "cold"],
-        "pig_sound_variant" => &["classic", "big", "mini"],
-        "chicken_variant" => &["temperate", "warm", "cold"],
-        "chicken_sound_variant" => &["classic", "picky"],
-        "zombie_nautilus_variant" => &["temperate", "warm"],
-        "painting_variant" => &[
-            "kebab",
-            "aztec",
-            "alban",
-            "aztec2",
-            "bomb",
-            "plant",
-            "wasteland",
-            "pool",
-            "courbet",
-            "sea",
-            "sunset",
-            "creebet",
-            "wanderer",
-            "graham",
-            "match",
-            "bust",
-            "stage",
-            "void",
-            "skull_and_roses",
-            "wither",
-            "fighters",
-            "pointer",
-            "pigscene",
-            "burning_skull",
-            "skeleton",
-            "earth",
-            "wind",
-            "water",
-            "fire",
-            "donkey_kong",
-            "baroque",
-            "humble",
-            "meditative",
-            "prairie_ride",
-            "unpacked",
-            "backyard",
-            "bouquet",
-            "cavebird",
-            "changing",
-            "cotan",
-            "endboss",
-            "fern",
-            "finding",
-            "lowmist",
-            "orb",
-            "owlemons",
-            "passage",
-            "pond",
-            "sunflowers",
-            "tides",
-            "dennis",
-        ],
-        _ => panic!("Missing vanilla variant order for {subdir}"),
-    }
+fn extracted_variant_order(subdir: &str) -> Vec<String> {
+    const ASSET: &str = "build_assets/entity_variant_registries.json";
+
+    let mut registries: FxHashMap<String, Vec<ExtractedVariantRegistryEntry>> =
+        read_json_asset(ASSET);
+    let mut entries = registries
+        .remove(subdir)
+        .unwrap_or_else(|| panic!("Missing vanilla {subdir} registry in {ASSET}"));
+    sort_contiguous_registry_entries(&mut entries, ASSET, |entry| entry.id);
+
+    entries
+        .into_iter()
+        .map(|entry| {
+            let Some(key) = entry.key.strip_prefix("minecraft:") else {
+                panic!(
+                    "Expected vanilla {subdir} registry key in {ASSET}, got {}",
+                    entry.key
+                );
+            };
+            key.to_owned()
+        })
+        .collect()
 }

--- a/steel-registry/build_assets/entity_variant_registries.json
+++ b/steel-registry/build_assets/entity_variant_registries.json
@@ -1,0 +1,432 @@
+{
+  "cat_variant": [
+    {
+      "id": 0,
+      "key": "minecraft:all_black"
+    },
+    {
+      "id": 1,
+      "key": "minecraft:black"
+    },
+    {
+      "id": 2,
+      "key": "minecraft:british_shorthair"
+    },
+    {
+      "id": 3,
+      "key": "minecraft:calico"
+    },
+    {
+      "id": 4,
+      "key": "minecraft:jellie"
+    },
+    {
+      "id": 5,
+      "key": "minecraft:persian"
+    },
+    {
+      "id": 6,
+      "key": "minecraft:ragdoll"
+    },
+    {
+      "id": 7,
+      "key": "minecraft:red"
+    },
+    {
+      "id": 8,
+      "key": "minecraft:siamese"
+    },
+    {
+      "id": 9,
+      "key": "minecraft:tabby"
+    },
+    {
+      "id": 10,
+      "key": "minecraft:white"
+    }
+  ],
+  "cat_sound_variant": [
+    {
+      "id": 0,
+      "key": "minecraft:classic"
+    },
+    {
+      "id": 1,
+      "key": "minecraft:royal"
+    }
+  ],
+  "cow_variant": [
+    {
+      "id": 0,
+      "key": "minecraft:cold"
+    },
+    {
+      "id": 1,
+      "key": "minecraft:temperate"
+    },
+    {
+      "id": 2,
+      "key": "minecraft:warm"
+    }
+  ],
+  "cow_sound_variant": [
+    {
+      "id": 0,
+      "key": "minecraft:classic"
+    },
+    {
+      "id": 1,
+      "key": "minecraft:moody"
+    }
+  ],
+  "wolf_variant": [
+    {
+      "id": 0,
+      "key": "minecraft:ashen"
+    },
+    {
+      "id": 1,
+      "key": "minecraft:black"
+    },
+    {
+      "id": 2,
+      "key": "minecraft:chestnut"
+    },
+    {
+      "id": 3,
+      "key": "minecraft:pale"
+    },
+    {
+      "id": 4,
+      "key": "minecraft:rusty"
+    },
+    {
+      "id": 5,
+      "key": "minecraft:snowy"
+    },
+    {
+      "id": 6,
+      "key": "minecraft:spotted"
+    },
+    {
+      "id": 7,
+      "key": "minecraft:striped"
+    },
+    {
+      "id": 8,
+      "key": "minecraft:woods"
+    }
+  ],
+  "wolf_sound_variant": [
+    {
+      "id": 0,
+      "key": "minecraft:angry"
+    },
+    {
+      "id": 1,
+      "key": "minecraft:big"
+    },
+    {
+      "id": 2,
+      "key": "minecraft:classic"
+    },
+    {
+      "id": 3,
+      "key": "minecraft:cute"
+    },
+    {
+      "id": 4,
+      "key": "minecraft:grumpy"
+    },
+    {
+      "id": 5,
+      "key": "minecraft:puglin"
+    },
+    {
+      "id": 6,
+      "key": "minecraft:sad"
+    }
+  ],
+  "frog_variant": [
+    {
+      "id": 0,
+      "key": "minecraft:cold"
+    },
+    {
+      "id": 1,
+      "key": "minecraft:temperate"
+    },
+    {
+      "id": 2,
+      "key": "minecraft:warm"
+    }
+  ],
+  "pig_variant": [
+    {
+      "id": 0,
+      "key": "minecraft:cold"
+    },
+    {
+      "id": 1,
+      "key": "minecraft:temperate"
+    },
+    {
+      "id": 2,
+      "key": "minecraft:warm"
+    }
+  ],
+  "pig_sound_variant": [
+    {
+      "id": 0,
+      "key": "minecraft:big"
+    },
+    {
+      "id": 1,
+      "key": "minecraft:classic"
+    },
+    {
+      "id": 2,
+      "key": "minecraft:mini"
+    }
+  ],
+  "chicken_variant": [
+    {
+      "id": 0,
+      "key": "minecraft:cold"
+    },
+    {
+      "id": 1,
+      "key": "minecraft:temperate"
+    },
+    {
+      "id": 2,
+      "key": "minecraft:warm"
+    }
+  ],
+  "chicken_sound_variant": [
+    {
+      "id": 0,
+      "key": "minecraft:classic"
+    },
+    {
+      "id": 1,
+      "key": "minecraft:picky"
+    }
+  ],
+  "zombie_nautilus_variant": [
+    {
+      "id": 0,
+      "key": "minecraft:temperate"
+    },
+    {
+      "id": 1,
+      "key": "minecraft:warm"
+    }
+  ],
+  "painting_variant": [
+    {
+      "id": 0,
+      "key": "minecraft:alban"
+    },
+    {
+      "id": 1,
+      "key": "minecraft:aztec"
+    },
+    {
+      "id": 2,
+      "key": "minecraft:aztec2"
+    },
+    {
+      "id": 3,
+      "key": "minecraft:backyard"
+    },
+    {
+      "id": 4,
+      "key": "minecraft:baroque"
+    },
+    {
+      "id": 5,
+      "key": "minecraft:bomb"
+    },
+    {
+      "id": 6,
+      "key": "minecraft:bouquet"
+    },
+    {
+      "id": 7,
+      "key": "minecraft:burning_skull"
+    },
+    {
+      "id": 8,
+      "key": "minecraft:bust"
+    },
+    {
+      "id": 9,
+      "key": "minecraft:cavebird"
+    },
+    {
+      "id": 10,
+      "key": "minecraft:changing"
+    },
+    {
+      "id": 11,
+      "key": "minecraft:cotan"
+    },
+    {
+      "id": 12,
+      "key": "minecraft:courbet"
+    },
+    {
+      "id": 13,
+      "key": "minecraft:creebet"
+    },
+    {
+      "id": 14,
+      "key": "minecraft:dennis"
+    },
+    {
+      "id": 15,
+      "key": "minecraft:donkey_kong"
+    },
+    {
+      "id": 16,
+      "key": "minecraft:earth"
+    },
+    {
+      "id": 17,
+      "key": "minecraft:endboss"
+    },
+    {
+      "id": 18,
+      "key": "minecraft:fern"
+    },
+    {
+      "id": 19,
+      "key": "minecraft:fighters"
+    },
+    {
+      "id": 20,
+      "key": "minecraft:finding"
+    },
+    {
+      "id": 21,
+      "key": "minecraft:fire"
+    },
+    {
+      "id": 22,
+      "key": "minecraft:graham"
+    },
+    {
+      "id": 23,
+      "key": "minecraft:humble"
+    },
+    {
+      "id": 24,
+      "key": "minecraft:kebab"
+    },
+    {
+      "id": 25,
+      "key": "minecraft:lowmist"
+    },
+    {
+      "id": 26,
+      "key": "minecraft:match"
+    },
+    {
+      "id": 27,
+      "key": "minecraft:meditative"
+    },
+    {
+      "id": 28,
+      "key": "minecraft:orb"
+    },
+    {
+      "id": 29,
+      "key": "minecraft:owlemons"
+    },
+    {
+      "id": 30,
+      "key": "minecraft:passage"
+    },
+    {
+      "id": 31,
+      "key": "minecraft:pigscene"
+    },
+    {
+      "id": 32,
+      "key": "minecraft:plant"
+    },
+    {
+      "id": 33,
+      "key": "minecraft:pointer"
+    },
+    {
+      "id": 34,
+      "key": "minecraft:pond"
+    },
+    {
+      "id": 35,
+      "key": "minecraft:pool"
+    },
+    {
+      "id": 36,
+      "key": "minecraft:prairie_ride"
+    },
+    {
+      "id": 37,
+      "key": "minecraft:sea"
+    },
+    {
+      "id": 38,
+      "key": "minecraft:skeleton"
+    },
+    {
+      "id": 39,
+      "key": "minecraft:skull_and_roses"
+    },
+    {
+      "id": 40,
+      "key": "minecraft:stage"
+    },
+    {
+      "id": 41,
+      "key": "minecraft:sunflowers"
+    },
+    {
+      "id": 42,
+      "key": "minecraft:sunset"
+    },
+    {
+      "id": 43,
+      "key": "minecraft:tides"
+    },
+    {
+      "id": 44,
+      "key": "minecraft:unpacked"
+    },
+    {
+      "id": 45,
+      "key": "minecraft:void"
+    },
+    {
+      "id": 46,
+      "key": "minecraft:wanderer"
+    },
+    {
+      "id": 47,
+      "key": "minecraft:wasteland"
+    },
+    {
+      "id": 48,
+      "key": "minecraft:water"
+    },
+    {
+      "id": 49,
+      "key": "minecraft:wind"
+    },
+    {
+      "id": 50,
+      "key": "minecraft:wither"
+    }
+  ]
+}

--- a/steel-registry/src/entity_data/mod.rs
+++ b/steel-registry/src/entity_data/mod.rs
@@ -43,8 +43,22 @@ use steel_utils::{
 use text_components::TextComponent;
 use uuid::Uuid;
 
+use crate::RegistryReference;
+use crate::cat_sound_variant::CatSoundVariant;
+use crate::cat_variant::CatVariant;
+use crate::chicken_sound_variant::ChickenSoundVariant;
+use crate::chicken_variant::ChickenVariant;
+use crate::cow_sound_variant::CowSoundVariant;
+use crate::cow_variant::CowVariant;
+use crate::frog_variant::FrogVariant;
 use crate::item_stack::ItemStack;
+use crate::painting_variant::PaintingVariant;
 pub use crate::particle_type::{ColorParticleOption, ParticleData};
+use crate::pig_sound_variant::PigSoundVariant;
+use crate::pig_variant::PigVariant;
+use crate::wolf_sound_variant::WolfSoundVariant;
+use crate::wolf_variant::WolfVariant;
+use crate::zombie_nautilus_variant::ZombieNautilusVariant;
 
 // Re-export types used in generated code
 pub use crate::blocks::properties::Direction;
@@ -380,20 +394,20 @@ pub enum EntityData {
     // Optional numeric
     OptionalUnsignedInt(Option<u32>),
 
-    // Holder/registry reference variants (VarInt registry IDs)
-    CatVariant(i32),
-    CatSoundVariant(i32),
-    CowVariant(i32),
-    CowSoundVariant(i32),
-    WolfVariant(i32),
-    WolfSoundVariant(i32),
-    FrogVariant(i32),
-    PigVariant(i32),
-    PigSoundVariant(i32),
-    ChickenVariant(i32),
-    ChickenSoundVariant(i32),
-    ZombieNautilusVariant(i32),
-    PaintingVariant(i32),
+    // Holder/registry reference variants (encoded as VarInt registry IDs)
+    CatVariant(RegistryReference<CatVariant>),
+    CatSoundVariant(RegistryReference<CatSoundVariant>),
+    CowVariant(RegistryReference<CowVariant>),
+    CowSoundVariant(RegistryReference<CowSoundVariant>),
+    WolfVariant(RegistryReference<WolfVariant>),
+    WolfSoundVariant(RegistryReference<WolfSoundVariant>),
+    FrogVariant(RegistryReference<FrogVariant>),
+    PigVariant(RegistryReference<PigVariant>),
+    PigSoundVariant(RegistryReference<PigSoundVariant>),
+    ChickenVariant(RegistryReference<ChickenVariant>),
+    ChickenSoundVariant(RegistryReference<ChickenSoundVariant>),
+    ZombieNautilusVariant(RegistryReference<ZombieNautilusVariant>),
+    PaintingVariant(RegistryReference<PaintingVariant>),
 
     // Global position
     OptionalGlobalPos(Option<GlobalPos>),

--- a/steel-registry/src/entity_data/vanilla_serializers.rs
+++ b/steel-registry/src/entity_data/vanilla_serializers.rs
@@ -67,23 +67,25 @@ ser_write!(ser_item_stack, ItemStack);
 ser_write!(ser_boolean, Boolean);
 ser_write!(ser_block_state, BlockState);
 
-// VarInt serializers (for i32 holder/registry IDs)
+// Plain i32 VarInt serializers
 ser_varint!(ser_int, Int);
-ser_varint!(ser_cat_variant, CatVariant);
-ser_varint!(ser_cat_sound_variant, CatSoundVariant);
-ser_varint!(ser_cow_variant, CowVariant);
-ser_varint!(ser_cow_sound_variant, CowSoundVariant);
-ser_varint!(ser_wolf_variant, WolfVariant);
-ser_varint!(ser_wolf_sound_variant, WolfSoundVariant);
-ser_varint!(ser_frog_variant, FrogVariant);
-ser_varint!(ser_pig_variant, PigVariant);
-ser_varint!(ser_pig_sound_variant, PigSoundVariant);
-ser_varint!(ser_chicken_variant, ChickenVariant);
-ser_varint!(ser_chicken_sound_variant, ChickenSoundVariant);
-ser_varint!(ser_zombie_nautilus_variant, ZombieNautilusVariant);
-ser_varint!(ser_painting_variant, PaintingVariant);
 ser_varint!(ser_copper_golem_state, CopperGolemState);
 ser_varint!(ser_weathering_copper_state, WeatheringCopperState);
+
+// Holder/registry reference serializers resolve protocol IDs at the network edge.
+ser_write!(ser_cat_variant, CatVariant);
+ser_write!(ser_cat_sound_variant, CatSoundVariant);
+ser_write!(ser_cow_variant, CowVariant);
+ser_write!(ser_cow_sound_variant, CowSoundVariant);
+ser_write!(ser_wolf_variant, WolfVariant);
+ser_write!(ser_wolf_sound_variant, WolfSoundVariant);
+ser_write!(ser_frog_variant, FrogVariant);
+ser_write!(ser_pig_variant, PigVariant);
+ser_write!(ser_pig_sound_variant, PigSoundVariant);
+ser_write!(ser_chicken_variant, ChickenVariant);
+ser_write!(ser_chicken_sound_variant, ChickenSoundVariant);
+ser_write!(ser_zombie_nautilus_variant, ZombieNautilusVariant);
+ser_write!(ser_painting_variant, PaintingVariant);
 
 // Enum as VarInt serializers
 ser_enum_varint!(ser_direction, Direction);
@@ -335,8 +337,9 @@ pub fn register_vanilla_entity_data_serializers(registry: &mut EntityDataSeriali
 
 #[cfg(test)]
 mod tests {
-    use crate::RegistryExt;
     use crate::entity_data::ResolvableProfile;
+    use crate::test_support::init_test_registry;
+    use crate::{REGISTRY, RegistryExt, RegistryReference, vanilla_pig_variants};
 
     use super::*;
 
@@ -436,6 +439,37 @@ mod tests {
         let mut buf = Vec::new();
         writer(&EntityData::Boolean(true), &mut buf).unwrap();
         assert_eq!(buf, vec![1]);
+    }
+
+    #[test]
+    fn holder_serializer_resolves_the_registered_variant_id() {
+        init_test_registry();
+
+        let mut serializers = EntityDataSerializerRegistry::new();
+        register_vanilla_entity_data_serializers(&mut serializers);
+        let serializer_id = serializers
+            .id_from_key(&id!("pig_variant"))
+            .expect("pig variant serializer must be registered");
+        let writer = serializers
+            .get_writer(serializer_id as i32)
+            .expect("pig variant serializer must have a writer");
+
+        let mut encoded = Vec::new();
+        writer(
+            &EntityData::PigVariant(RegistryReference::new(&vanilla_pig_variants::WARM)),
+            &mut encoded,
+        )
+        .expect("pig variant reference should encode");
+
+        let variant_id = REGISTRY
+            .pig_variants
+            .id_from_key(&vanilla_pig_variants::WARM.key)
+            .expect("warm pig variant must be registered");
+        let mut expected = Vec::new();
+        VarInt(variant_id as i32)
+            .write(&mut expected)
+            .expect("pig variant id should encode");
+        assert_eq!(encoded, expected);
     }
 
     #[test]

--- a/steel-registry/src/loot_table/context.rs
+++ b/steel-registry/src/loot_table/context.rs
@@ -129,7 +129,10 @@ impl NumberProvider {
 
     /// Get the value as an integer.
     pub fn get_int(&self, rng: &mut impl rand::Rng) -> i32 {
-        self.get_simple(rng).floor() as i32
+        match self {
+            Self::Uniform { min, max } => uniform_int(rng, math_round(*min), math_round(*max)),
+            other => math_round(other.get_simple(rng)),
+        }
     }
 
     /// Get the value as an integer with context.
@@ -138,7 +141,25 @@ impl NumberProvider {
         rng: &mut R,
         ctx: Option<&LootContextRef<'_>>,
     ) -> i32 {
-        self.get(rng, ctx).floor() as i32
+        match self {
+            Self::Uniform { min, max } => uniform_int(rng, math_round(*min), math_round(*max)),
+            other => math_round(other.get(rng, ctx)),
+        }
+    }
+}
+
+/// `java.lang.Math.round` semantics for a float.
+fn math_round(value: f32) -> i32 {
+    (value + 0.5).floor() as i32
+}
+
+/// Vanilla `Mth.nextInt(random, min, max)` is inclusive and clamps to `min`
+/// when `min >= max`.
+fn uniform_int(rng: &mut impl rand::Rng, min: i32, max: i32) -> i32 {
+    if min >= max {
+        min
+    } else {
+        rng.random_range(min..=max)
     }
 }
 

--- a/steel-registry/src/loot_table/tests.rs
+++ b/steel-registry/src/loot_table/tests.rs
@@ -142,6 +142,23 @@ fn test_pig_loot_smelt_condition_uses_entity_fire_flag() {
 }
 
 #[test]
+fn test_uniform_get_int_reaches_inclusive_max() {
+    // Vanilla UniformGenerator.getInt uses Mth.nextInt(rand, min, max), which
+    // samples the integer range inclusively; a uniform 1..3 count must yield 3.
+    let provider = NumberProvider::Uniform { min: 1.0, max: 3.0 };
+    let mut seen = [false; 4];
+    for seed in 0u64..1000 {
+        let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+        let value = provider.get_int(&mut rng);
+        seen[value as usize] = true;
+    }
+    assert!(
+        seen[1] && seen[2] && seen[3],
+        "uniform 1..=3 must produce 1, 2 and 3, saw {seen:?}"
+    );
+}
+
+#[test]
 fn test_explosion_decay_function() {
     // Test the explosion_decay function directly
     init_test_registries();

--- a/steel-registry/src/registry/mod.rs
+++ b/steel-registry/src/registry/mod.rs
@@ -847,22 +847,22 @@ mod tests {
             Some(&none)
         );
         assert_eq!(
-            registry.cat_variants.by_id(0).map(|entry| &entry.key),
+            registry.cat_variants.by_id(9).map(|entry| &entry.key),
             Some(&tabby)
         );
         assert_eq!(
             registry
                 .wolf_sound_variants
-                .by_id(3)
+                .by_id(0)
                 .map(|entry| &entry.key),
             Some(&angry)
         );
         assert_eq!(
-            registry.pig_sound_variants.by_id(1).map(|entry| &entry.key),
+            registry.pig_sound_variants.by_id(0).map(|entry| &entry.key),
             Some(&big)
         );
         assert_eq!(
-            registry.painting_variants.by_id(25).map(|entry| &entry.key),
+            registry.painting_variants.by_id(16).map(|entry| &entry.key),
             Some(&earth)
         );
     }

--- a/steel-registry/src/registry/reference.rs
+++ b/steel-registry/src/registry/reference.rs
@@ -19,6 +19,7 @@ use crate::cow_sound_variant::CowSoundVariant;
 use crate::cow_variant::CowVariant;
 use crate::frog_variant::FrogVariant;
 use crate::map_decoration_type::MapDecorationType;
+use crate::painting_variant::PaintingVariant;
 use crate::pig_sound_variant::PigSoundVariant;
 use crate::pig_variant::PigVariant;
 use crate::potion::Potion;
@@ -165,6 +166,7 @@ impl_registry_reference_entry!(
 impl_registry_reference_entry!(FrogVariant, frog_variants, "frog variant");
 impl_registry_reference_entry!(CatVariant, cat_variants, "cat variant");
 impl_registry_reference_entry!(CatSoundVariant, cat_sound_variants, "cat sound variant");
+impl_registry_reference_entry!(PaintingVariant, painting_variants, "painting variant");
 impl_registry_reference_entry!(Potion, potions, "potion");
 impl_registry_reference_entry!(
     MapDecorationType,
@@ -191,6 +193,7 @@ mod tests {
     use crate::cow_variant::CowVariant;
     use crate::frog_variant::FrogVariant;
     use crate::map_decoration_type::MapDecorationType;
+    use crate::painting_variant::PaintingVariant;
     use crate::pig_sound_variant::PigSoundVariant;
     use crate::pig_variant::PigVariant;
     use crate::test_support::init_test_registry;
@@ -241,6 +244,7 @@ mod tests {
         assert_codecs::<FrogVariant>();
         assert_codecs::<CatVariant>();
         assert_codecs::<CatSoundVariant>();
+        assert_codecs::<PaintingVariant>();
         assert_codecs::<MapDecorationType>();
     }
 


### PR DESCRIPTION
Makes two changes:

1. Reduces mob complexity by hoisting repeat boilerplate to the parent trait
2. Fixes a bug where uniform int RNG was not inclusive (which I discovered via killing many pigs and never getting 3 porkchops as a drop)

With this, writing mobs should be slightly easier and more focused on the individual implementations!