### PR TITLE
feat: Add in-memory gameplay test harness

### DIFF
--- a/steel-core/Cargo.toml
+++ b/steel-core/Cargo.toml
@@ -12,6 +12,7 @@ stand-alone = []
 slow_chunk_gen = []
 flint = []
 benchmark-support = []
+test-harness = []
 
 [dependencies]
 # Internal crates

--- a/steel-core/src/bootstrap.rs
+++ b/steel-core/src/bootstrap.rs
@@ -30,9 +30,8 @@ pub(crate) fn init_globals() -> Result<(), String> {
     Ok(())
 }
 
-/// Idempotent [`init_globals`] for tests and benchmarks, which bootstrap
-/// repeatedly in one process.
-#[cfg(any(test, feature = "benchmark-support"))]
+/// Idempotent [`init_globals`] for in-process test and benchmark runtimes.
+#[cfg(any(test, feature = "benchmark-support", feature = "test-harness"))]
 pub fn init_globals_once() {
     use std::sync::Once;
 

--- a/steel-core/src/chunk/chunk_holder.rs
+++ b/steel-core/src/chunk/chunk_holder.rs
@@ -1193,6 +1193,13 @@ impl ChunkHolder {
         }
     }
 
+    /// Runs the normal generated-chunk Full promotion and publication boundary synchronously.
+    #[cfg(feature = "test-harness")]
+    pub(crate) fn promote_to_full_for_test_harness(self: &Arc<Self>) {
+        self.upgrade_to_full();
+        self.finish_generation_status(ChunkStatus::Full);
+    }
+
     /// Runs Full-load post-processing and returns the number of packed positions attempted.
     pub(crate) fn post_process_generation(&self) -> Result<usize, PostProcessGenerationError> {
         let postprocessing = {

--- a/steel-core/src/chunk/chunk_map/mod.rs
+++ b/steel-core/src/chunk/chunk_map/mod.rs
@@ -58,6 +58,8 @@ use crate::chunk::light::{
     propagate_sky_light_changes_with_empty_sections,
 };
 use crate::chunk::player_chunk_view::PlayerChunkView;
+#[cfg(feature = "test-harness")]
+use crate::chunk::section::{ChunkSection, Sections};
 use crate::chunk::{
     Chunk,
     chunk_generation_task::ChunkGenerationTask,
@@ -213,6 +215,25 @@ struct ReadinessReconcileResult {
     post_process_chunk_count: usize,
     post_process_position_count: usize,
     candidate_count: usize,
+}
+
+/// Failure while synchronously installing Full chunks for the in-memory test harness.
+#[cfg(feature = "test-harness")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TestHarnessChunkError {
+    /// The configured dimension height cannot be represented by chunk sections.
+    InvalidWorldHeight { height: i32 },
+    /// The requested halo extends beyond representable chunk coordinates.
+    HaloCoordinateOverflow { center: ChunkPos, radius: u8 },
+    /// An existing holder has not completed its Full lifecycle.
+    ChunkNotFull {
+        pos: ChunkPos,
+        status: Option<ChunkStatus>,
+    },
+    /// Another lifecycle operation claimed the position during installation.
+    ChunkInsertConflict { pos: ChunkPos },
+    /// An unloading holder could not be revived synchronously.
+    ChunkLifecycleUnavailable { pos: ChunkPos },
 }
 
 /// A map of chunks managing their state, loading, and generation.
@@ -478,6 +499,139 @@ impl ChunkMap {
         assert!(holder.simulation_level().is_none());
         assert!(self.ticking_chunks.load().block.is_empty());
         let _ = self.chunks.insert_sync(pos, holder);
+    }
+
+    /// Installs an empty Full halo through the normal holder publication and readiness paths.
+    ///
+    /// The caller must serialize this with world ticks. Existing Full chunks are reused, newly
+    /// created halo chunks are load-only, and `center` receives the requested simulation level.
+    #[cfg(feature = "test-harness")]
+    pub(crate) fn install_test_harness_full_halo(
+        self: &Arc<Self>,
+        center: ChunkPos,
+        radius: u8,
+        simulation_level: ChunkTicketLevel,
+    ) -> Result<Arc<ChunkHolder>, TestHarnessChunkError> {
+        let min_y = self.world_gen_context.min_y();
+        let height = self.world_gen_context.height();
+        if height <= 0 || height % 16 != 0 {
+            return Err(TestHarnessChunkError::InvalidWorldHeight { height });
+        }
+
+        let positions = Self::test_harness_halo_positions(center, radius)?;
+        for &pos in &positions {
+            if let Some(holder) = self.chunks.read_sync(&pos, |_, holder| Arc::clone(holder))
+                && holder.published_status() != Some(ChunkStatus::Full)
+            {
+                return Err(TestHarnessChunkError::ChunkNotFull {
+                    pos,
+                    status: holder.published_status(),
+                });
+            }
+        }
+
+        let mut changed_positions = Vec::with_capacity(positions.len());
+        for pos in positions {
+            let requested_simulation = (pos == center).then_some(simulation_level);
+            let requested_load_level = if pos == center {
+                simulation_level
+            } else {
+                ChunkTicketLevel::FULL_CHUNK
+            };
+            let existing = self.chunks.read_sync(&pos, |_, holder| Arc::clone(holder));
+            let load_level = existing
+                .as_ref()
+                .and_then(|holder| holder.load_level())
+                .map_or(requested_load_level, |current| {
+                    current.min(requested_load_level)
+                });
+            let simulation = match (
+                existing
+                    .as_ref()
+                    .and_then(|holder| holder.simulation_level()),
+                requested_simulation,
+            ) {
+                (Some(current), Some(requested)) => Some(current.min(requested)),
+                (Some(current), None) => Some(current),
+                (None, requested) => requested,
+            };
+            if let Some(holder) = existing
+                && holder.load_level() == Some(load_level)
+                && holder.simulation_level() == simulation
+            {
+                changed_positions.push(pos);
+                continue;
+            }
+            let holder = self
+                .update_chunk_level(pos, Some(load_level), simulation)
+                .ok_or(TestHarnessChunkError::ChunkLifecycleUnavailable { pos })?;
+
+            if holder.published_status() == Some(ChunkStatus::Full) {
+                changed_positions.push(pos);
+                continue;
+            }
+
+            if holder.published_status().is_some() {
+                return Err(TestHarnessChunkError::ChunkInsertConflict { pos });
+            }
+            let sections = (0..height / 16)
+                .map(|_| ChunkSection::new_empty())
+                .collect::<Vec<_>>()
+                .into_boxed_slice();
+            holder.insert_chunk(
+                Chunk::new(
+                    Sections::from_owned(sections),
+                    pos,
+                    min_y,
+                    height,
+                    self.world_gen_context.weak_world(),
+                ),
+                ChunkStatus::Empty,
+            );
+            self.world_gen_context.world().on_entity_chunk_loaded(pos);
+            holder.promote_to_full_for_test_harness();
+            changed_positions.push(pos);
+        }
+
+        match self.reconcile_ticking_readiness_measured(&changed_positions) {
+            Ok(_) => {}
+            Err(error) => {
+                self.recover_ticking_readiness_index(error);
+            }
+        }
+        self.rebuild_ticking_chunk_snapshot();
+
+        self.chunks
+            .read_sync(&center, |_, holder| Arc::clone(holder))
+            .ok_or(TestHarnessChunkError::ChunkLifecycleUnavailable { pos: center })
+    }
+
+    #[cfg(feature = "test-harness")]
+    fn test_harness_halo_positions(
+        center: ChunkPos,
+        radius: u8,
+    ) -> Result<Vec<ChunkPos>, TestHarnessChunkError> {
+        let side = usize::from(radius) * 2 + 1;
+        let mut positions = Vec::with_capacity(side * side);
+        let radius = i32::from(radius);
+        for dz in -radius..=radius {
+            for dx in -radius..=radius {
+                let Some(x) = center.0.x.checked_add(dx) else {
+                    return Err(TestHarnessChunkError::HaloCoordinateOverflow {
+                        center,
+                        radius: radius as u8,
+                    });
+                };
+                let Some(z) = center.0.y.checked_add(dz) else {
+                    return Err(TestHarnessChunkError::HaloCoordinateOverflow {
+                        center,
+                        radius: radius as u8,
+                    });
+                };
+                positions.push(ChunkPos::new(x, z));
+            }
+        }
+        Ok(positions)
     }
 
     #[inline]

--- a/steel-core/src/lib.rs
+++ b/steel-core/src/lib.rs
@@ -25,6 +25,8 @@ pub mod poi;
 pub(crate) mod portal;
 pub mod scoreboard;
 pub mod server;
+#[cfg(feature = "test-harness")]
+pub mod test_harness;
 #[cfg(test)]
 #[path = "../tests/support/mod.rs"]
 pub(crate) mod test_support;

--- a/steel-core/src/test_harness.rs
+++ b/steel-core/src/test_harness.rs
@@ -1,0 +1,21 @@
+//! Single-threaded, in-memory Steel runtime for external behavior test adapters.
+//!
+//! This module owns the infrastructure needed to exercise production [`World`] and
+//! [`Player`] behavior without starting a network server. It deliberately contains no
+//! test-framework-specific types.
+//!
+//! [`Player`]: crate::player::Player
+//! [`World`]: crate::world::World
+
+mod connection;
+mod error;
+mod player;
+mod world;
+
+pub use connection::{RecordedConnectionEvent, RecordingConnection};
+pub use error::TestHarnessError;
+pub use player::TestPlayer;
+pub use world::InMemoryWorld;
+
+#[cfg(test)]
+mod tests;

--- a/steel-core/src/test_harness/connection.rs
+++ b/steel-core/src/test_harness/connection.rs
@@ -1,0 +1,105 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use steel_protocol::packet_traits::{CompressionInfo, EncodedPacket};
+use steel_utils::locks::SyncMutex;
+use text_components::TextComponent;
+
+use crate::player::connection::NetworkConnection;
+
+/// One event observed by a [`RecordingConnection`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RecordedConnectionEvent {
+    /// One encoded client-bound packet.
+    Packet(Vec<u8>),
+    /// One atomic encoded packet bundle.
+    Bundle(Vec<Vec<u8>>),
+    /// A server-requested disconnect.
+    Disconnected(String),
+}
+
+#[derive(Default)]
+struct RecordingConnectionState {
+    events: SyncMutex<Vec<RecordedConnectionEvent>>,
+    closed: AtomicBool,
+}
+
+/// Cloneable observer for the non-networked connection attached to a test player.
+#[derive(Clone, Default)]
+pub struct RecordingConnection {
+    state: Arc<RecordingConnectionState>,
+}
+
+impl RecordingConnection {
+    /// Returns a stable snapshot of all connection events in send order.
+    #[must_use]
+    pub fn events(&self) -> Vec<RecordedConnectionEvent> {
+        self.state.events.lock().clone()
+    }
+
+    /// Clears previously recorded connection events.
+    pub fn clear(&self) {
+        self.state.events.lock().clear();
+    }
+
+    /// Returns whether Steel closed this connection.
+    #[must_use]
+    pub fn is_closed(&self) -> bool {
+        self.state.closed.load(Ordering::Acquire)
+    }
+}
+
+impl NetworkConnection for RecordingConnection {
+    fn compression(&self) -> Option<CompressionInfo> {
+        None
+    }
+
+    fn send_encoded(&self, packet: EncodedPacket) {
+        if self.is_closed() {
+            return;
+        }
+        self.state
+            .events
+            .lock()
+            .push(RecordedConnectionEvent::Packet(
+                packet.encoded_data.as_slice().to_vec(),
+            ));
+    }
+
+    fn send_encoded_bundle(&self, packets: Vec<EncodedPacket>) {
+        if self.is_closed() {
+            return;
+        }
+        self.state
+            .events
+            .lock()
+            .push(RecordedConnectionEvent::Bundle(
+                packets
+                    .into_iter()
+                    .map(|packet| packet.encoded_data.as_slice().to_vec())
+                    .collect(),
+            ));
+    }
+
+    fn disconnect_with_reason(&self, reason: TextComponent) {
+        self.state
+            .events
+            .lock()
+            .push(RecordedConnectionEvent::Disconnected(format!("{reason:?}")));
+        self.close();
+    }
+
+    fn tick(&self) {}
+
+    fn latency(&self) -> i32 {
+        0
+    }
+
+    fn close(&self) {
+        self.state.closed.store(true, Ordering::Release);
+    }
+
+    fn closed(&self) -> bool {
+        self.is_closed()
+    }
+}

--- a/steel-core/src/test_harness/error.rs
+++ b/steel-core/src/test_harness/error.rs
@@ -1,0 +1,147 @@
+use std::io;
+
+use serde_json::Value;
+use steel_utils::{ChunkPos, Identifier};
+use thiserror::Error;
+use tokio::task::JoinError;
+use uuid::Uuid;
+
+use crate::chunk::chunk_map::TestHarnessChunkError;
+use crate::chunk::status::ChunkStatus;
+
+/// Errors returned by the in-memory Steel test harness.
+#[derive(Debug, Error)]
+pub enum TestHarnessError {
+    /// The single-thread Tokio runtime could not be created.
+    #[error("failed to create the test harness runtime: {0}")]
+    Runtime(#[source] io::Error),
+    /// The single-thread chunk-generation pool could not be created.
+    #[error("failed to create the test harness generation pool: {0}")]
+    GenerationPool(#[source] rayon::ThreadPoolBuildError),
+    /// Steel could not initialize the RAM-only world.
+    #[error("failed to initialize the in-memory world: {0}")]
+    World(#[source] io::Error),
+    /// The runtime task responsible for world initialization stopped unexpectedly.
+    #[error("the in-memory world initialization task stopped: {0}")]
+    WorldTask(#[source] JoinError),
+    /// The configured dimension height cannot be represented by whole chunk sections.
+    #[error("invalid test world height {height}; it must be positive and divisible by 16")]
+    InvalidWorldHeight {
+        /// Configured world height.
+        height: i32,
+    },
+    /// A chunk already existed but had not reached the required state.
+    #[error("chunk {pos:?} exists at {status:?}, but the harness requires Full")]
+    ChunkNotFull {
+        /// Requested chunk position.
+        pos: ChunkPos,
+        /// Currently published status, if any.
+        status: Option<ChunkStatus>,
+    },
+    /// A concurrent or external insertion claimed the same chunk position.
+    #[error("chunk {pos:?} was inserted concurrently")]
+    ChunkInsertConflict {
+        /// Requested chunk position.
+        pos: ChunkPos,
+    },
+    /// The requested Full halo extends beyond representable chunk coordinates.
+    #[error("the radius-{radius} Full halo around {center:?} exceeds chunk coordinates")]
+    HaloCoordinateOverflow {
+        /// Requested center chunk.
+        center: ChunkPos,
+        /// Required halo radius.
+        radius: u8,
+    },
+    /// A retained chunk could not enter the active lifecycle synchronously.
+    #[error("chunk {pos:?} could not enter the active test-harness lifecycle")]
+    ChunkLifecycleUnavailable {
+        /// Requested chunk position.
+        pos: ChunkPos,
+    },
+    /// The harness failed to publish the requested chunk ticking readiness.
+    #[error("chunk {pos:?} did not become {required} ticking")]
+    ChunkNotTicking {
+        /// Requested chunk position.
+        pos: ChunkPos,
+        /// Required ticking level.
+        required: &'static str,
+    },
+    /// The Overworld clock or day timeline is unavailable.
+    #[error("the vanilla Overworld day clock is unavailable")]
+    MissingOverworldClock,
+    /// Daytime must be one tick within a vanilla day.
+    #[error("invalid daytime {value}; expected 0..={max}")]
+    InvalidDaytime {
+        /// Rejected daytime value.
+        value: u32,
+        /// Largest accepted daytime value.
+        max: u32,
+    },
+    /// The world's stored clock value could not be represented as daytime.
+    #[error("invalid stored Overworld clock value {value}")]
+    InvalidStoredDaytime {
+        /// Stored total tick value.
+        value: i64,
+    },
+    /// The tick counter exhausted its representable range.
+    #[error("test harness tick counter overflowed")]
+    TickOverflow,
+    /// A game-rule key was not registered by Steel.
+    #[error("unknown game rule {key}")]
+    UnknownGameRule {
+        /// Unregistered game-rule key.
+        key: Identifier,
+    },
+    /// A serialized game-rule value did not match its registered type or limits.
+    #[error("invalid value {value} for game rule {key}")]
+    InvalidGameRuleValue {
+        /// Registered game-rule key.
+        key: Identifier,
+        /// Rejected serialized value.
+        value: Value,
+    },
+    /// A player name did not satisfy Minecraft's profile-name rules.
+    #[error("invalid player name {name:?}")]
+    InvalidPlayerName {
+        /// Rejected profile name.
+        name: String,
+    },
+    /// The UUID is already attached to this world.
+    #[error("player UUID {uuid} is already attached to the test world")]
+    DuplicatePlayerUuid {
+        /// Already registered player UUID.
+        uuid: Uuid,
+    },
+    /// The entity ID is already owned by an entity in this world.
+    #[error("entity ID {entity_id} is already registered in the test world")]
+    DuplicateEntityId {
+        /// Already registered runtime entity ID.
+        entity_id: i32,
+    },
+    /// Production world lifecycle rejected the player registration.
+    #[error("Steel rejected player {name:?} during world attachment")]
+    PlayerRegistrationRejected {
+        /// Rejected player's profile name.
+        name: String,
+    },
+}
+
+impl From<TestHarnessChunkError> for TestHarnessError {
+    fn from(error: TestHarnessChunkError) -> Self {
+        match error {
+            TestHarnessChunkError::InvalidWorldHeight { height } => {
+                Self::InvalidWorldHeight { height }
+            }
+            TestHarnessChunkError::HaloCoordinateOverflow { center, radius } => {
+                Self::HaloCoordinateOverflow { center, radius }
+            }
+            TestHarnessChunkError::ChunkNotFull { pos, status } => {
+                Self::ChunkNotFull { pos, status }
+            }
+            TestHarnessChunkError::ChunkInsertConflict { pos } => Self::ChunkInsertConflict { pos },
+            TestHarnessChunkError::ChunkLifecycleUnavailable { pos } => {
+                Self::ChunkLifecycleUnavailable { pos }
+            }
+        }
+    }
+}

--- a/steel-core/src/test_harness/player.rs
+++ b/steel-core/src/test_harness/player.rs
@@ -1,0 +1,105 @@
+use std::sync::{Arc, Weak};
+
+use crate::config::RuntimeConfig;
+use crate::player::{
+    ClientInformation, GameProfile, Player, PlayerConnection, ResetReason, is_valid_player_name,
+};
+use crate::world::World;
+use uuid::Uuid;
+
+use super::{RecordingConnection, TestHarnessError};
+
+/// An attached production [`Player`] and its observable connection.
+pub struct TestPlayer {
+    player: Arc<Player>,
+    connection: RecordingConnection,
+}
+
+impl TestPlayer {
+    pub(super) fn attach(
+        world: &Arc<World>,
+        uuid: Uuid,
+        name: String,
+        entity_id: i32,
+    ) -> Result<Self, TestHarnessError> {
+        if !is_valid_player_name(&name) {
+            return Err(TestHarnessError::InvalidPlayerName { name });
+        }
+        if world.players.get_by_uuid(&uuid).is_some() || world.get_entity_by_uuid(&uuid).is_some() {
+            return Err(TestHarnessError::DuplicatePlayerUuid { uuid });
+        }
+        if world.players.get_by_entity_id(entity_id).is_some()
+            || world.get_entity_by_id(entity_id).is_some()
+        {
+            return Err(TestHarnessError::DuplicateEntityId { entity_id });
+        }
+
+        let connection = RecordingConnection::default();
+        let player_connection = Arc::new(PlayerConnection::Other(Box::new(connection.clone())));
+        let player = Arc::new(Player::new(
+            GameProfile {
+                id: uuid,
+                name: name.clone(),
+                properties: Vec::new(),
+                profile_actions: None,
+            },
+            player_connection,
+            Arc::clone(world),
+            Weak::new(),
+            test_runtime_config(),
+            entity_id,
+            ClientInformation::default(),
+        ));
+        if !world.add_player(Arc::clone(&player), ResetReason::InitialJoin) {
+            return Err(TestHarnessError::PlayerRegistrationRejected { name });
+        }
+
+        Ok(Self { player, connection })
+    }
+
+    /// Returns the production player used by Steel gameplay code.
+    #[must_use]
+    pub const fn player(&self) -> &Arc<Player> {
+        &self.player
+    }
+
+    /// Returns the connection observer receiving this player's client-bound packets.
+    #[must_use]
+    pub const fn connection(&self) -> &RecordingConnection {
+        &self.connection
+    }
+}
+
+impl Drop for TestPlayer {
+    fn drop(&mut self) {
+        self.player
+            .get_world()
+            .remove_player_for_world_change(&self.player);
+    }
+}
+
+fn test_runtime_config() -> Arc<RuntimeConfig> {
+    Arc::new(RuntimeConfig {
+        max_players: 1,
+        view_distance: 2,
+        simulation_distance: 2,
+        max_chained_neighbor_updates: 1_000_000,
+        online_mode: false,
+        auth_server: None,
+        profile_server: None,
+        services_server: None,
+        encryption: false,
+        allow_flight: false,
+        motd: String::new(),
+        use_favicon: false,
+        favicon: String::new(),
+        enforce_secure_chat: false,
+        chat_spam_threshold_seconds: 10,
+        command_spam_threshold_seconds: 10,
+        compression: None,
+        server_links: None,
+        packet_workers: Some(1),
+        chunk_generation_threads: Some(1),
+        chunk_encoding_threads: Some(1),
+    })
+}

--- a/steel-core/src/test_harness/tests.rs
+++ b/steel-core/src/test_harness/tests.rs
@@ -1,0 +1,215 @@
+use std::sync::Arc;
+
+use serde_json::json;
+use steel_registry::blocks::block_state_ext::BlockStateExt;
+use steel_registry::fluid::FluidStateExt;
+use steel_registry::vanilla_game_rules::ADVANCE_TIME;
+use steel_registry::{REGISTRY, vanilla_blocks, vanilla_fluids};
+use steel_utils::types::UpdateFlags;
+use steel_utils::{BlockPos, ChunkPos, Identifier};
+use uuid::Uuid;
+
+use super::{InMemoryWorld, TestHarnessError};
+use crate::chunk::chunk_ticket_manager::ChunkTicketLevel;
+use crate::chunk::status::ChunkStatus;
+use crate::world::ScheduledTickAccess;
+
+#[test]
+fn worlds_keep_block_state_isolated() -> Result<(), TestHarnessError> {
+    let first = InMemoryWorld::new()?;
+    let second = InMemoryWorld::new()?;
+    let pos = BlockPos::new(3, 64, 5);
+    let chunk = ChunkPos::from_block_pos(pos);
+    first.ensure_chunk(chunk)?;
+    second.ensure_chunk(chunk)?;
+
+    let stone = REGISTRY.blocks.get_default_state_id(&vanilla_blocks::STONE);
+    let air = REGISTRY.blocks.get_default_state_id(&vanilla_blocks::AIR);
+    assert!(first.world().set_block(pos, stone, UpdateFlags::UPDATE_ALL));
+    assert_eq!(first.world().get_block_state(pos), stone);
+    assert_eq!(second.world().get_block_state(pos), air);
+    Ok(())
+}
+
+#[test]
+fn ensured_chunk_is_full_and_block_ticking() -> Result<(), TestHarnessError> {
+    let mut harness = InMemoryWorld::new()?;
+    let pos = ChunkPos::new(4, -2);
+    harness.ensure_chunk(pos)?;
+    let holder = harness
+        .world()
+        .chunk_map
+        .chunks
+        .read_sync(&pos, |_, holder| Arc::clone(holder))
+        .ok_or(TestHarnessError::ChunkNotFull { pos, status: None })?;
+
+    assert_eq!(holder.published_status(), Some(ChunkStatus::Full));
+    assert!(holder.ticking_readiness_snapshot().is_block_ticking());
+    assert!(
+        holder
+            .simulation_level()
+            .is_some_and(ChunkTicketLevel::is_block_ticking)
+    );
+    assert_full_halo(&harness, pos, 1, ChunkTicketLevel::BLOCK_TICKING_CHUNK);
+    let timings = harness.tick_once()?;
+    assert_eq!(timings.chunk_map.tickable_count, 1);
+    Ok(())
+}
+
+#[test]
+fn scheduled_water_crosses_a_chunk_edge_through_the_full_halo() -> Result<(), TestHarnessError> {
+    let mut harness = InMemoryWorld::new()?;
+    let center = ChunkPos::new(0, 0);
+    harness.ensure_chunk(center)?;
+
+    let source = BlockPos::new(15, 64, 0);
+    let across_edge = BlockPos::new(16, 64, 0);
+    let stone = REGISTRY.blocks.get_default_state_id(&vanilla_blocks::STONE);
+    let water = REGISTRY.blocks.get_default_state_id(&vanilla_blocks::WATER);
+    let fixture_flags = UpdateFlags::UPDATE_NONE | UpdateFlags::UPDATE_SKIP_ON_PLACE;
+
+    for pos in [
+        source.below(),
+        across_edge.below(),
+        BlockPos::new(14, 64, 0),
+        BlockPos::new(15, 64, -1),
+        BlockPos::new(15, 64, 1),
+    ] {
+        assert!(harness.world().set_block(pos, stone, fixture_flags));
+    }
+    assert!(harness.world().set_block(source, water, fixture_flags));
+    assert!(harness.world().get_block_state(across_edge).is_air());
+    assert!(
+        harness
+            .world()
+            .schedule_fluid_tick_default(source, &vanilla_fluids::WATER, 1,)
+    );
+
+    let _ = harness.tick_once()?;
+    let resulting_fluid = harness
+        .world()
+        .get_block_state(across_edge)
+        .get_fluid_state();
+    assert!(resulting_fluid.is_water());
+    assert!(!resulting_fluid.is_empty());
+    Ok(())
+}
+
+#[test]
+fn ticks_and_daytime_are_exact() -> Result<(), TestHarnessError> {
+    let mut harness = InMemoryWorld::new()?;
+    assert_eq!(harness.current_tick(), 0);
+    assert_eq!(harness.daytime()?, 0);
+
+    harness.set_daytime(23_999)?;
+    assert_eq!(harness.daytime()?, 23_999);
+    let _ = harness.tick_once()?;
+    assert_eq!(harness.current_tick(), 1);
+    assert_eq!(harness.daytime()?, 0);
+
+    harness.set_daytime(123)?;
+    harness.set_game_rule(&Identifier::vanilla_static("advance_time"), &json!(false))?;
+    let _ = harness.tick_once()?;
+    assert_eq!(harness.current_tick(), 2);
+    assert_eq!(harness.daytime()?, 123);
+    assert!(matches!(
+        harness.set_daytime(24_000),
+        Err(TestHarnessError::InvalidDaytime { .. })
+    ));
+    Ok(())
+}
+
+#[test]
+fn player_is_attached_through_world_lifecycle() -> Result<(), TestHarnessError> {
+    let harness = InMemoryWorld::new()?;
+    let uuid = Uuid::from_u128(1);
+    let test_player = harness.create_player(uuid, "FlintPlayer", 7)?;
+    assert_full_halo(
+        &harness,
+        ChunkPos::new(0, 0),
+        2,
+        ChunkTicketLevel::ENTITY_TICKING_CHUNK,
+    );
+    assert!(
+        harness
+            .world()
+            .chunk_map
+            .tickable_full_chunk_positions()
+            .contains(&ChunkPos::new(0, 0))
+    );
+    let registered = harness
+        .world()
+        .players
+        .get_by_uuid(&uuid)
+        .ok_or(TestHarnessError::DuplicatePlayerUuid { uuid })?;
+
+    assert!(Arc::ptr_eq(&registered, test_player.player()));
+    assert!(harness.world().get_entity_by_id(7).is_some());
+    assert!(!test_player.connection().events().is_empty());
+    drop(test_player);
+    assert!(harness.world().players.is_empty());
+    assert!(harness.world().get_entity_by_id(7).is_none());
+    Ok(())
+}
+
+#[test]
+fn game_rule_values_are_registry_validated() -> Result<(), TestHarnessError> {
+    let harness = InMemoryWorld::new()?;
+    let advance_time = Identifier::vanilla_static("advance_time");
+    harness.set_game_rule(&advance_time, &json!(false))?;
+    assert!(!harness.world().get_game_rule(&ADVANCE_TIME));
+    assert!(matches!(
+        harness.set_game_rule(&advance_time, &json!("false")),
+        Err(TestHarnessError::InvalidGameRuleValue { .. })
+    ));
+    assert!(matches!(
+        harness.set_game_rule(&Identifier::vanilla_static("missing"), &json!(true)),
+        Err(TestHarnessError::UnknownGameRule { .. })
+    ));
+    Ok(())
+}
+
+#[test]
+fn repeated_world_shutdown_has_no_generation_work() -> Result<(), TestHarnessError> {
+    for index in 0..8 {
+        let mut harness = InMemoryWorld::new()?;
+        harness.ensure_chunk(ChunkPos::new(index, -index))?;
+        let _ = harness.tick_once()?;
+        assert_eq!(harness.world().chunk_map.task_tracker.len(), 1);
+        drop(harness);
+    }
+    Ok(())
+}
+
+fn assert_full_halo(
+    harness: &InMemoryWorld,
+    center: ChunkPos,
+    radius: u8,
+    center_level: ChunkTicketLevel,
+) {
+    let side = usize::from(radius) * 2 + 1;
+    let radius = i32::from(radius);
+    assert_eq!(harness.world().chunk_map.chunks.len(), side * side);
+    for z in center.0.y - radius..=center.0.y + radius {
+        for x in center.0.x - radius..=center.0.x + radius {
+            let pos = ChunkPos::new(x, z);
+            let holder = harness
+                .world()
+                .chunk_map
+                .chunks
+                .read_sync(&pos, |_, holder| Arc::clone(holder));
+            let Some(holder) = holder else {
+                panic!("Full halo is missing {pos:?}");
+            };
+            assert_eq!(holder.published_status(), Some(ChunkStatus::Full));
+            if pos == center {
+                assert_eq!(holder.load_level(), Some(center_level));
+                assert_eq!(holder.simulation_level(), Some(center_level));
+            } else {
+                assert_eq!(holder.load_level(), Some(ChunkTicketLevel::FULL_CHUNK));
+                assert_eq!(holder.simulation_level(), None);
+                assert!(!holder.ticking_readiness_snapshot().is_block_ticking());
+            }
+        }
+    }
+}

--- a/steel-core/src/test_harness/world.rs
+++ b/steel-core/src/test_harness/world.rs
@@ -1,0 +1,336 @@
+use std::sync::Arc;
+
+use futures::executor::block_on;
+use rayon::ThreadPoolBuilder;
+use serde_json::Value;
+use steel_registry::{REGISTRY, vanilla_dimension_types, vanilla_timelines, vanilla_world_clocks};
+use steel_utils::locks::SyncMutex;
+use steel_utils::types::{Difficulty, GameType};
+use steel_utils::{ChunkPos, Identifier};
+use tokio::runtime::{Builder as RuntimeBuilder, Runtime};
+use toml::map::Map;
+use uuid::Uuid;
+
+use crate::bootstrap::init_globals_once;
+use crate::chunk::chunk_holder::ChunkHolder;
+use crate::chunk::chunk_ticket_manager::ChunkTicketLevel;
+use crate::chunk::status::ChunkStatus;
+use crate::level_data::WorldGenerationSettings;
+use crate::world::{World, WorldConfig, WorldGameTickTimings, WorldStorageConfig};
+use crate::worldgen::{ChunkGeneratorType, EmptyChunkGenerator};
+
+use super::{TestHarnessError, TestPlayer};
+
+#[derive(Clone, Copy)]
+enum RequiredReadiness {
+    Block,
+    Entity,
+}
+
+impl RequiredReadiness {
+    const fn ticket_level(self) -> ChunkTicketLevel {
+        match self {
+            Self::Block => ChunkTicketLevel::BLOCK_TICKING_CHUNK,
+            Self::Entity => ChunkTicketLevel::ENTITY_TICKING_CHUNK,
+        }
+    }
+
+    const fn halo_radius(self) -> u8 {
+        match self {
+            Self::Block => 1,
+            Self::Entity => 2,
+        }
+    }
+
+    const fn label(self) -> &'static str {
+        match self {
+            Self::Block => "block",
+            Self::Entity => "entity",
+        }
+    }
+
+    fn is_satisfied_by(self, holder: &ChunkHolder) -> bool {
+        let readiness = holder.ticking_readiness_snapshot();
+        match self {
+            Self::Block => readiness.is_block_ticking(),
+            Self::Entity => readiness.is_entity_ticking(),
+        }
+    }
+}
+
+/// A seed-zero, RAM-only Overworld that runs production Steel gameplay code.
+pub struct InMemoryWorld {
+    world: Arc<World>,
+    _runtime: Arc<Runtime>,
+    current_tick: u64,
+    chunk_mutation: SyncMutex<()>,
+    player_mutation: SyncMutex<()>,
+}
+
+impl InMemoryWorld {
+    /// Creates an empty Overworld with seed zero and deterministic single-thread resources.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the runtime, generation pool, or Steel world cannot initialize.
+    pub fn new() -> Result<Self, TestHarnessError> {
+        init_globals_once();
+
+        let runtime = Arc::new(
+            RuntimeBuilder::new_multi_thread()
+                .worker_threads(1)
+                .thread_name("steel-test-harness-runtime")
+                .enable_all()
+                .build()
+                .map_err(TestHarnessError::Runtime)?,
+        );
+        let generation_pool = Arc::new(
+            ThreadPoolBuilder::new()
+                .num_threads(1)
+                .thread_name(|index| format!("steel-test-harness-{index}"))
+                .build()
+                .map_err(TestHarnessError::GenerationPool)?,
+        );
+        let generator = Arc::new(ChunkGeneratorType::Empty(EmptyChunkGenerator::new()));
+        let generator_config = toml::Value::Table(Map::new());
+        let generation_settings = WorldGenerationSettings::from_generator_config(
+            Identifier::new_static("steel", "empty"),
+            &generator_config,
+            vanilla_dimension_types::OVERWORLD.key.clone(),
+            vanilla_dimension_types::OVERWORLD.min_y,
+            vanilla_dimension_types::OVERWORLD.height,
+        );
+        let config = WorldConfig {
+            storage: WorldStorageConfig::RamOnly,
+            level_data_path: None,
+            generator,
+            generation_settings,
+            view_distance: 2,
+            simulation_distance: 2,
+            max_chained_neighbor_updates: 1_000_000,
+            compression: None,
+            is_flat: false,
+            sea_level: 63,
+            default_gamemode: GameType::Survival,
+            difficulty: Difficulty::Normal,
+        };
+        let world_runtime = Arc::clone(&runtime);
+        let world_task = runtime.spawn(async move {
+            World::new_with_config(
+                world_runtime,
+                Identifier::new_static("steel", "test_harness"),
+                &vanilla_dimension_types::OVERWORLD,
+                0,
+                config,
+                generation_pool,
+            )
+            .await
+        });
+        let world = block_on(world_task)
+            .map_err(TestHarnessError::WorldTask)?
+            .map_err(TestHarnessError::World)?;
+
+        Ok(Self {
+            world,
+            _runtime: runtime,
+            current_tick: 0,
+            chunk_mutation: SyncMutex::new(()),
+            player_mutation: SyncMutex::new(()),
+        })
+    }
+
+    /// Returns the production world used for block, entity, and player operations.
+    ///
+    /// Adapters must serialize world mutations with [`Self::tick_once`], just as Steel's
+    /// server loop serializes its world-mutation phase.
+    #[must_use]
+    pub const fn world(&self) -> &Arc<World> {
+        &self.world
+    }
+
+    /// Makes an empty 3x3 Full halo synchronously available around a block-ticking center.
+    ///
+    /// Newly created halo chunks remain load-only. The requested center receives block simulation
+    /// and confirmed `BlockTicking` readiness through Steel's normal Full publication lifecycle.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if an externally inserted chunk is incomplete or readiness cannot
+    /// be published.
+    pub fn ensure_chunk(&self, pos: ChunkPos) -> Result<(), TestHarnessError> {
+        self.ensure_chunk_with_readiness(pos, RequiredReadiness::Block)
+    }
+
+    /// Makes an empty 5x5 Full halo synchronously available around an entity-ticking center.
+    ///
+    /// The halo remains load-only. The requested center receives entity simulation and confirmed
+    /// `EntityTicking` readiness through Steel's normal Full publication lifecycle.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if an existing chunk is incomplete or the halo cannot be published.
+    pub fn ensure_entity_chunk(&self, pos: ChunkPos) -> Result<(), TestHarnessError> {
+        self.ensure_chunk_with_readiness(pos, RequiredReadiness::Entity)
+    }
+
+    /// Runs exactly one normal production game tick.
+    ///
+    /// Timed chunk tickets advance before [`World::tick_game`], matching the server tick worker.
+    /// The first call runs tick one.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the harness tick counter is exhausted.
+    pub fn tick_once(&mut self) -> Result<WorldGameTickTimings, TestHarnessError> {
+        let next_tick = self
+            .current_tick
+            .checked_add(1)
+            .ok_or(TestHarnessError::TickOverflow)?;
+        self.world.chunk_map.tick_timed_tickets();
+        let timings = self.world.tick_game(next_tick, true);
+        self.current_tick = next_tick;
+        Ok(timings)
+    }
+
+    /// Returns the last completed harness tick, starting at zero.
+    #[must_use]
+    pub const fn current_tick(&self) -> u64 {
+        self.current_tick
+    }
+
+    /// Returns the current tick inside the 24,000-tick Overworld day.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if Steel's Overworld clock is missing or contains invalid state.
+    pub fn daytime(&self) -> Result<u32, TestHarnessError> {
+        let total = self
+            .world
+            .clock_total_ticks(&vanilla_world_clocks::OVERWORLD)
+            .ok_or(TestHarnessError::MissingOverworldClock)?;
+        let period = day_period()?;
+        u32::try_from(total.rem_euclid(i64::from(period)))
+            .map_err(|_| TestHarnessError::InvalidStoredDaytime { value: total })
+    }
+
+    /// Sets the Overworld clock's absolute total to one tick within the day period.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for values outside the vanilla day or if the clock is unavailable.
+    pub fn set_daytime(&self, value: u32) -> Result<(), TestHarnessError> {
+        let period = day_period()?;
+        if value >= period {
+            return Err(TestHarnessError::InvalidDaytime {
+                value,
+                max: period - 1,
+            });
+        }
+        self.world
+            .set_clock_total_ticks(&vanilla_world_clocks::OVERWORLD, i64::from(value))
+            .ok_or(TestHarnessError::MissingOverworldClock)
+    }
+
+    /// Sets a registered game rule from its JSON representation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the key is unknown or the value has the wrong type or range.
+    pub fn set_game_rule(&self, key: &Identifier, value: &Value) -> Result<(), TestHarnessError> {
+        let rule = REGISTRY
+            .game_rules
+            .by_key(key)
+            .ok_or_else(|| TestHarnessError::UnknownGameRule { key: key.clone() })?;
+        let parsed = rule.deserialize_erased_value(value).ok_or_else(|| {
+            TestHarnessError::InvalidGameRuleValue {
+                key: key.clone(),
+                value: value.clone(),
+            }
+        })?;
+        if self.world.set_erased_game_rule(rule, parsed) {
+            Ok(())
+        } else {
+            Err(TestHarnessError::InvalidGameRuleValue {
+                key: key.clone(),
+                value: value.clone(),
+            })
+        }
+    }
+
+    /// Creates a production player and attaches it through Steel's world lifecycle.
+    ///
+    /// The player's starting chunk is made entity-ticking before registration. Entity-ticking
+    /// is stronger than the `BlockTicking` guarantee exposed by [`Self::ensure_chunk`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for invalid identity data, duplicate IDs, or lifecycle rejection.
+    pub fn create_player(
+        &self,
+        uuid: Uuid,
+        name: impl Into<String>,
+        entity_id: i32,
+    ) -> Result<TestPlayer, TestHarnessError> {
+        self.ensure_entity_chunk(ChunkPos::new(0, 0))?;
+        let _guard = self.player_mutation.lock();
+        TestPlayer::attach(&self.world, uuid, name.into(), entity_id)
+    }
+
+    fn ensure_chunk_with_readiness(
+        &self,
+        pos: ChunkPos,
+        required: RequiredReadiness,
+    ) -> Result<(), TestHarnessError> {
+        let _guard = self.chunk_mutation.lock();
+        let level = required.ticket_level();
+        let holder = self.world.chunk_map.install_test_harness_full_halo(
+            pos,
+            required.halo_radius(),
+            level,
+        )?;
+        Self::verify_chunk_readiness(pos, &holder, required)
+    }
+
+    fn verify_chunk_readiness(
+        pos: ChunkPos,
+        holder: &ChunkHolder,
+        required: RequiredReadiness,
+    ) -> Result<(), TestHarnessError> {
+        if holder.published_status() == Some(ChunkStatus::Full) && required.is_satisfied_by(holder)
+        {
+            Ok(())
+        } else {
+            Err(TestHarnessError::ChunkNotTicking {
+                pos,
+                required: required.label(),
+            })
+        }
+    }
+}
+
+impl Drop for InMemoryWorld {
+    fn drop(&mut self) {
+        let mut players = Vec::new();
+        self.world.players.iter_players(|_, player| {
+            players.push(Arc::clone(player));
+            true
+        });
+        for player in players {
+            self.world.remove_player_for_world_change(&player);
+        }
+
+        self.world.chunk_map.stop_generation_refill_loop();
+        self.world.chunk_map.task_tracker.close();
+        block_on(self.world.chunk_map.task_tracker.wait());
+    }
+}
+
+fn day_period() -> Result<u32, TestHarnessError> {
+    let Some(period) = vanilla_timelines::DAY.period_ticks else {
+        return Err(TestHarnessError::MissingOverworldClock);
+    };
+    u32::try_from(period)
+        .ok()
+        .filter(|period| *period > 0)
+        .ok_or(TestHarnessError::MissingOverworldClock)
+}


### PR DESCRIPTION
## Summary

Adds a feature-gated, Flint-independent harness for running real Steel gameplay code without starting a network server.

- creates isolated RAM-only worlds with complete Steel bootstrap
- advances one production-equivalent tick at a time
- prepares production Full safety halos for block-ticking and entity-ticking chunks
- attaches real players through the normal world lifecycle
- exposes a recording connection for protocol-facing assertions
- applies daytime and game rules through a small test API
- cancels and drains background world work during shutdown

This is the Steel half of the working Flint-Steel MVP. The adapter remains in `flint-steel`; this PR adds no Flint dependency.

## Correctness details

`ensure_chunk` installs a 3x3 Full halo with only the center block-ticking. `ensure_entity_chunk` installs a 5x5 Full halo with only the center entity-ticking. Both go through holder publication and readiness reconciliation rather than directly forcing readiness states.

The regression suite includes scheduled water flow across x=15 to x=16, repeated create/use/drop cycles, exact tick advancement, player attachment, world configuration, and clean shutdown.

## Verification

- `cargo test -p steel-core --features test-harness test_harness::tests --no-fail-fast` (7 passed)
- `cargo clippy -p steel-core --features test-harness --all-targets -- -D warnings`
- `cargo check -p steel-core`
- `cargo fmt --all --check`
- `git diff --check`

The complete Flint-Steel runner was also tested five consecutive times against this exact commit, with 35 fixture executions and no skipped tests, panics, or leaked world-generation work.
