### PR TITLE
fix inverted keep mode in setblock

### DIFF
--- a/steel-core/src/command/builtins/setblock.rs
+++ b/steel-core/src/command/builtins/setblock.rs
@@ -90,8 +90,8 @@ fn set_block(
     // World the player is in
     let level = context.source().world();
 
-    // Keep mode throw an error when you try to replace an air block
-    if matches!(mode, SetBlockMode::Keep) && level.get_block_state(block_pos).is_air() {
+    // Keep mode only places into air; fail if the target is occupied
+    if matches!(mode, SetBlockMode::Keep) && !level.get_block_state(block_pos).is_air() {
         return Ok(set_block_failed(context.source()));
     }
 


### PR DESCRIPTION
keep was failing on air targets and placing into occupied ones. vanilla only places when the target block is air and fails otherwise.

<!--
PR template
-->

## Type of change

- [ ] Block implementation
- [ ] Item implementation
- [ ] Command implementation
- [ ] Entity implementation
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [ ] Performance improvement
- [ ] Documentation
- [ ] Chore / tooling

## Description

<!-- What this PR does, why. -->

## How this was tested

<!-- Steps to reproduce/verify. Include env (MC version, OS) if relevant. -->
<!-- For commands please provide example commands -->
<!-- Also if possible link here flint tests, this will help us to review your PR quicker -->

## Screenshots / logs

<!-- If applicable -->

## Checklist

- [ ] Code builds w/o errors or warnings
- [ ] Self-reviewed the diff
- [ ] Docs updated (if applicable)
- [ ] No leftover debug code / comments

## Additional notes

<!-- Anything else reviewers should know -->
