### PR TITLE
Fix handle_hello ignores online_mode if encryption is enabled

### DIFF
--- a/steel-login/src/handlers/login.rs
+++ b/steel-login/src/handlers/login.rs
@@ -39,7 +39,7 @@ impl JavaTcpClient {
                 String::new(),
                 &self.server.key_store.public_key_der,
                 challenge,
-                true,
+                self.server.config.online_mode,
             ))
             .await;
             return ConnectionAction::none();


### PR DESCRIPTION
<!--
PR template
-->

## Type of change

- [ ] Block implementation
- [ ] Item implementation
- [ ] Command implementation
- [ ] Entity implementation
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [ ] Performance improvement
- [ ] Documentation
- [ ] Chore / tooling

## Description
Changes the `CHello` packet sent when encryption is enabled to respect the value of `online_mode`
This was an issue as when encryption was enabled and online_mode was disabled offline accounts would get `Invalid session` errors when trying to connect
<!-- What this PR does, why. -->

## How this was tested
Tested manually by attempting to login to the server with different configurations and accounts

## Screenshots / logs

<!-- If applicable -->

## Checklist

- [x] Code builds w/o errors or warnings
- [ ] Self-reviewed the diff
- [ ] Docs updated (if applicable)
- [x] No leftover debug code / comments

## Additional notes

<!-- Anything else reviewers should know -->
