### PR TITLE
remove some LevelReader

### DIFF
--- a/steel-core/src/behavior/block/mod.rs
+++ b/steel-core/src/behavior/block/mod.rs
@@ -1104,6 +1104,9 @@ pub trait BlockBehavior: Send + Sync {
 
     /// Returns the analog output signal strength (0-15) for comparators.
     ///
+    /// Vanilla accepts a concrete `Level` here rather than `LevelReader`, so this
+    /// hook is live-world-only.
+    ///
     /// Only called if `has_analog_output_signal()` returns `true`.
     /// For containers, this is typically based on how full they are.
     ///
@@ -1119,7 +1122,7 @@ pub trait BlockBehavior: Send + Sync {
     fn get_analog_output_signal(
         &self,
         state: BlockStateId,
-        world: &dyn LevelReader,
+        world: &World,
         pos: BlockPos,
         direction: Direction,
     ) -> i32 {

--- a/steel-core/src/behavior/blocks/building/cauldron_block.rs
+++ b/steel-core/src/behavior/blocks/building/cauldron_block.rs
@@ -20,7 +20,7 @@ use steel_utils::{BlockPos, BlockStateId, types::UpdateFlags};
 use crate::{
     behavior::{BlockBehavior, BlockPlaceContext, blocks::vegetation},
     entity::ai::path::PathComputationType,
-    world::{LevelReader, World, game_event::GameEventContext},
+    world::{World, game_event::GameEventContext},
 };
 
 /// Vanilla empty cauldron behavior.
@@ -51,7 +51,7 @@ impl BlockBehavior for CauldronBlock {
     fn get_analog_output_signal(
         &self,
         _state: BlockStateId,
-        _world: &dyn LevelReader,
+        _world: &World,
         _pos: BlockPos,
         _direction: Direction,
     ) -> i32 {
@@ -126,7 +126,7 @@ impl BlockBehavior for LayeredCauldronBlock {
     fn get_analog_output_signal(
         &self,
         state: BlockStateId,
-        _world: &dyn LevelReader,
+        _world: &World,
         _pos: BlockPos,
         _direction: Direction,
     ) -> i32 {
@@ -174,21 +174,21 @@ mod tests {
     use super::*;
     use crate::{
         behavior::{BLOCK_BEHAVIORS, init_behaviors},
-        test_support::TestLevel,
+        test_support::fresh_test_world,
     };
 
     #[test]
     fn registered_cauldron_behaviors_expose_vanilla_fill_levels() {
         init_vanilla_registry();
         init_behaviors();
-        let level = TestLevel::default();
+        let world = fresh_test_world("cauldron_analog_output");
         let pos = BlockPos::ZERO;
 
         let empty = vanilla_blocks::CAULDRON.default_state();
         let empty_behavior = BLOCK_BEHAVIORS.get_behavior(empty.get_block());
         assert!(empty_behavior.has_analog_output_signal(empty));
         assert_eq!(
-            empty_behavior.get_analog_output_signal(empty, &level, pos, Direction::North),
+            empty_behavior.get_analog_output_signal(empty, world.as_ref(), pos, Direction::North),
             0,
         );
 
@@ -198,7 +198,7 @@ mod tests {
                 .set_value(LEVEL_CAULDRON, level_value);
             let behavior = BLOCK_BEHAVIORS.get_behavior(state.get_block());
             assert_eq!(
-                behavior.get_analog_output_signal(state, &level, pos, Direction::North),
+                behavior.get_analog_output_signal(state, world.as_ref(), pos, Direction::North),
                 i32::from(level_value),
             );
         }

--- a/steel-core/src/behavior/blocks/building/composter_block.rs
+++ b/steel-core/src/behavior/blocks/building/composter_block.rs
@@ -14,7 +14,7 @@ use steel_utils::{BlockPos, BlockStateId};
 use crate::{
     behavior::{BlockBehavior, BlockPlaceContext},
     entity::ai::path::PathComputationType,
-    world::LevelReader,
+    world::World,
 };
 
 /// Vanilla composter behavior required by analog signal readers.
@@ -45,7 +45,7 @@ impl BlockBehavior for ComposterBlock {
     fn get_analog_output_signal(
         &self,
         state: BlockStateId,
-        _world: &dyn LevelReader,
+        _world: &World,
         _pos: BlockPos,
         _direction: Direction,
     ) -> i32 {
@@ -68,13 +68,14 @@ mod tests {
     use super::*;
     use crate::{
         behavior::{BLOCK_BEHAVIORS, init_behaviors},
-        test_support::TestLevel,
+        test_support::fresh_test_world,
     };
 
     #[test]
     fn registered_composter_outputs_its_full_state_level() {
         init_vanilla_registry();
         init_behaviors();
+        let world = fresh_test_world("composter_analog_output");
         let state = vanilla_blocks::COMPOSTER
             .default_state()
             .set_value(LEVEL_COMPOSTER, 8);
@@ -84,7 +85,7 @@ mod tests {
         assert_eq!(
             behavior.get_analog_output_signal(
                 state,
-                &TestLevel::default(),
+                world.as_ref(),
                 BlockPos::ZERO,
                 Direction::North,
             ),

--- a/steel-core/src/behavior/blocks/building/lava_cauldron_block.rs
+++ b/steel-core/src/behavior/blocks/building/lava_cauldron_block.rs
@@ -63,7 +63,7 @@ impl BlockBehavior for LavaCauldronBlock {
     fn get_analog_output_signal(
         &self,
         _state: BlockStateId,
-        _world: &dyn LevelReader,
+        _world: &World,
         _pos: BlockPos,
         _direction: Direction,
     ) -> i32 {
@@ -103,7 +103,7 @@ mod tests {
     use super::*;
     use crate::{
         behavior::{BLOCK_BEHAVIORS, init_behaviors},
-        test_support::TestLevel,
+        test_support::fresh_test_world,
     };
 
     fn assert_f64_close(actual: f64, expected: f64) {
@@ -132,6 +132,7 @@ mod tests {
     fn registered_lava_cauldron_outputs_three() {
         init_vanilla_registry();
         init_behaviors();
+        let world = fresh_test_world("lava_cauldron_analog_output");
         let state = vanilla_blocks::LAVA_CAULDRON.default_state();
         let behavior = BLOCK_BEHAVIORS.get_behavior(&vanilla_blocks::LAVA_CAULDRON);
 
@@ -139,7 +140,7 @@ mod tests {
         assert_eq!(
             behavior.get_analog_output_signal(
                 state,
-                &TestLevel::default(),
+                world.as_ref(),
                 BlockPos::ZERO,
                 Direction::North,
             ),

--- a/steel-core/src/behavior/blocks/container/barrel_block.rs
+++ b/steel-core/src/behavior/blocks/container/barrel_block.rs
@@ -105,7 +105,7 @@ impl BlockBehavior for BarrelBlock {
     fn get_analog_output_signal(
         &self,
         _state: BlockStateId,
-        world: &dyn LevelReader,
+        world: &World,
         pos: BlockPos,
         _direction: Direction,
     ) -> i32 {

--- a/steel-core/src/behavior/blocks/container/beehive_block.rs
+++ b/steel-core/src/behavior/blocks/container/beehive_block.rs
@@ -14,7 +14,7 @@ use steel_utils::{BlockPos, BlockStateId};
 use crate::behavior::block::{BlockBehavior, BlockEntityCreation};
 use crate::behavior::context::BlockPlaceContext;
 use crate::block_entity::BLOCK_ENTITIES;
-use crate::world::{LevelReader, World};
+use crate::world::World;
 
 /// Behavior for beehive and bee nest blocks.
 // TODO: Implement full vanilla beehive interactions, bee release, smoke/fire handling, loot/data components, and ticking.
@@ -64,7 +64,7 @@ impl BlockBehavior for BeehiveBlock {
     fn get_analog_output_signal(
         &self,
         state: BlockStateId,
-        _world: &dyn LevelReader,
+        _world: &World,
         _pos: BlockPos,
         _direction: Direction,
     ) -> i32 {

--- a/steel-core/src/behavior/blocks/decoration/cake_block.rs
+++ b/steel-core/src/behavior/blocks/decoration/cake_block.rs
@@ -163,7 +163,7 @@ impl BlockBehavior for CakeBlock {
     fn get_analog_output_signal(
         &self,
         state: BlockStateId,
-        _world: &dyn LevelReader,
+        _world: &World,
         _pos: BlockPos,
         _direction: Direction,
     ) -> i32 {

--- a/steel-core/src/behavior/blocks/decoration/candle_cake_block.rs
+++ b/steel-core/src/behavior/blocks/decoration/candle_cake_block.rs
@@ -157,7 +157,7 @@ impl BlockBehavior for CandleCakeBlock {
     fn get_analog_output_signal(
         &self,
         _state: BlockStateId,
-        _world: &dyn LevelReader,
+        _world: &World,
         _pos: BlockPos,
         _direction: Direction,
     ) -> i32 {

--- a/steel-core/src/behavior/blocks/portal/end_portal_frame_block.rs
+++ b/steel-core/src/behavior/blocks/portal/end_portal_frame_block.rs
@@ -10,7 +10,7 @@ use steel_utils::{BlockPos, BlockStateId};
 
 use crate::behavior::block::BlockBehavior;
 use crate::behavior::context::BlockPlaceContext;
-use crate::world::LevelReader;
+use crate::world::World;
 
 /// Behavior for end portal frame blocks.
 #[block_behavior]
@@ -49,7 +49,7 @@ impl BlockBehavior for EndPortalFrameBlock {
     fn get_analog_output_signal(
         &self,
         state: BlockStateId,
-        _world: &dyn LevelReader,
+        _world: &World,
         _pos: BlockPos,
         _direction: Direction,
     ) -> i32 {

--- a/steel-core/src/behavior/blocks/portal/respawn_anchor_block.rs
+++ b/steel-core/src/behavior/blocks/portal/respawn_anchor_block.rs
@@ -270,7 +270,7 @@ impl BlockBehavior for RespawnAnchorBlock {
     fn get_analog_output_signal(
         &self,
         state: BlockStateId,
-        _world: &dyn LevelReader,
+        _world: &World,
         _pos: BlockPos,
         _direction: Direction,
     ) -> i32 {

--- a/steel-core/src/behavior/blocks/redstone/copper_bulb_block.rs
+++ b/steel-core/src/behavior/blocks/redstone/copper_bulb_block.rs
@@ -12,7 +12,7 @@ use steel_utils::{BlockPos, BlockStateId};
 
 use crate::behavior::blocks::{WeatherState, WeatheringCopper};
 use crate::behavior::{BlockBehavior, BlockPlaceContext};
-use crate::world::{LevelReader, SignalGetter as _, World};
+use crate::world::{SignalGetter as _, World};
 
 /// Vanilla `CopperBulbBlock`, used directly by waxed bulb variants.
 #[block_behavior]
@@ -66,7 +66,7 @@ impl CopperBulbBlock {
         }
     }
 
-    fn analog_output(world: &dyn LevelReader, pos: BlockPos) -> i32 {
+    fn analog_output(world: &World, pos: BlockPos) -> i32 {
         if world.get_block_state(pos).get_value(LIT) {
             15
         } else {
@@ -109,7 +109,7 @@ impl BlockBehavior for CopperBulbBlock {
     fn get_analog_output_signal(
         &self,
         _state: BlockStateId,
-        world: &dyn LevelReader,
+        world: &World,
         pos: BlockPos,
         _direction: Direction,
     ) -> i32 {
@@ -174,7 +174,7 @@ impl BlockBehavior for WeatheringCopperBulbBlock {
     fn get_analog_output_signal(
         &self,
         _state: BlockStateId,
-        world: &dyn LevelReader,
+        world: &World,
         pos: BlockPos,
         _direction: Direction,
     ) -> i32 {

--- a/steel-core/src/behavior/blocks/redstone/rail/detector_rail_block.rs
+++ b/steel-core/src/behavior/blocks/redstone/rail/detector_rail_block.rs
@@ -217,7 +217,7 @@ impl BlockBehavior for DetectorRailBlock {
     fn get_analog_output_signal(
         &self,
         _state: BlockStateId,
-        _world: &dyn LevelReader,
+        _world: &World,
         _pos: BlockPos,
         _direction: Direction,
     ) -> i32 {

--- a/steel-core/src/entity/ai/goal/breath_air.rs
+++ b/steel-core/src/entity/ai/goal/breath_air.rs
@@ -9,7 +9,7 @@ use crate::behavior::BlockStateBehaviorExt as _;
 use crate::entity::PathfinderMob;
 use crate::entity::ai::path::PathComputationType;
 use crate::physics::MoverType;
-use crate::world::LevelReader;
+use crate::world::World;
 
 const BREATH_AIR_THRESHOLD: i32 = 140;
 const AIR_SEARCH_HORIZONTAL_RADIUS: f64 = 1.0;
@@ -80,7 +80,7 @@ fn find_air_position(mob: &dyn PathfinderMob) {
     );
 }
 
-fn first_air_position(level: &dyn LevelReader, position: DVec3) -> Option<BlockPos> {
+fn first_air_position(level: &World, position: DVec3) -> Option<BlockPos> {
     let (min, max) = air_search_bounds(position);
     first_matching_pos_in_closed_box(min, max, |pos| gives_air(level, pos))
 }
@@ -118,7 +118,7 @@ fn first_matching_pos_in_closed_box(
     None
 }
 
-fn gives_air(level: &dyn LevelReader, pos: BlockPos) -> bool {
+fn gives_air(level: &World, pos: BlockPos) -> bool {
     let state = level.get_block_state(pos);
     (!state.has_fluid() || state.get_block() == &vanilla_blocks::BUBBLE_COLUMN)
         && state.is_pathfindable(PathComputationType::Land)

--- a/steel-core/src/entity/ai/goal/move_to_block.rs
+++ b/steel-core/src/entity/ai/goal/move_to_block.rs
@@ -1,7 +1,7 @@
 use super::reduced_tick_delay;
 use super::selector::{Goal, GoalControls};
 use crate::entity::PathfinderMob;
-use crate::world::LevelReader;
+use crate::world::World;
 use glam::DVec3;
 use steel_utils::BlockPos;
 
@@ -12,7 +12,7 @@ const DEFAULT_VERTICAL_SEARCH_RANGE: i32 = 1;
 const DEFAULT_RECALCULATE_PATH_INTERVAL: i32 = 40;
 const DEFAULT_ACCEPTED_DISTANCE: f64 = 1.0;
 
-type ValidTargetPredicate = Box<dyn Fn(&dyn LevelReader, BlockPos) -> bool + Send + Sync>;
+type ValidTargetPredicate = Box<dyn Fn(&World, BlockPos) -> bool + Send + Sync>;
 type MoveToTarget = Box<dyn Fn(BlockPos) -> BlockPos + Send + Sync>;
 
 pub struct MoveToBlockGoal {
@@ -36,7 +36,7 @@ impl MoveToBlockGoal {
     pub(crate) fn new(
         speed_modifier: f64,
         search_range: i32,
-        target_predicate: impl Fn(&dyn LevelReader, BlockPos) -> bool + Send + Sync + 'static,
+        target_predicate: impl Fn(&World, BlockPos) -> bool + Send + Sync + 'static,
     ) -> Self {
         Self::with_vertical_search_range(
             speed_modifier,
@@ -51,7 +51,7 @@ impl MoveToBlockGoal {
         speed_modifier: f64,
         search_range: i32,
         vertical_search_range: i32,
-        target_predicate: impl Fn(&dyn LevelReader, BlockPos) -> bool + Send + Sync + 'static,
+        target_predicate: impl Fn(&World, BlockPos) -> bool + Send + Sync + 'static,
     ) -> Self {
         Self {
             block_pos: BlockPos::ZERO,
@@ -129,7 +129,7 @@ impl MoveToBlockGoal {
         self.try_ticks % self.recalculate_path_interval == 0
     }
 
-    fn find_nearest_block(&mut self, mob: &dyn PathfinderMob, level: &dyn LevelReader) -> bool {
+    fn find_nearest_block(&mut self, mob: &dyn PathfinderMob, level: &World) -> bool {
         let Some(block_pos) = find_nearest_block_from(
             mob.block_position(),
             self.search_range,

--- a/steel-core/src/entity/animal.rs
+++ b/steel-core/src/entity/animal.rs
@@ -188,7 +188,7 @@ pub trait Animal: AgeableMob {
     }
 
     /// Returns vanilla `Animal.isBrightEnoughToSpawn`.
-    fn is_bright_enough_to_spawn(level: &dyn LevelReader, pos: BlockPos) -> bool
+    fn is_bright_enough_to_spawn(level: &impl LevelReader, pos: BlockPos) -> bool
     where
         Self: Sized,
     {
@@ -197,7 +197,7 @@ pub trait Animal: AgeableMob {
 
     /// Returns vanilla `Animal.checkAnimalSpawnRules`.
     fn check_animal_spawn_rules(
-        level: &dyn LevelReader,
+        level: &impl LevelReader,
         spawn_reason: EntitySpawnReason,
         pos: BlockPos,
     ) -> bool

--- a/steel-core/src/entity/mob/pathfinder.rs
+++ b/steel-core/src/entity/mob/pathfinder.rs
@@ -350,9 +350,9 @@ pub(super) fn path_end_node_can_reach_target(path: &Path, target: BlockPos) -> b
     f64::from(dx * dx + dz * dz) <= TARGET_REACH_DISTANCE_SQR
 }
 
-fn path_target_for_mob<M: PathfinderMob + ?Sized>(
+fn path_target_for_mob<M: PathfinderMob + ?Sized, L: LevelReader>(
     mob: &M,
-    level: &dyn LevelReader,
+    level: &L,
     target: BlockPos,
 ) -> BlockPos {
     if mob.can_path_to_targets_below_surface() {
@@ -363,7 +363,7 @@ fn path_target_for_mob<M: PathfinderMob + ?Sized>(
 }
 
 pub(super) fn find_ground_path_target_surface(
-    level: &dyn LevelReader,
+    level: &impl LevelReader,
     mut pos: BlockPos,
 ) -> BlockPos {
     if level.get_block_state(pos).is_air() {

--- a/steel-core/src/entity/mod.rs
+++ b/steel-core/src/entity/mod.rs
@@ -229,7 +229,7 @@ fn entity_eye_suffocation_box(eye_pos: DVec3, width: f64) -> WorldAabb {
 
 fn block_state_suffocates_eye_box(
     state: BlockStateId,
-    world: &dyn LevelReader,
+    world: &impl LevelReader,
     pos: BlockPos,
     eye_box: WorldAabb,
 ) -> bool {


### PR DESCRIPTION
<!--
PR template
-->

## Type of change

- [x] Breaking change
- [x] Refactor / code cleanup
- [x] Performance improvement

## Description

I remove LevelReader to some emplacement were it's useless, like get_analog_output_signal. like mentioned in trade-off in https://doc.rust-lang.org/std/keyword.dyn.html, it add some performance penalty, remove it allow to gain some performance 

## How this was tested

It compile

## Checklist

- [x] Code builds w/o errors or warnings
- [x] Self-reviewed the diff
- [x] Docs updated (if applicable)
- [x] No leftover debug code / comments

## Additional notes

The pr are in Draft because there is maybe some other place and larger change like also change &Arc<World> to &World
