### PR TITLE
Add a headless pregeneration benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2709,6 +2709,7 @@ dependencies = [
  "heck",
  "log",
  "md5",
+ "mimalloc",
  "parking_lot",
  "proc-macro2",
  "quote",

--- a/steel-core/Cargo.toml
+++ b/steel-core/Cargo.toml
@@ -88,10 +88,16 @@ glob = "0.3.4"
 
 [dev-dependencies]
 criterion.workspace = true
+mimalloc = "0.1.52"
 steel-registry.workspace = true
 
 [[bench]]
 name = "worldgen"
+harness = false
+required-features = ["benchmark-support"]
+
+[[bench]]
+name = "pregen"
 harness = false
 required-features = ["benchmark-support"]
 

--- a/steel-core/benches/pregen.rs
+++ b/steel-core/benches/pregen.rs
@@ -1,0 +1,381 @@
+//! End-to-end pregeneration throughput, without a server.
+//!
+//! The other benchmarks in this crate drive `GENERATION_PYRAMID` steps against
+//! hand-built holders, which measures generation compute. This one runs the
+//! production pregeneration driver against a bare `World`, so it covers the
+//! whole pipeline: tickets, scheduling epochs, the generation pool, unload and
+//! region saves.
+//!
+//! ```text
+//! cargo bench -p steel-core --bench pregen --features benchmark-support -- --size 301 --reps 3
+//! ```
+use std::env;
+use std::fmt::Display;
+use std::fs;
+use std::num::NonZero;
+use std::path::PathBuf;
+use std::process;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use steel_core::bootstrap::init_globals_once;
+use steel_core::config::WorldStorageConfig;
+use steel_core::level_data::WorldGenerationSettings;
+use steel_core::server::pregen::pregen_area_for_benchmark;
+use steel_core::world::{World, WorldConfig};
+use steel_core::worldgen::WorldGeneratorRegistry;
+use steel_registry::vanilla_dimension_types;
+use steel_utils::threading::worker_threads_for_available;
+use steel_utils::types::{Difficulty, GameType};
+use steel_utils::{ChunkPos, Identifier};
+use tokio::runtime::{Builder, Runtime};
+use tokio_util::sync::CancellationToken;
+use toml::Value;
+use toml::map::Map;
+
+const DEFAULT_SEED: i64 = -9_091_483_014_810_473_238;
+const DEFAULT_SIZE: i32 = 301;
+const DEFAULT_REPS: usize = 3;
+
+#[global_allocator]
+static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+struct Options {
+    size: i32,
+    reps: usize,
+    seed: i64,
+    generation_threads: usize,
+    chunk_workers: usize,
+    main_workers: usize,
+    encoding_threads: usize,
+    window_size: Option<i32>,
+    ram_only: bool,
+    keep_storage: bool,
+}
+
+impl Options {
+    fn parse() -> Result<Self, String> {
+        let available = thread::available_parallelism().map_or(4, NonZero::get);
+        let mut options = Self {
+            size: DEFAULT_SIZE,
+            reps: DEFAULT_REPS,
+            seed: DEFAULT_SEED,
+            generation_threads: available,
+            chunk_workers: worker_threads_for_available(None, available),
+            main_workers: worker_threads_for_available(None, available),
+            encoding_threads: available,
+            window_size: None,
+            ram_only: false,
+            keep_storage: false,
+        };
+
+        // `cargo bench` passes libtest's own flags through.
+        let mut args = env::args().skip(1).peekable();
+        while let Some(arg) = args.next() {
+            let mut value = || args.next().ok_or_else(|| format!("{arg} requires a value"));
+            match arg.as_str() {
+                "--size" => options.size = parse(&value()?, "--size")?,
+                "--reps" => options.reps = parse(&value()?, "--reps")?,
+                "--seed" => options.seed = parse(&value()?, "--seed")?,
+                "--gen-threads" => options.generation_threads = parse(&value()?, "--gen-threads")?,
+                "--chunk-workers" => options.chunk_workers = parse(&value()?, "--chunk-workers")?,
+                "--main-workers" => options.main_workers = parse(&value()?, "--main-workers")?,
+                "--encode-threads" => {
+                    options.encoding_threads = parse(&value()?, "--encode-threads")?;
+                }
+                "--window" => options.window_size = Some(parse(&value()?, "--window")?),
+                "--ram-only" => options.ram_only = true,
+                "--keep-storage" => options.keep_storage = true,
+                "--bench" | "--test" => {}
+                "--help" | "-h" => {
+                    print_usage();
+                    process::exit(0);
+                }
+                other => return Err(format!("unknown argument {other} (try --help)")),
+            }
+        }
+
+        if options.reps == 0 {
+            return Err("--reps must be at least 1".to_owned());
+        }
+        Ok(options)
+    }
+}
+
+fn parse<T: FromStr>(value: &str, flag: &str) -> Result<T, String>
+where
+    T::Err: Display,
+{
+    value
+        .parse()
+        .map_err(|error| format!("{flag} takes a number: {error}"))
+}
+
+fn print_usage() {
+    println!(
+        "\
+Headless pregeneration benchmark.
+
+  --size N           chunk side length, odd (default {DEFAULT_SIZE})
+  --reps N           runs to perform (default {DEFAULT_REPS})
+  --seed N           world seed (default {DEFAULT_SEED})
+  --gen-threads N    generation pool threads (default: the server's)
+  --chunk-workers N  chunk runtime workers (default: the server's)
+  --main-workers N   main runtime workers (default: the server's)
+  --encode-threads N encoding pool threads (default: the server's)
+  --window N         pregen window side length (default: the server's)
+  --ram-only         skip region-file persistence entirely
+  --keep-storage     do not delete the per-run storage directory
+"
+    );
+}
+
+/// Current and peak resident set size in MiB.
+///
+/// Peak is process-lifetime and does not reset between reps, so use `--reps 1`
+/// when comparing it. Linux only; elsewhere the rate is printed on its own.
+#[cfg(target_os = "linux")]
+fn rss_mib() -> Option<(u64, u64)> {
+    let status = fs::read_to_string("/proc/self/status").ok()?;
+    let field = |name: &str| {
+        let line = status.lines().find(|line| line.starts_with(name))?;
+        let kib: u64 = line.split_whitespace().nth(1)?.parse().ok()?;
+        Some(kib / 1024)
+    };
+    Some((field("VmRSS:")?, field("VmHWM:")?))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn rss_mib() -> Option<(u64, u64)> {
+    None
+}
+
+/// Unique per run and removed afterwards. Under `target/` because a 601x601 run
+/// writes gigabytes of region files.
+fn storage_root(rep: usize) -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |elapsed| elapsed.as_nanos());
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../target/bench-pregen")
+        .join(format!("{}-{rep}-{unique}", process::id()))
+}
+
+struct Harness {
+    world: Arc<World>,
+    main_runtime: Runtime,
+    /// Held so the world's runtime outlives it; dropped last.
+    _chunk_runtime: Arc<Runtime>,
+    storage: Option<PathBuf>,
+}
+
+fn build_harness(options: &Options, rep: usize) -> Result<Harness, String> {
+    let chunk_runtime = Arc::new(
+        Builder::new_multi_thread()
+            .worker_threads(options.chunk_workers)
+            .thread_name("chunk-worker")
+            .enable_all()
+            .build()
+            .map_err(|error| format!("chunk runtime should start: {error}"))?,
+    );
+    let main_runtime = Builder::new_multi_thread()
+        .worker_threads(options.main_workers)
+        .thread_name("main-worker")
+        .enable_all()
+        .build()
+        .map_err(|error| format!("main runtime should start: {error}"))?;
+
+    let generation_pool = Arc::new(
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(options.generation_threads)
+            .thread_name(|index| format!("rayon-gen-{index}"))
+            .build()
+            .map_err(|error| format!("generation pool should start: {error}"))?,
+    );
+    let encoding_pool = Arc::new(
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(options.encoding_threads)
+            .thread_name(|index| format!("rayon-chunk-enc-{index}"))
+            .build()
+            .map_err(|error| format!("encoding pool should start: {error}"))?,
+    );
+
+    let generator_key = Identifier::vanilla_static("overworld");
+    let generator_registry = WorldGeneratorRegistry::new_with_builtins()
+        .map_err(|error| format!("built-in generators should register: {error}"))?;
+    let generator_config = generator_registry
+        .validate_config(&generator_key, &Value::Table(Map::new()))
+        .map_err(|error| format!("overworld generator config should validate: {error}"))?;
+    let generator_output = generator_registry
+        .create(
+            None,
+            &generator_config,
+            options.seed,
+            generation_pool.clone(),
+        )
+        .map_err(|error| format!("overworld generator should build: {error}"))?;
+
+    let (storage, storage_config) = if options.ram_only {
+        (None, WorldStorageConfig::RamOnly)
+    } else {
+        let root = storage_root(rep);
+        fs::create_dir_all(&root)
+            .map_err(|error| format!("bench storage directory should be creatable: {error}"))?;
+        let path = root.to_string_lossy().into_owned();
+        (Some(root), WorldStorageConfig::Disk { path })
+    };
+
+    let generation_settings = WorldGenerationSettings::from_generator_config(
+        generator_key,
+        &generator_output.config,
+        generator_output.dimension_type.key.clone(),
+        generator_output.dimension_type.min_y,
+        generator_output.dimension_type.height,
+    );
+    let is_flat = generator_output.is_flat;
+    let sea_level = generator_output.sea_level;
+    let dimension_type = generator_output.dimension_type;
+
+    let world = main_runtime
+        .block_on(World::new_with_config_and_encoding_pool(
+            Arc::clone(&chunk_runtime),
+            vanilla_dimension_types::OVERWORLD.key.clone(),
+            dimension_type,
+            options.seed,
+            WorldConfig {
+                storage: storage_config,
+                level_data_path: None,
+                generator: Arc::new(generator_output.generator),
+                generation_settings,
+                view_distance: 10,
+                simulation_distance: 10,
+                max_chained_neighbor_updates: 1_000_000,
+                compression: None,
+                is_flat,
+                sea_level,
+                default_gamemode: GameType::Survival,
+                difficulty: Difficulty::Normal,
+            },
+            generation_pool,
+            encoding_pool,
+        ))
+        .map_err(|error| format!("bench world should initialize: {error}"))?;
+
+    Ok(Harness {
+        world,
+        main_runtime,
+        _chunk_runtime: chunk_runtime,
+        storage,
+    })
+}
+
+impl Harness {
+    fn run(&self, options: &Options) -> Result<Duration, String> {
+        let cancel_token = CancellationToken::new();
+        self.main_runtime
+            .block_on(pregen_area_for_benchmark(
+                &self.world,
+                ChunkPos::new(0, 0),
+                options.size,
+                options.window_size,
+                &cancel_token,
+            ))?
+            .ok_or_else(|| "pregeneration was cancelled".to_owned())
+    }
+
+    /// Quiesces the world the way server shutdown does, so the next rep does not
+    /// start while this one is still generating and saving.
+    fn shutdown(self, keep_storage: bool) {
+        let Self {
+            world,
+            main_runtime,
+            _chunk_runtime,
+            storage,
+        } = self;
+        main_runtime.block_on(async {
+            world.chunk_map.stop_generation_refill_loop();
+            world.chunk_map.task_tracker.close();
+            world.chunk_map.task_tracker.wait().await;
+        });
+        drop(world);
+        match storage {
+            Some(storage) if keep_storage => {
+                println!("  storage kept at {}", storage.display());
+            }
+            Some(storage) => {
+                let _ = fs::remove_dir_all(storage);
+            }
+            None => {}
+        }
+    }
+}
+
+fn main() {
+    let options = match Options::parse() {
+        Ok(options) => options,
+        Err(error) => {
+            eprintln!("error: {error}");
+            process::exit(2);
+        }
+    };
+
+    init_globals_once();
+
+    let total_chunks = f64::from(options.size) * f64::from(options.size);
+    println!(
+        "pregen {size}x{size} ({total} chunks), seed {seed}, {gen} generation threads, \
+    {chunk} chunk workers, {main} main workers, {store}",
+        size = options.size,
+        total = total_chunks as u64,
+        seed = options.seed,
+        gen = options.generation_threads,
+        chunk = options.chunk_workers,
+        main = options.main_workers,
+        store = if options.ram_only { "ram-only" } else { "disk" },
+    );
+
+    let mut rates = Vec::with_capacity(options.reps);
+    for rep in 0..options.reps {
+        let harness = match build_harness(&options, rep) {
+            Ok(harness) => harness,
+            Err(error) => {
+                eprintln!("error: {error}");
+                process::exit(1);
+            }
+        };
+        let elapsed = match harness.run(&options) {
+            Ok(elapsed) => elapsed,
+            Err(error) => {
+                eprintln!("error: {error}");
+                process::exit(1);
+            }
+        };
+        harness.shutdown(options.keep_storage);
+
+        let rate = total_chunks / elapsed.as_secs_f64();
+        rates.push(rate);
+        let rss = match rss_mib() {
+            Some((now, peak)) => format!("  RSS {now} MiB (peak {peak})"),
+            None => String::new(),
+        };
+        println!(
+            "  rep {}: {:.2}s  {rate:.1} chunks/s{rss}",
+            rep + 1,
+            elapsed.as_secs_f64(),
+        );
+    }
+
+    let mean = rates.iter().sum::<f64>() / rates.len() as f64;
+    let min = rates.iter().copied().fold(f64::INFINITY, f64::min);
+    let max = rates.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+    println!(
+        "mean {mean:.1} chunks/s  (min {min:.1}, max {max:.1}, spread {:.2}%)",
+        if mean > 0.0 {
+            (max - min) / mean * 100.0
+        } else {
+            0.0
+        },
+    );
+}

--- a/steel-core/benches/pregen.rs
+++ b/steel-core/benches/pregen.rs
@@ -23,6 +23,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use steel_core::bootstrap::init_globals_once;
 use steel_core::config::WorldStorageConfig;
 use steel_core::level_data::WorldGenerationSettings;
+use steel_core::server::pools::{build_chunk_encoding_pool, build_generation_pool};
 use steel_core::server::pregen::pregen_area_for_benchmark;
 use steel_core::world::{World, WorldConfig};
 use steel_core::worldgen::WorldGeneratorRegistry;
@@ -187,20 +188,8 @@ fn build_harness(options: &Options, rep: usize) -> Result<Harness, String> {
         .build()
         .map_err(|error| format!("main runtime should start: {error}"))?;
 
-    let generation_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(options.generation_threads)
-            .thread_name(|index| format!("rayon-gen-{index}"))
-            .build()
-            .map_err(|error| format!("generation pool should start: {error}"))?,
-    );
-    let encoding_pool = Arc::new(
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(options.encoding_threads)
-            .thread_name(|index| format!("rayon-chunk-enc-{index}"))
-            .build()
-            .map_err(|error| format!("encoding pool should start: {error}"))?,
-    );
+    let generation_pool = build_generation_pool(Some(options.generation_threads))?;
+    let encoding_pool = build_chunk_encoding_pool(Some(options.encoding_threads))?;
 
     let generator_key = Identifier::vanilla_static("overworld");
     let generator_registry = WorldGeneratorRegistry::new_with_builtins()
@@ -227,13 +216,8 @@ fn build_harness(options: &Options, rep: usize) -> Result<Harness, String> {
         (Some(root), WorldStorageConfig::Disk { path })
     };
 
-    let generation_settings = WorldGenerationSettings::from_generator_config(
-        generator_key,
-        &generator_output.config,
-        generator_output.dimension_type.key.clone(),
-        generator_output.dimension_type.min_y,
-        generator_output.dimension_type.height,
-    );
+    let generation_settings =
+        WorldGenerationSettings::from_generator_output(generator_key, &generator_output);
     let is_flat = generator_output.is_flat;
     let sea_level = generator_output.sea_level;
     let dimension_type = generator_output.dimension_type;
@@ -295,9 +279,7 @@ impl Harness {
             storage,
         } = self;
         main_runtime.block_on(async {
-            world.chunk_map.stop_generation_refill_loop();
-            world.chunk_map.task_tracker.close();
-            world.chunk_map.task_tracker.wait().await;
+            world.chunk_map.quiesce().await;
         });
         drop(world);
         match storage {

--- a/steel-core/src/chunk/chunk_map/mod.rs
+++ b/steel-core/src/chunk/chunk_map/mod.rs
@@ -432,6 +432,13 @@ impl ChunkMap {
         self.generation_refill_notify.notify_waiters();
     }
 
+    /// Stops generation and waits for the outstanding chunk work to finish.
+    pub async fn quiesce(&self) {
+        self.stop_generation_refill_loop();
+        self.task_tracker.close();
+        self.task_tracker.wait().await;
+    }
+
     pub(crate) fn notify_generation_refill(&self) {
         self.generation_refill_notify.notify_one();
     }

--- a/steel-core/src/level_data/mod.rs
+++ b/steel-core/src/level_data/mod.rs
@@ -17,6 +17,8 @@ use steel_utils::types::Difficulty;
 use steel_utils::{BlockPos, GlobalPos, Identifier};
 use tokio::fs;
 
+use crate::worldgen::GeneratorOutput;
+
 use crate::world::clock::WorldClockManager;
 
 /// Persistent world border data stored with Steel level data.
@@ -134,6 +136,18 @@ impl WorldGenerationSettings {
             min_y,
             height,
         }
+    }
+
+    /// The same, taking the dimension fields from a built generator.
+    #[must_use]
+    pub fn from_generator_output(generator: Identifier, output: &GeneratorOutput) -> Self {
+        Self::from_generator_config(
+            generator,
+            &output.config,
+            output.dimension_type.key.clone(),
+            output.dimension_type.min_y,
+            output.dimension_type.height,
+        )
     }
 }
 

--- a/steel-core/src/server/mod.rs
+++ b/steel-core/src/server/mod.rs
@@ -3,7 +3,10 @@ mod broadcasting;
 /// Tick-polled server jobs.
 pub mod jobs;
 mod packet_processor;
+#[cfg(not(feature = "benchmark-support"))]
 mod pregen;
+#[cfg(feature = "benchmark-support")]
+pub mod pregen;
 /// The registry cache for the server.
 pub mod registry_cache;
 mod run_loop;

--- a/steel-core/src/server/mod.rs
+++ b/steel-core/src/server/mod.rs
@@ -4,6 +4,10 @@ mod broadcasting;
 pub mod jobs;
 mod packet_processor;
 #[cfg(not(feature = "benchmark-support"))]
+mod pools;
+#[cfg(feature = "benchmark-support")]
+pub mod pools;
+#[cfg(not(feature = "benchmark-support"))]
 mod pregen;
 #[cfg(feature = "benchmark-support")]
 pub mod pregen;
@@ -38,6 +42,7 @@ use crate::config::{ResolvedWorldConfig, RuntimeConfig, WorldsConfig, validate_l
 use crate::entity::{
     Entity, EntityBase, PendingWorldChangeToken, RemovalReason, SharedEntity, change_entity_world,
 };
+use crate::server::pools::{build_chunk_encoding_pool, build_generation_pool};
 
 use crate::chunk_saver::{ChunkStorage, PersistentEntity, registry::WorldStorageRegistry};
 use crate::level_data::{LevelDataManager, RespawnData, WorldGenerationSettings};
@@ -73,7 +78,7 @@ use crate::worldgen::WorldGeneratorRegistry;
 use crate::worldgen::registry::GeneratorOutput;
 use crossbeam::queue::SegQueue;
 use glam::DVec3;
-use rayon::{ThreadPool, ThreadPoolBuilder};
+use rayon::ThreadPool;
 use rustc_hash::FxHashMap;
 use std::{
     collections::BTreeSet,
@@ -161,23 +166,15 @@ const CHUNK_SENDING_TPS: u64 = 20;
 /// Work duration at which background chunk work is considered slow.
 const SLOW_CHUNK_TICK_THRESHOLD: Duration = Duration::from_millis(50);
 
-fn configured_chunk_generation_threads(configured_threads: Option<usize>) -> Option<usize> {
-    cap_positive_thread_count(configured_threads, available_worker_threads())
-}
-
-fn configured_chunk_encoding_threads(configured_threads: Option<usize>) -> Option<usize> {
-    cap_positive_thread_count(configured_threads, available_worker_threads())
-}
-
 fn configured_packet_workers(configured_workers: Option<usize>) -> usize {
     packet_workers_for_available(configured_workers, available_worker_threads())
 }
 
-fn available_worker_threads() -> usize {
+pub(crate) fn available_worker_threads() -> usize {
     thread::available_parallelism().map_or(4, NonZero::get)
 }
 
-fn cap_positive_thread_count(
+pub(crate) fn cap_positive_thread_count(
     configured_threads: Option<usize>,
     available_threads: usize,
 ) -> Option<usize> {
@@ -302,12 +299,9 @@ fn generation_settings_for_world(
     world_entry: &ResolvedWorldConfig,
     generator_output: &GeneratorOutput,
 ) -> WorldGenerationSettings {
-    WorldGenerationSettings::from_generator_config(
+    WorldGenerationSettings::from_generator_output(
         world_entry.generator_config.generator().clone(),
-        &generator_output.config,
-        generator_output.dimension_type.key.clone(),
-        generator_output.dimension_type.min_y,
-        generator_output.dimension_type.height,
+        generator_output,
     )
 }
 
@@ -557,33 +551,8 @@ impl Server {
             .validate_and_resolve(&generator_registry, &storage_registry)
             .map_err(|e| format!("failed to validate worlds.toml: {e}"))?;
 
-        let generation_pool: Arc<ThreadPool> = Arc::new({
-            let mut builder = ThreadPoolBuilder::new().thread_name(|i| format!("rayon-gen-{i}"));
-            if let Some(chunk_generation_threads) =
-                configured_chunk_generation_threads(config.chunk_generation_threads)
-            {
-                builder = builder.num_threads(chunk_generation_threads);
-            }
-            // Debug builds have deep call chains in density functions that overflow the default 2 MB stack
-            if cfg!(debug_assertions) {
-                builder = builder.stack_size(8 * 1024 * 1024);
-            }
-            builder
-                .build()
-                .map_err(|e| format!("failed to create generation thread pool: {e}"))?
-        });
-        let chunk_encoding_pool = Arc::new({
-            let mut builder =
-                ThreadPoolBuilder::new().thread_name(|i| format!("rayon-chunk-encode-{i}"));
-            if let Some(chunk_encoding_threads) =
-                configured_chunk_encoding_threads(config.chunk_encoding_threads)
-            {
-                builder = builder.num_threads(chunk_encoding_threads);
-            }
-            builder
-                .build()
-                .map_err(|e| format!("failed to create chunk encoding thread pool: {e}"))?
-        });
+        let generation_pool = build_generation_pool(config.chunk_generation_threads)?;
+        let chunk_encoding_pool = build_chunk_encoding_pool(config.chunk_encoding_threads)?;
 
         let player_data_storage = PlayerDataStorage::new(
             resolved_worlds.save_path.clone(),

--- a/steel-core/src/server/pools.rs
+++ b/steel-core/src/server/pools.rs
@@ -1,0 +1,48 @@
+//! The rayon pools the server runs chunk work on.
+
+use std::sync::Arc;
+
+use rayon::{ThreadPool, ThreadPoolBuilder};
+
+use super::{available_worker_threads, cap_positive_thread_count};
+
+/// Builds the chunk generation pool.
+///
+/// `configured_threads` is the operator's count; `None` leaves rayon's default.
+///
+/// # Errors
+/// Returns an error if the pool cannot be started.
+pub fn build_generation_pool(configured_threads: Option<usize>) -> Result<Arc<ThreadPool>, String> {
+    let mut builder = ThreadPoolBuilder::new().thread_name(|i| format!("rayon-gen-{i}"));
+    if let Some(threads) = cap_positive_thread_count(configured_threads, available_worker_threads())
+    {
+        builder = builder.num_threads(threads);
+    }
+    // Debug builds have deep call chains in density functions that overflow the
+    // default 2 MB stack.
+    if cfg!(debug_assertions) {
+        builder = builder.stack_size(8 * 1024 * 1024);
+    }
+    builder
+        .build()
+        .map(Arc::new)
+        .map_err(|error| format!("failed to create generation thread pool: {error}"))
+}
+
+/// Builds the chunk encoding pool.
+///
+/// # Errors
+/// Returns an error if the pool cannot be started.
+pub fn build_chunk_encoding_pool(
+    configured_threads: Option<usize>,
+) -> Result<Arc<ThreadPool>, String> {
+    let mut builder = ThreadPoolBuilder::new().thread_name(|i| format!("rayon-chunk-encode-{i}"));
+    if let Some(threads) = cap_positive_thread_count(configured_threads, available_worker_threads())
+    {
+        builder = builder.num_threads(threads);
+    }
+    builder
+        .build()
+        .map(Arc::new)
+        .map_err(|error| format!("failed to create chunk encoding thread pool: {error}"))
+}

--- a/steel-core/src/server/pregen.rs
+++ b/steel-core/src/server/pregen.rs
@@ -215,6 +215,42 @@ impl Server {
     }
 }
 
+/// Runs one pregeneration pass with every parameter supplied explicitly.
+///
+/// The server path takes its parameters from the `PREGEN_*` environment
+/// variables and needs a fully built [`Server`], which binds a listener as soon
+/// as it starts. This entry point takes a bare world instead, so a benchmark can
+/// drive the real scheduler -- tickets, epochs, generation, unload and save --
+/// without a network port to contend for or a shared save directory to collide
+/// over. Everything below it is the production path, unchanged.
+///
+/// `window_size` defaults to the server's value when `None`. Returns the wall
+/// time of the pass, or `None` if it was cancelled.
+///
+/// # Errors
+/// Returns an error if `side_length` is not a positive odd integer, or if the
+/// window size exceeds the unload-backpressure budget.
+#[cfg(feature = "benchmark-support")]
+pub async fn pregen_area_for_benchmark(
+    world: &Arc<World>,
+    center_chunk: ChunkPos,
+    side_length: i32,
+    window_size: Option<i32>,
+    cancel_token: &CancellationToken,
+) -> Result<Option<Duration>, String> {
+    let Some(pregen_size) = PregenSize::from_side_length(side_length)? else {
+        return Ok(Some(Duration::ZERO));
+    };
+    let window_size =
+        check_pregen_window_budget(window_size.unwrap_or(DEFAULT_PREGEN_WINDOW_SIZE))?;
+
+    let start = Instant::now();
+    let completed =
+        generate_pregen(world, center_chunk, pregen_size, window_size, cancel_token).await;
+
+    Ok(completed.then(|| start.elapsed()))
+}
+
 fn get_pregen_size() -> Result<Option<PregenSize>, String> {
     let side_length = match env::var(PREGEN_SIZE_ENV) {
         Ok(value) => value
@@ -243,6 +279,14 @@ fn parse_pregen_window_size(value: &str) -> Result<i32, String> {
     let window_size = value
         .parse::<i32>()
         .map_err(|error| format!("{PREGEN_WINDOW_SIZE_ENV} must be a positive integer: {error}"))?;
+    check_pregen_window_budget(window_size)
+}
+
+/// Checks a window size against the unload-backpressure budget.
+///
+/// Shared by the environment-variable path and by
+/// [`pregen_area_for_benchmark`], which supplies the size directly.
+fn check_pregen_window_budget(window_size: i32) -> Result<i32, String> {
     if window_size <= 0 {
         return Err(format!(
             "{PREGEN_WINDOW_SIZE_ENV} must be a positive integer"

--- a/steel-core/src/world/mod.rs
+++ b/steel-core/src/world/mod.rs
@@ -333,7 +333,55 @@ impl World {
         .await
     }
 
+    /// Creates a world with an explicit chunk-encoding pool.
+    ///
+    /// Public under `benchmark-support` so the pregeneration benchmark can build
+    /// a world with the same pool split the server uses, without a `Server`.
+    #[cfg(feature = "benchmark-support")]
+    pub async fn new_with_config_and_encoding_pool(
+        chunk_runtime: Arc<Runtime>,
+        key: Identifier,
+        dimension_type: DimensionTypeRef,
+        seed: i64,
+        config: WorldConfig,
+        generation_pool: Arc<rayon::ThreadPool>,
+        chunk_encoding_pool: Arc<rayon::ThreadPool>,
+    ) -> io::Result<Arc<Self>> {
+        Self::new_with_config_and_encoding_pool_impl(
+            chunk_runtime,
+            key,
+            dimension_type,
+            seed,
+            config,
+            generation_pool,
+            chunk_encoding_pool,
+        )
+        .await
+    }
+
+    #[cfg(not(feature = "benchmark-support"))]
     pub(crate) async fn new_with_config_and_encoding_pool(
+        chunk_runtime: Arc<Runtime>,
+        key: Identifier,
+        dimension_type: DimensionTypeRef,
+        seed: i64,
+        config: WorldConfig,
+        generation_pool: Arc<rayon::ThreadPool>,
+        chunk_encoding_pool: Arc<rayon::ThreadPool>,
+    ) -> io::Result<Arc<Self>> {
+        Self::new_with_config_and_encoding_pool_impl(
+            chunk_runtime,
+            key,
+            dimension_type,
+            seed,
+            config,
+            generation_pool,
+            chunk_encoding_pool,
+        )
+        .await
+    }
+
+    async fn new_with_config_and_encoding_pool_impl(
         chunk_runtime: Arc<Runtime>,
         key: Identifier,
         dimension_type: DimensionTypeRef,

--- a/steel/src/main.rs
+++ b/steel/src/main.rs
@@ -396,9 +396,7 @@ async fn shutdown_worlds(server: &Arc<Server>) {
     }
 
     for world in server.worlds.values() {
-        world.chunk_map.stop_generation_refill_loop();
-        world.chunk_map.task_tracker.close();
-        world.chunk_map.task_tracker.wait().await;
+        world.chunk_map.quiesce().await;
     }
 
     let mut players_to_save = Vec::new();


### PR DESCRIPTION
Headless pregen benchmark so we can measure the whole pipeline (tickets, scheduling, generation, unload, saves) without running the server binary and fighting over port 25565 and `saves/`.

Stacked on #314, so it shows both commits for now - only the second one is this PR.