### PR TITLE
Fix pick block ignoring item components when matching inventory stacks

### DIFF
--- a/steel-core/src/player/player_inventory/core.rs
+++ b/steel-core/src/player/player_inventory/core.rs
@@ -228,7 +228,9 @@ impl PlayerInventory {
     #[must_use]
     pub fn find_slot_matching_item(&self, stack: &ItemStack) -> i32 {
         for i in 0..Self::INVENTORY_SIZE {
-            if !self.items[i].is_empty() && ItemStack::is_same_item(&self.items[i], stack) {
+            if !self.items[i].is_empty()
+                && ItemStack::is_same_item_same_components(&self.items[i], stack)
+            {
                 return i as i32;
             }
         }


### PR DESCRIPTION
Pick block searched the inventory by item identity only, so a stack with different components (e.g. a custom name) was selected instead of adding and selecting the clone stack. Use is_same_item_same_components to match vanilla Inventory.findSlotMatchingItem behavior.

Fixes #387

<!--
PR template
-->

## Type of change

- [ ] Block implementation
- [ ] Item implementation
- [ ] Command implementation
- [ ] Entity implementation
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [ ] Performance improvement
- [ ] Documentation
- [ ] Chore / tooling

## Description

<!-- What this PR does, why. -->

## How this was tested

<!-- Steps to reproduce/verify. Include env (MC version, OS) if relevant. -->
<!-- For commands please provide example commands -->
<!-- Also if possible link here flint tests, this will help us to review your PR quicker -->

## Screenshots / logs

<!-- If applicable -->

## Checklist

- [ ] Code builds w/o errors or warnings
- [ ] Self-reviewed the diff
- [ ] Docs updated (if applicable)
- [ ] No leftover debug code / comments

## Additional notes

<!-- Anything else reviewers should know -->
