### PR TITLE
feat(command): implement `/setidletimeout` command and the idle-kick system

### DIFF
--- a/steel-core/src/command/builtins/mod.rs
+++ b/steel-core/src/command/builtins/mod.rs
@@ -153,6 +153,7 @@ mod tests {
                 "return",
                 "seed",
                 "setblock",
+                "setidletimeout",
                 "setworldspawn",
                 "stop",
                 "summon",

--- a/steel-core/src/command/builtins/mod.rs
+++ b/steel-core/src/command/builtins/mod.rs
@@ -20,6 +20,7 @@ mod perms;
 mod return_command;
 mod seed;
 mod setblock;
+mod setidletimeout;
 mod setworldspawn;
 mod stop;
 mod summon;
@@ -28,7 +29,6 @@ mod tellraw;
 mod tick;
 mod time;
 mod weather;
-mod setidletimeout;
 
 pub(crate) use difficulty::player_can_change_difficulty;
 
@@ -79,6 +79,7 @@ pub(crate) fn create_registered_dispatcher(
     builder.register(return_command::registration())?;
     builder.register(seed::registration())?;
     builder.register(setblock::registration())?;
+    builder.register(setidletimeout::registration())?;
     builder.register(setworldspawn::registration())?;
     builder.register(stop::registration())?;
     builder.register(summon::registration())?;

--- a/steel-core/src/command/builtins/mod.rs
+++ b/steel-core/src/command/builtins/mod.rs
@@ -28,6 +28,7 @@ mod tellraw;
 mod tick;
 mod time;
 mod weather;
+mod setidletimeout;
 
 pub(crate) use difficulty::player_can_change_difficulty;
 

--- a/steel-core/src/command/builtins/setidletimeout.rs
+++ b/steel-core/src/command/builtins/setidletimeout.rs
@@ -5,6 +5,7 @@ use crate::command::execution::{
     CommandSource, SteelCommandContext, SteelCommandRuntime, argument, literal,
 };
 use crate::command::registration::CommandRegistration;
+use std::sync::atomic::Ordering;
 use steel_utils::Identifier;
 use steel_utils::translations::{
     COMMANDS_SETIDLETIMEOUT_SUCCESS, COMMANDS_SETIDLETIMEOUT_SUCCESS_DISABLED,
@@ -25,10 +26,11 @@ fn set_idle_timeout(
 ) -> Result<i32, CommandSyntaxError> {
     let time = context.integer("minutes")?;
 
-    {
-        let mut guard = context.source().server().player_idle_timeout.lock();
-        *guard = time;
-    }
+    context
+        .source()
+        .server()
+        .player_idle_timeout
+        .store(time, Ordering::Relaxed);
 
     if time > 0 {
         context.source().send_success(

--- a/steel-core/src/command/builtins/setidletimeout.rs
+++ b/steel-core/src/command/builtins/setidletimeout.rs
@@ -1,0 +1,38 @@
+//! The vanilla `/setidletimeout` command.
+
+use text_components::TextComponent;
+use steel_utils::Identifier;
+use steel_utils::translations::{COMMANDS_SETIDLETIMEOUT_SUCCESS, COMMANDS_SETIDLETIMEOUT_SUCCESS_DISABLED};
+use crate::command::brigadier::{ArgumentType, CommandNodeBuilder, CommandSyntaxError};
+use crate::command::execution::{argument, literal, CommandSource, SteelCommandContext, SteelCommandRuntime};
+use crate::command::registration::CommandRegistration;
+
+pub(super) fn registration() -> CommandRegistration<CommandSource> {
+    CommandRegistration::new(Identifier::vanilla_static("setidletimeout"), |_| command())
+}
+
+fn command() -> CommandNodeBuilder<CommandSource, SteelCommandRuntime> {
+    literal("setidletimeout").then(
+        argument("minutes", ArgumentType::integer(0, i32::MAX)).executes(set_idle_timeout),
+    )
+}
+
+fn set_idle_timeout(context: &SteelCommandContext<CommandSource>) -> Result<i32, CommandSyntaxError> {
+    let Some(time) = context.integer("minutes") else {
+        return Err(missing_argument("pos"));
+    };
+    context.source().server().player_idle_timeout = time;
+
+    if time > 0 {
+        context.source().send_success(&COMMANDS_SETIDLETIMEOUT_SUCCESS.message([TextComponent::plain(format!("{}", time))]).component(), true);
+    } else {
+        context.source().send_success(&TextComponent::from(&COMMANDS_SETIDLETIMEOUT_SUCCESS_DISABLED), true);
+    }
+
+    Ok(1)
+}
+fn missing_argument(name: &str) -> CommandSyntaxError {
+    CommandSyntaxError::dynamic(format!(
+        "Parsed value for {name} is missing from the command context"
+    ))
+}

--- a/steel-core/src/command/builtins/setidletimeout.rs
+++ b/steel-core/src/command/builtins/setidletimeout.rs
@@ -46,5 +46,5 @@ fn set_idle_timeout(
         );
     }
 
-    Ok(1)
+    Ok(time)
 }

--- a/steel-core/src/command/builtins/setidletimeout.rs
+++ b/steel-core/src/command/builtins/setidletimeout.rs
@@ -5,7 +5,6 @@ use crate::command::execution::{
     CommandSource, SteelCommandContext, SteelCommandRuntime, argument, literal,
 };
 use crate::command::registration::CommandRegistration;
-use std::sync::atomic::Ordering;
 use steel_utils::Identifier;
 use steel_utils::translations::{
     COMMANDS_SETIDLETIMEOUT_SUCCESS, COMMANDS_SETIDLETIMEOUT_SUCCESS_DISABLED,
@@ -26,16 +25,15 @@ fn set_idle_timeout(
 ) -> Result<i32, CommandSyntaxError> {
     let time = context.integer("minutes")?;
 
-    context
-        .source()
-        .server()
-        .player_idle_timeout
-        .store(time, Ordering::Relaxed);
+    {
+        let mut guard = context.source().server().player_idle_timeout.lock();
+        *guard = time;
+    }
 
     if time > 0 {
         context.source().send_success(
             &COMMANDS_SETIDLETIMEOUT_SUCCESS
-                .message([TextComponent::plain(format!("{time}"))])
+                .message([TextComponent::plain(time.to_string())])
                 .component(),
             true,
         );

--- a/steel-core/src/command/builtins/setidletimeout.rs
+++ b/steel-core/src/command/builtins/setidletimeout.rs
@@ -1,38 +1,50 @@
 //! The vanilla `/setidletimeout` command.
 
-use text_components::TextComponent;
-use steel_utils::Identifier;
-use steel_utils::translations::{COMMANDS_SETIDLETIMEOUT_SUCCESS, COMMANDS_SETIDLETIMEOUT_SUCCESS_DISABLED};
 use crate::command::brigadier::{ArgumentType, CommandNodeBuilder, CommandSyntaxError};
-use crate::command::execution::{argument, literal, CommandSource, SteelCommandContext, SteelCommandRuntime};
+use crate::command::execution::{
+    CommandSource, SteelCommandContext, SteelCommandRuntime, argument, literal,
+};
 use crate::command::registration::CommandRegistration;
+use std::sync::atomic::Ordering;
+use steel_utils::Identifier;
+use steel_utils::translations::{
+    COMMANDS_SETIDLETIMEOUT_SUCCESS, COMMANDS_SETIDLETIMEOUT_SUCCESS_DISABLED,
+};
+use text_components::TextComponent;
 
 pub(super) fn registration() -> CommandRegistration<CommandSource> {
     CommandRegistration::new(Identifier::vanilla_static("setidletimeout"), |_| command())
 }
 
 fn command() -> CommandNodeBuilder<CommandSource, SteelCommandRuntime> {
-    literal("setidletimeout").then(
-        argument("minutes", ArgumentType::integer(0, i32::MAX)).executes(set_idle_timeout),
-    )
+    literal("setidletimeout")
+        .then(argument("minutes", ArgumentType::integer(0, i32::MAX)).executes(set_idle_timeout))
 }
 
-fn set_idle_timeout(context: &SteelCommandContext<CommandSource>) -> Result<i32, CommandSyntaxError> {
-    let Some(time) = context.integer("minutes") else {
-        return Err(missing_argument("pos"));
-    };
-    context.source().server().player_idle_timeout = time;
+fn set_idle_timeout(
+    context: &SteelCommandContext<CommandSource>,
+) -> Result<i32, CommandSyntaxError> {
+    let time = context.integer("minutes")?;
+
+    context
+        .source()
+        .server()
+        .player_idle_timeout
+        .store(time, Ordering::Relaxed);
 
     if time > 0 {
-        context.source().send_success(&COMMANDS_SETIDLETIMEOUT_SUCCESS.message([TextComponent::plain(format!("{}", time))]).component(), true);
+        context.source().send_success(
+            &COMMANDS_SETIDLETIMEOUT_SUCCESS
+                .message([TextComponent::plain(format!("{time}"))])
+                .component(),
+            true,
+        );
     } else {
-        context.source().send_success(&TextComponent::from(&COMMANDS_SETIDLETIMEOUT_SUCCESS_DISABLED), true);
+        context.source().send_success(
+            &TextComponent::from(&COMMANDS_SETIDLETIMEOUT_SUCCESS_DISABLED),
+            true,
+        );
     }
 
     Ok(1)
-}
-fn missing_argument(name: &str) -> CommandSyntaxError {
-    CommandSyntaxError::dynamic(format!(
-        "Parsed value for {name} is missing from the command context"
-    ))
 }

--- a/steel-core/src/player/chat/mod.rs
+++ b/steel-core/src/player/chat/mod.rs
@@ -235,6 +235,7 @@ impl Player {
 
     /// Handles a chat message from the player.
     pub fn handle_chat(&self, packet: SChat, player: Arc<Player>) {
+        player.reset_last_action_time();
         let chat_message = packet.message.clone();
 
         let verification_result = if let Some(_signature) = &packet.signature {

--- a/steel-core/src/player/connection/java.rs
+++ b/steel-core/src/player/connection/java.rs
@@ -310,7 +310,10 @@ impl ScheduledPlayPacket {
             ScheduledPlayPacketKind::SetCarriedItem(packet) => {
                 player.handle_set_carried_item(packet);
             }
-            ScheduledPlayPacketKind::Swing(packet) => player.swing(packet.hand, false),
+            ScheduledPlayPacketKind::Swing(packet) => {
+                player.reset_last_action_time();
+                player.swing(packet.hand, false);
+            },
             ScheduledPlayPacketKind::PlayerAction(packet) => {
                 player.handle_player_action(packet);
             }

--- a/steel-core/src/player/connection/java.rs
+++ b/steel-core/src/player/connection/java.rs
@@ -310,10 +310,7 @@ impl ScheduledPlayPacket {
             ScheduledPlayPacketKind::SetCarriedItem(packet) => {
                 player.handle_set_carried_item(packet);
             }
-            ScheduledPlayPacketKind::Swing(packet) => {
-                player.reset_last_action_time();
-                player.swing(packet.hand, false);
-            },
+            ScheduledPlayPacketKind::Swing(packet) => player.handle_animate(packet),
             ScheduledPlayPacketKind::PlayerAction(packet) => {
                 player.handle_player_action(packet);
             }

--- a/steel-core/src/player/connection/java.rs
+++ b/steel-core/src/player/connection/java.rs
@@ -264,6 +264,7 @@ impl ScheduledPlayPacket {
                 }
             }
             ScheduledPlayPacketKind::ChatCommand(packet) => {
+                player.reset_last_action_time();
                 if server
                     .submit_command(CommandSender::Player(Arc::clone(&player)), packet.command)
                     .is_err()

--- a/steel-core/src/player/game_mode/block_interaction.rs
+++ b/steel-core/src/player/game_mode/block_interaction.rs
@@ -64,6 +64,8 @@ impl Player {
             return;
         }
 
+        self.reset_last_action_time();
+
         let world = self.get_world();
 
         if pos.y() >= world.max_build_height() {
@@ -100,6 +102,8 @@ impl Player {
         if !self.has_client_loaded() {
             return;
         }
+
+        self.reset_last_action_time();
 
         let world = self.get_world();
         match packet.action {
@@ -236,6 +240,8 @@ impl Player {
         if !self.is_within_block_interaction_range(packet.pos) {
             return;
         }
+
+        self.reset_last_action_time();
 
         let world = self.get_world();
 

--- a/steel-core/src/player/game_mode/block_interaction.rs
+++ b/steel-core/src/player/game_mode/block_interaction.rs
@@ -1,5 +1,4 @@
 use super::{block_breaking::BlockBreakAction, *};
-use steel_protocol::packets::game::SSwing;
 use steel_utils::translations;
 
 impl Player {

--- a/steel-core/src/player/game_mode/block_interaction.rs
+++ b/steel-core/src/player/game_mode/block_interaction.rs
@@ -1,4 +1,5 @@
 use super::{block_breaking::BlockBreakAction, *};
+use steel_protocol::packets::game::SSwing;
 use steel_utils::translations;
 
 impl Player {
@@ -95,6 +96,12 @@ impl Player {
 
         self.send_block_updates(pos, direction);
         self.broadcast_inventory_changes();
+    }
+
+    /// Handles a player swing packet.
+    pub fn handle_animate(&self, packet: SSwing) {
+        self.reset_last_action_time();
+        self.swing(packet.hand, false);
     }
 
     /// Handles a player action packet (block breaking, item dropping, etc.).

--- a/steel-core/src/player/game_mode/block_interaction.rs
+++ b/steel-core/src/player/game_mode/block_interaction.rs
@@ -98,12 +98,6 @@ impl Player {
         self.broadcast_inventory_changes();
     }
 
-    /// Handles a player swing packet.
-    pub fn handle_animate(&self, packet: SSwing) {
-        self.reset_last_action_time();
-        self.swing(packet.hand, false);
-    }
-
     /// Handles a player action packet (block breaking, item dropping, etc.).
     pub fn handle_player_action(&self, packet: SPlayerAction) {
         if !self.has_client_loaded() {

--- a/steel-core/src/player/game_mode/entity_interaction.rs
+++ b/steel-core/src/player/game_mode/entity_interaction.rs
@@ -570,6 +570,8 @@ impl Player {
             return;
         };
 
+        self.reset_last_action_time();
+
         let target_pos = target.block_position();
         if !world.world_border_snapshot().is_within_bounds_with_margin(
             f64::from(target_pos.x()),
@@ -643,6 +645,7 @@ impl Player {
         }
 
         let world = self.get_world();
+        self.reset_last_action_time();
         let target = world.get_accessible_entity_by_id(packet.entity_id);
         self.set_crouching(packet.using_secondary_action);
         let Some(target) = target else {

--- a/steel-core/src/player/game_mode/item_interaction.rs
+++ b/steel-core/src/player/game_mode/item_interaction.rs
@@ -172,6 +172,8 @@ impl Player {
             return;
         }
 
+        self.reset_last_action_time();
+
         log::debug!(
             "Player {} used {:?} (sequence: {}, yaw: {}, pitch: {})",
             self.gameprofile.name,

--- a/steel-core/src/player/game_mode/player_methods.rs
+++ b/steel-core/src/player/game_mode/player_methods.rs
@@ -288,6 +288,8 @@ impl Player {
             return;
         }
 
+        self.reset_last_action_time();
+
         let Some(entity_id) = packet.spectate_entity_id else {
             return;
         };

--- a/steel-core/src/player/game_mode/player_methods.rs
+++ b/steel-core/src/player/game_mode/player_methods.rs
@@ -7,6 +7,7 @@ use super::{
     player_can_change_difficulty, shapes, vanilla_attributes,
 };
 use crate::behavior::blocks::PowderSnowBlock;
+use steel_protocol::packets::game::SSwing;
 
 const SURVIVAL_DEFAULT_BLOCK_INTERACTION_RANGE: f64 = 4.5;
 
@@ -314,5 +315,11 @@ impl Player {
     #[must_use]
     pub fn is_secondary_use_active(&self) -> bool {
         self.is_crouching()
+    }
+
+    /// Handles a player swing packet.
+    pub fn handle_animate(&self, packet: SSwing) {
+        self.reset_last_action_time();
+        self.swing(packet.hand, false);
     }
 }

--- a/steel-core/src/player/lifecycle/respawn.rs
+++ b/steel-core/src/player/lifecycle/respawn.rs
@@ -663,6 +663,7 @@ impl Player {
 
     /// Handles client commands, requestStats and `RequestGameRuleValues` are still todo
     pub fn handle_client_command(self: &Arc<Self>, action: ClientCommandAction) {
+        self.reset_last_action_time();
         match action {
             ClientCommandAction::PerformRespawn => {
                 if self.has_won_game() {

--- a/steel-core/src/player/mod.rs
+++ b/steel-core/src/player/mod.rs
@@ -50,6 +50,7 @@ pub use profile::{
 use simdnbt::owned::{NbtCompound, NbtList, NbtTag};
 use sleep_state::PlayerSleepState;
 use std::mem::replace;
+use std::sync::atomic::Ordering;
 use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
 use steel_protocol::packets::game::{
@@ -1252,7 +1253,7 @@ impl Player {
 
     fn check_idle_timeout(&self) {
         if let Some(server) = self.server.upgrade() {
-            let player_idle_timeout = *server.player_idle_timeout.lock();
+            let player_idle_timeout = server.player_idle_timeout.load(Ordering::Relaxed);
             if player_idle_timeout > 0
                 && Instant::now().duration_since(*self.last_action_time.lock())
                     > Duration::from_mins(player_idle_timeout as u64)

--- a/steel-core/src/player/mod.rs
+++ b/steel-core/src/player/mod.rs
@@ -50,7 +50,9 @@ pub use profile::{
 use simdnbt::owned::{NbtCompound, NbtList, NbtTag};
 use sleep_state::PlayerSleepState;
 use std::mem::replace;
+use std::sync::atomic::Ordering;
 use std::sync::{Arc, Weak};
+use std::time::{Duration, Instant};
 use steel_protocol::packets::game::{
     CEntityEvent, CPlayerCombatKill, CPlayerLookAt, CRespawn, CSetDefaultSpawnPosition, CSetHealth,
     CSetHeldSlot, CSetPassengers, ClientCommandAction, LookAtAnchor, RelativeMovement, SoundSource,
@@ -71,7 +73,7 @@ use steel_registry::{
     level_events, sound_events, vanilla_attributes, vanilla_damage_type_tags, vanilla_entities,
     vanilla_game_events,
 };
-use steel_utils::{entity_events::EntityStatus, locks::Shared};
+use steel_utils::{entity_events::EntityStatus, locks::Shared, translations};
 use tick_state::PlayerTickState;
 use uuid::Uuid;
 
@@ -258,6 +260,9 @@ pub struct Player {
 
     /// The counter keeping track of this player's statistics.
     stats: SyncMutex<StatsCounter>,
+
+    /// The last action time of this player.
+    last_action_time: SyncMutex<Instant>,
 }
 
 // SAFETY: This key is owned by Steel and uniquely identifies `Player`.
@@ -560,6 +565,7 @@ impl Player {
             residence: SyncMutex::new(PlayerResidenceState::new()),
             ender_pearls: SyncMutex::new(Vec::new()),
             stats: SyncMutex::new(StatsCounter::new()),
+            last_action_time: SyncMutex::new(Instant::now()),
         }
     }
 
@@ -574,6 +580,7 @@ impl Player {
         self.tick_item_cooldowns();
         self.tick_attack_strength();
         self.tick_spam_throttlers();
+        self.check_idle_timeout();
         self.tick_client_load_timeout();
         self.tick_sleep_counter();
         if self.is_sleeping() {
@@ -679,6 +686,12 @@ impl Player {
             }
         }
 
+        self.send_experience_packet_if_dirty();
+
+        self.connection.tick();
+    }
+
+    fn send_experience_packet_if_dirty(&self) {
         let experience_packet = {
             let mut experience = self.experience.lock();
             if experience.dirty {
@@ -695,8 +708,6 @@ impl Player {
         if let Some(packet) = experience_packet {
             self.send_packet(packet);
         }
-
-        self.connection.tick();
     }
 
     /// Ticks the death animation timer.
@@ -1232,6 +1243,22 @@ impl Player {
             above_pos
         } else {
             affecting_pos
+        }
+    }
+
+    /// Resets the last action time of the player (to the current time).
+    pub fn reset_last_action_time(&self) {
+        *self.last_action_time.lock() = Instant::now();
+    }
+
+    fn check_idle_timeout(&self) {
+        let player_idle_timeout = self.server().player_idle_timeout.load(Ordering::Relaxed);
+        if player_idle_timeout > 0
+            && Instant::now().duration_since(*self.last_action_time.lock())
+                > Duration::from_mins(player_idle_timeout as u64)
+            && !self.has_won_game()
+        {
+            self.disconnect(translations::MULTIPLAYER_DISCONNECT_IDLING.msg());
         }
     }
 }

--- a/steel-core/src/player/mod.rs
+++ b/steel-core/src/player/mod.rs
@@ -50,7 +50,6 @@ pub use profile::{
 use simdnbt::owned::{NbtCompound, NbtList, NbtTag};
 use sleep_state::PlayerSleepState;
 use std::mem::replace;
-use std::sync::atomic::Ordering;
 use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
 use steel_protocol::packets::game::{
@@ -1252,7 +1251,7 @@ impl Player {
     }
 
     fn check_idle_timeout(&self) {
-        let player_idle_timeout = self.server().player_idle_timeout.load(Ordering::Relaxed);
+        let player_idle_timeout = *self.server().player_idle_timeout.lock();
         if player_idle_timeout > 0
             && Instant::now().duration_since(*self.last_action_time.lock())
                 > Duration::from_mins(player_idle_timeout as u64)

--- a/steel-core/src/player/mod.rs
+++ b/steel-core/src/player/mod.rs
@@ -1255,7 +1255,7 @@ impl Player {
             let player_idle_timeout = *server.player_idle_timeout.lock();
             if player_idle_timeout > 0
                 && Instant::now().duration_since(*self.last_action_time.lock())
-                > Duration::from_mins(player_idle_timeout as u64)
+                    > Duration::from_mins(player_idle_timeout as u64)
                 && !self.has_won_game()
             {
                 self.disconnect(translations::MULTIPLAYER_DISCONNECT_IDLING.msg());

--- a/steel-core/src/player/mod.rs
+++ b/steel-core/src/player/mod.rs
@@ -1251,13 +1251,15 @@ impl Player {
     }
 
     fn check_idle_timeout(&self) {
-        let player_idle_timeout = *self.server().player_idle_timeout.lock();
-        if player_idle_timeout > 0
-            && Instant::now().duration_since(*self.last_action_time.lock())
+        if let Some(server) = self.server.upgrade() {
+            let player_idle_timeout = *server.player_idle_timeout.lock();
+            if player_idle_timeout > 0
+                && Instant::now().duration_since(*self.last_action_time.lock())
                 > Duration::from_mins(player_idle_timeout as u64)
-            && !self.has_won_game()
-        {
-            self.disconnect(translations::MULTIPLAYER_DISCONNECT_IDLING.msg());
+                && !self.has_won_game()
+            {
+                self.disconnect(translations::MULTIPLAYER_DISCONNECT_IDLING.msg());
+            }
         }
     }
 }

--- a/steel-core/src/player/movement/mod.rs
+++ b/steel-core/src/player/movement/mod.rs
@@ -45,6 +45,9 @@ pub const CLAMP_HORIZONTAL: f64 = 3.0E7;
 /// Vertical position clamping limit (matches vanilla).
 pub const CLAMP_VERTICAL: f64 = 2.0E7;
 
+/// The threshold of the client delta of a player in order to reset their action time.
+pub const RESET_ACTION_TIME_DELTA_THRESHOLD: f64 = 1E-5;
+
 /// Clamps a horizontal coordinate to vanilla limits.
 #[must_use]
 pub fn clamp_horizontal(value: f64) -> f64 {
@@ -429,10 +432,7 @@ impl Player {
         self.movement
             .lock()
             .mark_last_good_position(self.position());
-
-        self.movement
-            .lock()
-            .set_last_known_client_movement(client_delta);
+        self.handle_player_known_movement(client_delta);
     }
 
     /// Handles a controlled-vehicle movement packet.
@@ -598,9 +598,7 @@ impl Player {
                 return;
             }
         }
-        self.movement
-            .lock()
-            .set_last_known_client_movement(client_delta);
+        self.handle_player_known_movement(client_delta);
         world.chunk_map.update_player_status(self);
         self.record_client_vehicle_floating(
             &world,
@@ -611,6 +609,15 @@ impl Player {
         self.movement
             .lock()
             .mark_vehicle_last_good_position(vehicle.id(), vehicle.position());
+    }
+
+    fn handle_player_known_movement(&self, client_delta: DVec3) {
+        if client_delta.length_squared() > RESET_ACTION_TIME_DELTA_THRESHOLD {
+            self.reset_last_action_time();
+        }
+        self.movement
+            .lock()
+            .set_last_known_client_movement(client_delta);
     }
 
     fn record_client_floating(
@@ -866,8 +873,7 @@ impl Player {
             return;
         }
 
-        // TODO: Vanilla calls this.player.resetLastActionTime() here which sets
-        // lastActionTime = Util.getMillis(), preventing idle-kick. Add when idle-kick system is implemented.
+        self.reset_last_action_time();
 
         self.set_crouching(input.shift());
     }
@@ -888,8 +894,7 @@ impl Player {
             return;
         }
 
-        // TODO: Vanilla calls this.player.resetLastActionTime() here which sets
-        // noActionTime = 0, preventing idle-kick. Add when idle-kick system is implemented.
+        self.reset_last_action_time();
 
         match packet.action {
             PlayerCommandAction::StartSprinting => {

--- a/steel-core/src/player/player_inventory/player_handlers.rs
+++ b/steel-core/src/player/player_inventory/player_handlers.rs
@@ -203,6 +203,7 @@ impl Player {
 
     /// Handles a container click packet (slot interaction).
     pub fn handle_container_click(&self, packet: SContainerClick) {
+        self.reset_last_action_time();
         match self.take_open_menu_for_callback(Some(packet.container_id)) {
             Ok(mut menu) => {
                 self.process_container_click(&mut menu, packet);
@@ -437,6 +438,8 @@ impl Player {
                 "{} tried to set an invalid carried item",
                 self.gameprofile.name
             );
+        } else {
+            self.reset_last_action_time();
         }
     }
 

--- a/steel-core/src/server/mod.rs
+++ b/steel-core/src/server/mod.rs
@@ -74,7 +74,6 @@ use crossbeam::queue::SegQueue;
 use glam::DVec3;
 use rayon::{ThreadPool, ThreadPoolBuilder};
 use rustc_hash::FxHashMap;
-use std::sync::atomic::AtomicI32;
 use std::{
     collections::BTreeSet,
     io, mem,
@@ -418,7 +417,7 @@ pub struct Server {
     pub tick_rate_manager: SyncRwLock<TickRateManager>,
     /// The number of minutes required for a player to be idle for them to be kicked (timed out) from the server.
     /// If this is equal to 0, no kicking will happen.
-    pub player_idle_timeout: AtomicI32,
+    pub player_idle_timeout: SyncMutex<i32>,
     /// Command scoreboards isolated by Steel domain.
     pub scoreboards: DomainScoreboards,
     /// Command NBT storage isolated by Steel domain.
@@ -712,7 +711,7 @@ impl Server {
             player_admissions: SyncMutex::new(FxHashMap::default()),
             registry_cache,
             tick_rate_manager: SyncRwLock::new(TickRateManager::new()),
-            player_idle_timeout: AtomicI32::new(0),
+            player_idle_timeout: SyncMutex::new(0),
             scoreboards,
             command_storage,
             command_dispatcher: SyncRwLock::new(registered_commands.dispatcher),

--- a/steel-core/src/server/mod.rs
+++ b/steel-core/src/server/mod.rs
@@ -74,6 +74,7 @@ use crossbeam::queue::SegQueue;
 use glam::DVec3;
 use rayon::{ThreadPool, ThreadPoolBuilder};
 use rustc_hash::FxHashMap;
+use std::sync::atomic::AtomicI32;
 use std::{
     collections::BTreeSet,
     io, mem,
@@ -417,7 +418,7 @@ pub struct Server {
     pub tick_rate_manager: SyncRwLock<TickRateManager>,
     /// The number of minutes required for a player to be idle for them to be kicked (timed out) from the server.
     /// If this is equal to 0, no kicking will happen.
-    pub player_idle_timeout: i32,
+    pub player_idle_timeout: AtomicI32,
     /// Command scoreboards isolated by Steel domain.
     pub scoreboards: DomainScoreboards,
     /// Command NBT storage isolated by Steel domain.
@@ -711,7 +712,7 @@ impl Server {
             player_admissions: SyncMutex::new(FxHashMap::default()),
             registry_cache,
             tick_rate_manager: SyncRwLock::new(TickRateManager::new()),
-            player_idle_timeout: 0,
+            player_idle_timeout: AtomicI32::new(0),
             scoreboards,
             command_storage,
             command_dispatcher: SyncRwLock::new(registered_commands.dispatcher),

--- a/steel-core/src/server/mod.rs
+++ b/steel-core/src/server/mod.rs
@@ -74,6 +74,7 @@ use crossbeam::queue::SegQueue;
 use glam::DVec3;
 use rayon::{ThreadPool, ThreadPoolBuilder};
 use rustc_hash::FxHashMap;
+use std::sync::atomic::AtomicI32;
 use std::{
     collections::BTreeSet,
     io, mem,
@@ -417,7 +418,7 @@ pub struct Server {
     pub tick_rate_manager: SyncRwLock<TickRateManager>,
     /// The number of minutes required for a player to be idle for them to be kicked (timed out) from the server.
     /// If this is equal to 0, no kicking will happen.
-    pub player_idle_timeout: SyncMutex<i32>,
+    pub player_idle_timeout: AtomicI32,
     /// Command scoreboards isolated by Steel domain.
     pub scoreboards: DomainScoreboards,
     /// Command NBT storage isolated by Steel domain.
@@ -711,7 +712,7 @@ impl Server {
             player_admissions: SyncMutex::new(FxHashMap::default()),
             registry_cache,
             tick_rate_manager: SyncRwLock::new(TickRateManager::new()),
-            player_idle_timeout: SyncMutex::new(0),
+            player_idle_timeout: AtomicI32::new(0),
             scoreboards,
             command_storage,
             command_dispatcher: SyncRwLock::new(registered_commands.dispatcher),

--- a/steel-core/src/server/mod.rs
+++ b/steel-core/src/server/mod.rs
@@ -415,6 +415,9 @@ pub struct Server {
     player_admissions: SyncMutex<FxHashMap<Uuid, PlayerAdmissionState>>,
     /// The tick rate manager for the server.
     pub tick_rate_manager: SyncRwLock<TickRateManager>,
+    /// The number of minutes required for a player to be idle for them to be kicked (timed out) from the server.
+    /// If this is equal to 0, no kicking will happen.
+    pub player_idle_timeout: i32,
     /// Command scoreboards isolated by Steel domain.
     pub scoreboards: DomainScoreboards,
     /// Command NBT storage isolated by Steel domain.
@@ -708,6 +711,7 @@ impl Server {
             player_admissions: SyncMutex::new(FxHashMap::default()),
             registry_cache,
             tick_rate_manager: SyncRwLock::new(TickRateManager::new()),
+            player_idle_timeout: 0,
             scoreboards,
             command_storage,
             command_dispatcher: SyncRwLock::new(registered_commands.dispatcher),

--- a/steel-core/src/server/tests.rs
+++ b/steel-core/src/server/tests.rs
@@ -1,3 +1,5 @@
+use glam::DVec3;
+use std::sync::atomic::AtomicI32;
 use std::{
     env::temp_dir,
     io::Cursor,
@@ -9,8 +11,6 @@ use std::{
     },
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
-
-use glam::DVec3;
 use steel_protocol::packet_traits::{CompressionInfo, EncodedPacket};
 use steel_protocol::packets::common::{
     ChatVisibility, HumanoidArm, ParticleStatus, SClientInformation,
@@ -263,6 +263,7 @@ async fn test_server_with_worlds(
         pending_player_disconnects: PlayerDisconnectQueue::new(),
         pending_world_changes: SyncMutex::new(Vec::new()),
         pending_domain_switches: SyncMutex::new(Vec::new()),
+        player_idle_timeout: AtomicI32::new(0),
     }))
 }
 

--- a/steel-core/src/server/tests.rs
+++ b/steel-core/src/server/tests.rs
@@ -1,4 +1,5 @@
 use glam::DVec3;
+use std::sync::atomic::AtomicI32;
 use std::{
     env::temp_dir,
     io::Cursor,
@@ -262,7 +263,7 @@ async fn test_server_with_worlds(
         pending_player_disconnects: PlayerDisconnectQueue::new(),
         pending_world_changes: SyncMutex::new(Vec::new()),
         pending_domain_switches: SyncMutex::new(Vec::new()),
-        player_idle_timeout: SyncMutex::new(0),
+        player_idle_timeout: AtomicI32::new(0),
     }))
 }
 

--- a/steel-core/src/server/tests.rs
+++ b/steel-core/src/server/tests.rs
@@ -1,5 +1,4 @@
 use glam::DVec3;
-use std::sync::atomic::AtomicI32;
 use std::{
     env::temp_dir,
     io::Cursor,
@@ -263,7 +262,7 @@ async fn test_server_with_worlds(
         pending_player_disconnects: PlayerDisconnectQueue::new(),
         pending_world_changes: SyncMutex::new(Vec::new()),
         pending_domain_switches: SyncMutex::new(Vec::new()),
-        player_idle_timeout: AtomicI32::new(0),
+        player_idle_timeout: SyncMutex::new(0),
     }))
 }
 

--- a/steel/src/config/server.rs
+++ b/steel/src/config/server.rs
@@ -68,6 +68,10 @@ pub struct ServerConfig {
     /// Thread counts for server thread pools.
     #[serde(default)]
     pub threads: ThreadConfig,
+    /// The number of minutes required for a player to be idle for them to be kicked (timed out) from the server.
+    /// If this is equal to 0, no kicking will happen.
+    #[serde(default)]
+    pub player_idle_timeout: i32,
 }
 
 impl ServerConfig {

--- a/steel/src/lib.rs
+++ b/steel/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! The main library for the Steel Minecraft server.
 
+use std::sync::atomic::Ordering;
 use std::{
     error::Error,
     fmt, io,
@@ -100,6 +101,7 @@ impl SteelServer {
                     SteelServerError::Core(format!("failed to validate groups config: {error}"))
                 },
             )?;
+        let player_idle_timeout = steel_config.server.player_idle_timeout;
         let runtime_config = steel_config.server.into_runtime_config();
 
         let server = Server::new_with_commands(
@@ -112,6 +114,10 @@ impl SteelServer {
         )
         .await
         .map_err(SteelServerError::Core)?;
+
+        server
+            .player_idle_timeout
+            .store(player_idle_timeout, Ordering::Relaxed);
 
         let tcp_listener = TcpListener::bind(SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, server_port))
             .await


### PR DESCRIPTION
## Type of change

- [x] Command implementation
- [x] New feature

## Description

This PR adds the `/setidletimeout` command, and, along with it, the system to kick players for being idle for too long (depending on the server's player idle timeout value).

## How this was tested

I temporarily set the idle timeout duration to be ~3 seconds, and I tested every hook that could be reproduced (like a player moving, leaving a bed, updating a sign, etc.), which all delay the idle kick. Of course, I also tested the command itself, and it works properly.

## Checklist

- [x] Code builds w/o errors or warnings
- [x] Self-reviewed the diff
- [x] Docs updated (if applicable)
- [x] No leftover debug code / comments
