### PR TITLE
Added recursion limit to fix warning in steel-core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ rustc-ice-*
 .idea
 
 .DS_STORE
+/.vs

--- a/steel-core/src/lib.rs
+++ b/steel-core/src/lib.rs
@@ -3,6 +3,7 @@
 //! The core library for the Steel Minecraft server. Handles everything related to the PLAY state.
 
 #![feature(try_as_dyn)]
+#![recursion_limit = "256"]
 
 use crate::chunk::chunk_map::ChunkMap;
 


### PR DESCRIPTION
<!--
PR template
-->

## Type of change

- [ ] Block implementation
- [ ] Item implementation
- [ ] Command implementation
- [ ] Entity implementation
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Refactor / code cleanup
- [ ] Performance improvement
- [ ] Documentation
- [ ] Chore / tooling

## Description

<!-- What this PR does, why. -->
Fixes warning when compiling steel-core caused in pub fn queue_player_join

## How this was tested
Compiled the project after to check if the warning has been mitigated.

<!-- Steps to reproduce/verify. Include env (MC version, OS) if relevant. -->
<!-- For commands please provide example commands -->
<!-- Also if possible link here flint tests, this will help us to review your PR quicker -->

## Screenshots / logs

<!-- If applicable -->

## Checklist

- [X] Code builds w/o errors or warnings
- [X] Self-reviewed the diff
- [X] Docs updated (if applicable)
- [X] No leftover debug code / comments

## Additional notes

<!-- Anything else reviewers should know -->
