### PR TITLE
Fix/pick slot

### DIFF
--- a/steel-core/src/player/game_mode/block_interaction.rs
+++ b/steel-core/src/player/game_mode/block_interaction.rs
@@ -1,4 +1,5 @@
 use super::{block_breaking::BlockBreakAction, *};
+use log::info;
 
 impl Player {
     /// Sends block update packets for a position and its neighbor.
@@ -208,6 +209,14 @@ impl Player {
             if PlayerInventory::is_hotbar_slot(slot_with_item as usize) {
                 inventory.set_selected_slot(slot_with_item as u8);
             } else {
+                let free_slot = inventory.get_suitable_hotbar_slot();
+                info!(
+                    "Current: {}, Free: {}",
+                    inventory.get_selected_slot(),
+                    free_slot
+                );
+
+                inventory.set_selected_slot(free_slot as u8);
                 inventory.pick_slot(slot_with_item);
             }
         } else if self.has_infinite_materials() {

--- a/steel-core/src/player/game_mode/block_interaction.rs
+++ b/steel-core/src/player/game_mode/block_interaction.rs
@@ -1,5 +1,4 @@
 use super::{block_breaking::BlockBreakAction, *};
-use log::info;
 
 impl Player {
     /// Sends block update packets for a position and its neighbor.
@@ -210,13 +209,8 @@ impl Player {
                 inventory.set_selected_slot(slot_with_item as u8);
             } else {
                 let free_slot = inventory.get_suitable_hotbar_slot();
-                info!(
-                    "Current: {}, Free: {}",
-                    inventory.get_selected_slot(),
-                    free_slot
-                );
 
-                inventory.set_selected_slot(free_slot as u8);
+                inventory.set_selected_slot(free_slot);
                 inventory.pick_slot(slot_with_item);
             }
         } else if self.has_infinite_materials() {

--- a/steel-core/src/player/player_inventory/core.rs
+++ b/steel-core/src/player/player_inventory/core.rs
@@ -223,6 +223,18 @@ impl PlayerInventory {
         -1
     }
 
+    /// Finds the next empty slot after the selected in the inventory, or -1 if full.
+    #[must_use]
+    pub fn get_suitable_hotbar_slot(&self) -> u8 {
+        let selected = self.selected as usize;
+        let order = || (selected..Self::SELECTION_SIZE).chain(0..selected);
+
+        order()
+            .find(|&i| self.items[i].is_empty())
+            .or_else(|| order().find(|&i| !self.items[i].is_enchanted()))
+            .map_or(selected as u8, |i| i as u8)
+    }
+
     /// Finds a slot containing an item matching the given stack (same item type).
     /// Returns -1 if not found.
     #[must_use]

--- a/steel-registry/src/item_stack.rs
+++ b/steel-registry/src/item_stack.rs
@@ -586,6 +586,8 @@ impl ItemStack {
                 .is_some_and(ItemEnchantments::is_empty)
     }
 
+    /// Checks if `ItemStack` has an enchantment
+    #[must_use]
     pub fn is_enchanted(&self) -> bool {
         let Some(enchantments) = self.get_enchantments() else {
             return false;
@@ -595,7 +597,7 @@ impl ItemStack {
             return false;
         }
 
-        return true;
+        true
     }
 
     #[must_use]

--- a/steel-registry/src/item_stack.rs
+++ b/steel-registry/src/item_stack.rs
@@ -586,6 +586,18 @@ impl ItemStack {
                 .is_some_and(ItemEnchantments::is_empty)
     }
 
+    pub fn is_enchanted(&self) -> bool {
+        let Some(enchantments) = self.get_enchantments() else {
+            return false;
+        };
+
+        if enchantments.is_empty() {
+            return false;
+        }
+
+        return true;
+    }
+
     #[must_use]
     pub fn has_enchantment_effect(&self, component: EnchantmentEffectComponent) -> bool {
         let Some(enchantments) = self.get_enchantments() else {


### PR DESCRIPTION
<!--
PR template
-->

## Type of change

- [ ] Block implementation
- [ ] Item implementation
- [ ] Command implementation
- [ ] Entity implementation
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [ ] Performance improvement
- [ ] Documentation
- [ ] Chore / tooling

## Description

<!-- What this PR does, why. -->
This PR fixes a bug in which middle click a block would just overwrite what you are currently holding.
This PR fixes that by scanning your hotbar twice (both starting from the current selected position):
The first pass checks for empty slots.
The second pass checks for items that are not enchanted. 
If both return false (meaning that you hotbar is filled with enchanted items, then it returns the current slot)
#390 

## How this was tested

<!-- Steps to reproduce/verify. Include env (MC version, OS) if relevant. -->
FIll your hotbar completely with some item, then middle click the another block, it should overwrite your current slot.
Empty two slots and test in different hotbar slots what middle clicking does. It should also fill the slot to the right (and wrap around the hotbar)
Fill up your hotbar, get an enchanted item, select it, and middle click, it should not overwrite the enchanted item. 

<!-- For commands please provide example commands -->
<!-- Also if possible link here flint tests, this will help us to review your PR quicker -->

## Screenshots / logs

<!-- If applicable -->

## Checklist

- [x] Code builds w/o errors or warnings
- [x] Self-reviewed the diff
- [ ] Docs updated (if applicable)
- [x] No leftover debug code / comments

## Additional notes

<!-- Anything else reviewers should know -->
