### PR TITLE
allow simulation_distance of 0 in config schema

### DIFF
--- a/package-content/config.schema.json
+++ b/package-content/config.schema.json
@@ -36,8 +36,8 @@
         },
         "simulation_distance": {
           "type": "integer",
-          "description": "Maximum simulation distance in chunks",
-          "minimum": 1,
+          "description": "Simulation distance in chunks. Lower values reduce server work by restricting entity updates to fewer chunks around the player. At 0, only the player's current chunk receives entity updates.",
+          "minimum": 0,
           "maximum": 128,
           "default": 10
         },

--- a/package-content/config.toml
+++ b/package-content/config.toml
@@ -10,7 +10,9 @@ max_players = 20
 allow_extended_view_distance = false
 # Maximum view distance in chunks. Normally 1-32; 1-128 when allow_extended_view_distance is true.
 view_distance = 10
-# Maximum simulation distance in chunks
+# Simulation distance in chunks. Lower values reduce server work by restricting entity
+# updates to fewer chunks around the player. At 0, only the player's current chunk
+# receives entity updates.
 simulation_distance = 10
 # Maximum chained neighbor-update tasks. Negative values disable the limit.
 max_chained_neighbor_updates = 1000000

--- a/steel/src/config/tests.rs
+++ b/steel/src/config/tests.rs
@@ -283,6 +283,16 @@ fn validate_allows_extended_view_distance_with_opt_in() {
 }
 
 #[test]
+fn validate_allows_simulation_distance_zero() {
+    let config_toml = DEFAULT_CONFIG.replace("simulation_distance = 10", "simulation_distance = 0");
+    let config: SteelConfig = toml::from_str(&config_toml).expect("config parses");
+
+    validate(&config.server).expect("simulation distance of zero validates");
+    assert_eq!(config.server.simulation_distance, 0);
+    assert_eq!(config.server.into_runtime_config().simulation_distance, 0);
+}
+
+#[test]
 fn validate_rejects_view_distance_above_supported_ticket_range() {
     let config_toml = DEFAULT_CONFIG
         .replace(


### PR DESCRIPTION
Steel already accepts simulation_distance = 0 at runtime, but the packaged schema required a minimum of 1. Drop the minimum to 0, update descriptions, and add a validation test.

Fixes #345