### PR TITLE
fix(setblock air destroy)

### DIFF
--- a/steel-core/src/command/builtins/setblock.rs
+++ b/steel-core/src/command/builtins/setblock.rs
@@ -98,7 +98,7 @@ fn set_block(
     let place_needed = if matches!(mode, SetBlockMode::Destroy) {
         level.destroy_block(block_pos, true);
 
-        !block_state.is_air() || level.get_block_state(block_pos).is_air()
+        !block_state.is_air() || !level.get_block_state(block_pos).is_air()
     } else {
         true
     };


### PR DESCRIPTION
Fixed logic of command ```/setblock ~ ~ ~ air``` destroy resulting in an error

<!--
PR template
-->

## Type of change

- [ ] Block implementation
- [ ] Item implementation
- [ ] Command implementation
- [ ] Entity implementation
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [ ] Performance improvement
- [ ] Documentation
- [ ] Chore / tooling

## Description

<!-- What this PR does, why. -->
This PR fixes issue #385

## How this was tested

<!-- Steps to reproduce/verify. Include env (MC version, OS) if relevant. -->
<!-- For commands please provide example commands -->
I ran the following commands in order made sure they were the same:
/setblock ~ ~ ~ air destory 
/setblock ~ ~ ~ stone destroy

instead of the tidlas I was pointing at an actual block, and I ran each command twice, so I saw the difference between:
solid -> air
air -> air
air -> solid
solid -> solid

They all resulted in "Changed the block at ~, ~, ~"

<!-- Also if possible link here flint tests, this will help us to review your PR quicker -->

## Screenshots / logs
<img width="1511" height="623" alt="screenshot-20260819-231633" src="https://github.com/user-attachments/assets/44a7e24a-310a-4a0b-94d9-96a552a0cc94" />

<!-- If applicable -->

## Checklist

- [x] Code builds w/o errors or warnings
- [x] Self-reviewed the diff
- [ ] Docs updated (if applicable)
- [x] No leftover debug code / comments

## Additional notes

It was one exclamation point! (which gave me a lot a dopamine :)

<!-- Anything else reviewers should know -->
