### PR TITLE
Bump nightly

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Nightly
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2026-08-22
+          toolchain: nightly-2026-08-21
           components: rustfmt, clippy
 
       - name: Cache

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Nightly
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2026-07-23
+          toolchain: nightly-2026-08-22
           components: rustfmt, clippy
 
       - name: Cache

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ rustc-ice-*
 .idea
 
 .DS_STORE
+/.vs

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2026-08-22"
+channel = "nightly-2026-08-21"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2026-07-23"
+channel = "nightly-2026-08-22"

--- a/steel-core/src/behavior/blocks/vegetation/sweet_berry_bush.rs
+++ b/steel-core/src/behavior/blocks/vegetation/sweet_berry_bush.rs
@@ -388,7 +388,7 @@ mod tests {
 
         SweetBerryBushBlock::apply_contact_damage(test_world(), state_with_age(0), &entity);
 
-        assert!(entity.damage_events().is_empty());
+        assert_eq!(entity.damage_events().len(), 0);
     }
 
     #[test]
@@ -399,7 +399,7 @@ mod tests {
 
         SweetBerryBushBlock::apply_contact_damage(test_world(), state_with_age(1), &entity);
 
-        assert!(entity.damage_events().is_empty());
+        assert_eq!(entity.damage_events().len(), 0);
     }
 
     #[test]

--- a/steel-core/src/block_entity/storage.rs
+++ b/steel-core/src/block_entity/storage.rs
@@ -633,7 +633,7 @@ mod tests {
         assert!(!entity.is_removed());
         let (concrete, pending) = storage.save_snapshot();
         assert_eq!(concrete.len(), 1);
-        assert!(pending.is_empty());
+        assert_eq!(pending.len(), 0);
     }
 
     #[test]

--- a/steel-core/src/chunk/chunk_map/tests/player_tracking.rs
+++ b/steel-core/src/chunk/chunk_map/tests/player_tracking.rs
@@ -76,7 +76,7 @@ fn broadcast_changed_chunks_does_not_defer_blocks_while_light_work_is_blocked() 
 
     assert!(world.chunk_map.chunks_to_broadcast.lock().is_empty());
     assert!(!holder.has_changes_to_broadcast());
-    assert!(holder.take_changed_blocks().is_empty());
+    assert_eq!(holder.take_changed_blocks().len(), 0);
     assert!(world.chunk_map.light_update_touches_chunk(center));
     let relevant_packet_ids = packets
         .lock()

--- a/steel-core/src/chunk/chunk_ticket_manager.rs
+++ b/steel-core/src/chunk/chunk_ticket_manager.rs
@@ -711,7 +711,7 @@ impl ChunkTicketManager {
 
     /// Returns a drained change buffer for reuse by the next propagation pass.
     pub(crate) fn recycle_changes(&mut self, mut changes: Vec<LevelChange>) {
-        debug_assert!(self.changes.is_empty());
+        debug_assert_eq!(self.changes, []);
         changes.clear();
         self.changes = changes;
     }

--- a/steel-core/src/chunk/data.rs
+++ b/steel-core/src/chunk/data.rs
@@ -1500,7 +1500,7 @@ mod tests {
         proto.set_pending_block_entity(pos);
 
         assert!(proto.promote_pending_block_entity(pos).is_some());
-        assert!(proto.pending_block_entity_positions().is_empty());
+        assert_eq!(proto.pending_block_entity_positions().len(), 0);
     }
 
     #[test]
@@ -1529,7 +1529,7 @@ mod tests {
         );
 
         assert!(!proto.set_pending_block_entity_if_state(pos, copper));
-        assert!(proto.pending_block_entity_positions().is_empty());
+        assert_eq!(proto.pending_block_entity_positions().len(), 0);
         assert!(proto.set_pending_block_entity_if_state(pos, exposed));
 
         let stone = vanilla_blocks::STONE.default_state();
@@ -1545,7 +1545,7 @@ mod tests {
         assert!(!proto.remove_block_entity_if_state(pos, exposed));
         assert_eq!(proto.pending_block_entity_positions(), [pos]);
         assert!(proto.remove_block_entity_if_state(pos, stone));
-        assert!(proto.pending_block_entity_positions().is_empty());
+        assert_eq!(proto.pending_block_entity_positions().len(), 0);
     }
 
     #[test]

--- a/steel-core/src/chunk/full_chunk/tests.rs
+++ b/steel-core/src/chunk/full_chunk/tests.rs
@@ -216,7 +216,7 @@ fn extract_light_data_uses_chunk_owned_light_and_skylight_flag() {
 
     let without_sky = chunk.extract_light_data(false);
     assert_eq!(without_sky.sky_y_mask.0[0], 0);
-    assert!(without_sky.sky_updates.is_empty());
+    assert_eq!(without_sky.sky_updates.len(), 0);
     assert_eq!(without_sky.block_y_mask.0[0] & 0b10, 0b10);
     assert_eq!(without_sky.block_updates.len(), 1);
 }
@@ -261,7 +261,7 @@ fn draining_postprocessing_marks_full_chunk_dirty() {
 
     assert!(chunk.take_postprocessing().is_some());
     assert!(chunk.common().dirty.load(Ordering::Acquire));
-    assert!(chunk.postprocessing_for_serialization()[0].is_empty());
+    assert_eq!(chunk.postprocessing_for_serialization()[0].len(), 0);
 }
 
 #[test]

--- a/steel-core/src/chunk/light/mod.rs
+++ b/steel-core/src/chunk/light/mod.rs
@@ -256,10 +256,10 @@ mod tests {
 
         assert!(!mask_bit(&packet.sky_y_mask.0, 1));
         assert!(!mask_bit(&packet.empty_sky_y_mask.0, 1));
-        assert!(packet.sky_updates.is_empty());
+        assert_eq!(packet.sky_updates.len(), 0);
         assert!(!mask_bit(&packet.block_y_mask.0, 1));
         assert!(!mask_bit(&packet.empty_block_y_mask.0, 1));
-        assert!(packet.block_updates.is_empty());
+        assert_eq!(packet.block_updates.len(), 0);
     }
 
     #[test]
@@ -272,7 +272,7 @@ mod tests {
 
         assert!(!mask_bit(&packet.block_y_mask.0, 1));
         assert!(mask_bit(&packet.empty_block_y_mask.0, 1));
-        assert!(packet.block_updates.is_empty());
+        assert_eq!(packet.block_updates.len(), 0);
     }
 
     #[test]
@@ -298,7 +298,7 @@ mod tests {
 
         let packet = build_chunk_light_update_packet(&light, false);
 
-        assert!(packet.sky_updates.is_empty());
+        assert_eq!(packet.sky_updates.len(), 0);
         assert!(!mask_bit(&packet.sky_y_mask.0, 1));
         assert!(!mask_bit(&packet.empty_sky_y_mask.0, 1));
     }

--- a/steel-core/src/chunk/light/propagation.rs
+++ b/steel-core/src/chunk/light/propagation.rs
@@ -1397,7 +1397,7 @@ mod tests {
             panic!("dynamic block changes should skip a missing center chunk");
         };
 
-        assert!(result.updated_sections.is_empty());
+        assert_eq!(result.updated_sections.len(), 0);
     }
 
     #[test]

--- a/steel-core/src/chunk/light/sky_propagation/tests.rs
+++ b/steel-core/src/chunk/light/sky_propagation/tests.rs
@@ -444,5 +444,5 @@ fn sky_light_changes_skip_missing_center_chunk() {
         panic!("dynamic sky changes should skip a missing center chunk");
     };
 
-    assert!(result.updated_sections.is_empty());
+    assert_eq!(result.updated_sections.len(), 0);
 }

--- a/steel-core/src/chunk/player_chunk_view.rs
+++ b/steel-core/src/chunk/player_chunk_view.rs
@@ -178,8 +178,8 @@ mod tests {
         );
 
         // Just verify something happened
-        assert!(!added.is_empty());
-        assert!(!removed.is_empty());
+        assert_ne!(added.len(), 0);
+        assert_ne!(removed.len(), 0);
 
         // Verify intersection logic worked by ensuring we have balanced adds/removes for shift
         // (Rough check)

--- a/steel-core/src/chunk_saver/storage/tests/entities.rs
+++ b/steel-core/src/chunk_saver/storage/tests/entities.rs
@@ -135,7 +135,7 @@ fn proto_block_entities_roundtrip_and_promote_to_full_chunk() {
     assert!(loaded_full.get_block_entities().is_empty());
     assert_eq!(loaded_full.pending_block_entity_positions(), [block_pos]);
     assert!(loaded_full.get_block_entity(block_pos).is_some());
-    assert!(loaded_full.pending_block_entity_positions().is_empty());
+    assert_eq!(loaded_full.pending_block_entity_positions().len(), 0);
 }
 
 #[test]
@@ -230,8 +230,8 @@ fn proto_entities_roundtrip_and_promote_to_full_chunk() {
         prepared.persistent.entities[0].tags,
         vec!["steel:test".to_owned()]
     );
-    assert!(!prepared.persistent.entities[0].custom_name_nbt.is_empty());
-    assert!(!prepared.persistent.entities[0].custom_data_nbt.is_empty());
+    assert_ne!(prepared.persistent.entities[0].custom_name_nbt.len(), 0);
+    assert_ne!(prepared.persistent.entities[0].custom_data_nbt.len(), 0);
     let custom_name_nbt = read_borrowed_compound(&mut Cursor::new(
         &prepared.persistent.entities[0].custom_name_nbt,
     ))

--- a/steel-core/src/chunk_saver/storage/tests/structures.rs
+++ b/steel-core/src/chunk_saver/storage/tests/structures.rs
@@ -586,7 +586,7 @@ fn structure_start_roundtrip_preserves_template_and_procedural_payloads() {
     };
     assert_eq!(payload.height_position, Some(63));
     assert_eq!(payload.has_placed_chest, [true, false, true, false]);
-    assert!(payload.potential_suspicious_sand_world_positions.is_empty());
+    assert_eq!(payload.potential_suspicious_sand_world_positions.len(), 0);
     assert_eq!(payload.random_collapsed_roof_pos, BlockPos::new(0, 0, 0));
 
     let StructurePiecePayload::Procedural(ProceduralPieceData::JungleTemple(payload)) =

--- a/steel-core/src/command/brigadier/tests/parsing.rs
+++ b/steel-core/src/command/brigadier/tests/parsing.rs
@@ -42,7 +42,7 @@ fn parses_literal_commands_and_tracks_ranges() {
     let parse = dispatcher.parse("ping", TestSource { allowed: true });
 
     assert!(!parse.reader().can_read());
-    assert!(parse.errors().is_empty());
+    assert_eq!(parse.errors(), []);
     assert!(parse.context().is_executable());
     assert_eq!(parse.context().range(), StringRange::between(0, 4));
     assert_eq!(parsed_names(&dispatcher, parse.context().nodes()), ["ping"]);
@@ -69,7 +69,7 @@ fn literal_ranges_and_failure_cursors_use_utf16_units() {
 
     let failed = dispatcher.parse("say \u{1f603}", TestSource { allowed: true });
     assert_eq!(failed.reader().cursor(), 4);
-    assert!(failed.errors().is_empty());
+    assert_eq!(failed.errors(), []);
 }
 
 #[test]
@@ -86,8 +86,8 @@ fn requirements_hide_unavailable_nodes_from_parsing() {
 
     let denied = dispatcher.parse("secure", TestSource { allowed: false });
     assert_eq!(denied.reader().cursor(), 0);
-    assert!(denied.context().nodes().is_empty());
-    assert!(denied.errors().is_empty());
+    assert_eq!(denied.context().nodes(), []);
+    assert_eq!(denied.errors(), []);
 
     let allowed = dispatcher.parse("secure", TestSource { allowed: true });
     assert!(!allowed.reader().can_read());
@@ -148,7 +148,7 @@ fn unknown_subcommands_keep_the_last_successful_context() {
     assert_eq!(parse.reader().remaining(), "baz");
     assert_eq!(parsed_names(&dispatcher, parse.context().nodes()), ["foo"]);
     assert!(parse.context().is_executable());
-    assert!(parse.errors().is_empty());
+    assert_eq!(parse.errors(), []);
 }
 
 #[test]

--- a/steel-core/src/command/brigadier/tests/registration.rs
+++ b/steel-core/src/command/brigadier/tests/registration.rs
@@ -258,7 +258,10 @@ fn redirect_targets_must_belong_to_the_dispatcher() {
             target: foreign_target,
         },
     );
-    assert!(node_names(&second_dispatcher, second_dispatcher.root()).is_empty());
+    assert_eq!(
+        node_names(&second_dispatcher, second_dispatcher.root()).len(),
+        0
+    );
 }
 
 #[test]
@@ -272,7 +275,7 @@ fn redirected_nodes_cannot_have_children() {
             name: "alias".into(),
         },
     );
-    assert!(node_names(&dispatcher, root).is_empty());
+    assert_eq!(node_names(&dispatcher, root).len(), 0);
 }
 
 #[test]

--- a/steel-core/src/command/builtins/invsee/tests.rs
+++ b/steel-core/src/command/builtins/invsee/tests.rs
@@ -526,7 +526,7 @@ fn replacing_overriding_menu_keeps_main_inventory_sync_deferred() {
     recording.packets.lock().clear();
 
     recording.player.tick();
-    assert!(player_inventory_updates(&recording.packets).is_empty());
+    assert_eq!(player_inventory_updates(&recording.packets).len(), 0);
 
     recording.player.do_close_container();
     recording.player.tick();

--- a/steel-core/src/command/builtins/perms/config.rs
+++ b/steel-core/src/command/builtins/perms/config.rs
@@ -279,7 +279,7 @@ mod tests {
             set_permission(&mut config, "default", &global, None),
             Ok(true)
         );
-        assert!(config.groups["default"].allow.is_empty());
+        assert_eq!(config.groups["default"].allow.len(), 0);
         assert_eq!(
             config.groups["default"].deny,
             ["steel.build{domain=survival}"]
@@ -306,7 +306,7 @@ mod tests {
             ),
             Ok(true)
         );
-        assert!(config.groups["default"].allow.is_empty());
+        assert_eq!(config.groups["default"].allow.len(), 0);
         assert_eq!(
             config.groups["default"].deny,
             ["steel.build{domain=survival,plugin:region=spawn}"]

--- a/steel-core/src/command/storage.rs
+++ b/steel-core/src/command/storage.rs
@@ -243,7 +243,7 @@ mod tests {
 
         storage.set(key.clone(), NbtCompound::new());
         assert!(storage.get(&key).is_empty());
-        assert!(storage.keys().is_empty());
+        assert_eq!(storage.keys().len(), 0);
     }
 
     #[tokio::test]

--- a/steel-core/src/entity/base/tests.rs
+++ b/steel-core/src/entity/base/tests.rs
@@ -630,7 +630,7 @@ fn player_respawn_reset_restores_fresh_base_state_and_preserves_tags() {
         DVec3::new(2.0, 64.0, 1.0),
     ));
     base.set_position_local(DVec3::new(2.0, 64.0, 1.0));
-    assert!(!base.take_movements_for_block_effects().is_empty());
+    assert_ne!(base.take_movements_for_block_effects().len(), 0);
     base.record_movement_this_tick(EntityMovement::new(
         DVec3::new(2.0, 64.0, 1.0),
         DVec3::new(3.0, 64.0, 1.0),
@@ -663,7 +663,7 @@ fn player_respawn_reset_restores_fresh_base_state_and_preserves_tags() {
     assert!(!base.needs_velocity_sync());
     assert!(!base.hurt_marked());
     assert_eq!(base.dimensions(), reset_dimensions);
-    assert!(base.last_movements_for_block_effects().is_empty());
+    assert_eq!(base.last_movements_for_block_effects().len(), 0);
     assert_eq!(
         base.take_movements_for_block_effects(),
         vec![EntityMovement::new(reset_position, reset_position)]
@@ -1122,7 +1122,7 @@ fn movement_trace_replays_last_finalized_movements() {
         EntityDimensions::new(0.25, 0.25, 0.125),
         Weak::<World>::new(),
     );
-    assert!(base.last_movements_for_block_effects().is_empty());
+    assert_eq!(base.last_movements_for_block_effects().len(), 0);
 
     base.record_movement_this_tick(EntityMovement::new(DVec3::ZERO, DVec3::new(1.0, 0.0, 0.0)));
     base.set_position_local(DVec3::new(1.0, 0.0, 0.0));

--- a/steel-core/src/entity/entities/mobs/passive/sheep/tests/core.rs
+++ b/steel-core/src/entity/entities/mobs/passive/sheep/tests/core.rs
@@ -475,7 +475,7 @@ fn sheep_shear_loot_resolves_the_matching_color_table() {
         &mut rng,
     );
 
-    assert!(!drops.is_empty());
+    assert_ne!(drops.len(), 0);
     for drop in &drops {
         assert!(drop.is(&vanilla_items::RED_WOOL));
     }

--- a/steel-core/src/entity/living_base/tests.rs
+++ b/steel-core/src/entity/living_base/tests.rs
@@ -293,7 +293,7 @@ fn equipment_is_living_entity_state() {
     init_vanilla_registry();
     let base = LivingEntityBase::new(&vanilla_entities::PLAYER);
 
-    assert!(base.equipment().lock().non_empty_items().is_empty());
+    assert_eq!(base.equipment().lock().non_empty_items().len(), 0);
 
     base.equipment()
         .lock()

--- a/steel-core/src/entity/tests/mod.rs
+++ b/steel-core/src/entity/tests/mod.rs
@@ -859,7 +859,7 @@ fn wither_effect_only_damages_on_its_vanilla_interval() {
     entity.tick_mob_effects();
 
     assert_f32_close(entity.get_health(), 20.0);
-    assert!(entity.damage_type_keys().is_empty());
+    assert_eq!(entity.damage_type_keys().len(), 0);
     assert_eq!(
         entity
             .mob_effect(vanilla_mob_effects::WITHER)

--- a/steel-core/src/entity/tests/riding_and_leashes.rs
+++ b/steel-core/src/entity/tests/riding_and_leashes.rs
@@ -144,7 +144,7 @@ fn set_leashed_to_notifies_replaced_holder() {
     assert!(mob.set_leashed_to(&new_holder));
 
     assert_eq!(old_holder_typed.removed_notifications(), vec![3]);
-    assert!(new_holder_typed.removed_notifications().is_empty());
+    assert_eq!(new_holder_typed.removed_notifications().len(), 0);
 }
 
 #[test]
@@ -168,7 +168,7 @@ fn tick_leash_notifies_live_holder() {
 
     assert_eq!(holder_typed.holder_notifications(), vec![3]);
     assert!(mob.is_leashed());
-    assert!(holder_typed.removed_notifications().is_empty());
+    assert_eq!(holder_typed.removed_notifications().len(), 0);
 }
 
 #[test]

--- a/steel-core/src/entity/tracker/tests/passenger_leash.rs
+++ b/steel-core/src/entity/tracker/tests/passenger_leash.rs
@@ -125,7 +125,7 @@ fn send_changes_broadcasts_leash_link_changes_once() {
             entity_link: |entity_id, packet| updates.push((entity_id, packet)),
         },
     );
-    assert!(updates.is_empty());
+    assert_eq!(updates.len(), 0);
 
     assert!(pig_mob.set_leashed_to(&holder));
     tracker.send_changes(
@@ -159,7 +159,7 @@ fn send_changes_broadcasts_leash_link_changes_once() {
             entity_link: |entity_id, packet| updates.push((entity_id, packet)),
         },
     );
-    assert!(updates.is_empty());
+    assert_eq!(updates.len(), 0);
 
     pig_mob.remove_leash_state();
     tracker.send_changes(
@@ -272,7 +272,7 @@ fn send_changes_broadcasts_passenger_changes_once() {
     assert_eq!(updates.len(), 1);
     assert_eq!(updates[0].0, 99);
     assert_eq!(updates[0].1.vehicle_id, 1);
-    assert!(updates[0].1.passenger_ids.is_empty());
+    assert_eq!(updates[0].1.passenger_ids.len(), 0);
 }
 
 #[test]
@@ -311,5 +311,5 @@ fn send_changes_removes_untracked_passenger_from_vehicle_packet() {
     assert_eq!(updates.len(), 1);
     assert_eq!(updates[0].0, 99);
     assert_eq!(updates[0].1.vehicle_id, 1);
-    assert!(updates[0].1.passenger_ids.is_empty());
+    assert_eq!(updates[0].1.passenger_ids.len(), 0);
 }

--- a/steel-core/src/fluid/conversion.rs
+++ b/steel-core/src/fluid/conversion.rs
@@ -401,7 +401,7 @@ mod tests {
         }
 
         let blocked = get_spread(&world, origin, source_water, &vanilla_fluids::WATER, 1, 4);
-        assert!(blocked.is_empty());
+        assert_eq!(blocked.len(), 0);
 
         assert!(world.set_block_with_limit(
             origin.north(),

--- a/steel-core/src/level_data/mod.rs
+++ b/steel-core/src/level_data/mod.rs
@@ -773,10 +773,6 @@ mod tests {
     }
 
     #[test]
-    #[expect(
-        clippy::float_cmp,
-        reason = "the exactly representable configured clock rate must round-trip unchanged"
-    )]
     fn level_data_round_trips_world_clock_state() {
         init_vanilla_registry();
         let mut data = LevelData::new_with_seed(1);

--- a/steel-core/src/lib.rs
+++ b/steel-core/src/lib.rs
@@ -3,8 +3,6 @@
 //! The core library for the Steel Minecraft server. Handles everything related to the PLAY state.
 
 #![feature(try_as_dyn)]
-// TODO: do a proper fix
-#![recursion_limit = "256"]
 
 use crate::chunk::chunk_map::ChunkMap;
 

--- a/steel-core/src/lib.rs
+++ b/steel-core/src/lib.rs
@@ -3,6 +3,7 @@
 //! The core library for the Steel Minecraft server. Handles everything related to the PLAY state.
 
 #![feature(try_as_dyn)]
+#![recursion_limit = "256"]
 
 use crate::chunk::chunk_map::ChunkMap;
 

--- a/steel-core/src/lib.rs
+++ b/steel-core/src/lib.rs
@@ -3,6 +3,7 @@
 //! The core library for the Steel Minecraft server. Handles everything related to the PLAY state.
 
 #![feature(try_as_dyn)]
+// TODO: do a proper fix
 #![recursion_limit = "256"]
 
 use crate::chunk::chunk_map::ChunkMap;

--- a/steel-core/src/physics/shapes.rs
+++ b/steel-core/src/physics/shapes.rs
@@ -338,7 +338,6 @@ fn project_offset_shape_onto_grid(
 }
 
 #[cfg(test)]
-#[expect(clippy::float_cmp, reason = "exact match against vanilla test vectors")]
 mod tests {
     use super::*;
 

--- a/steel-core/src/player/item_cooldowns.rs
+++ b/steel-core/src/player/item_cooldowns.rs
@@ -116,7 +116,7 @@ mod tests {
         assert!(cooldowns.is_on_cooldown(&stack));
 
         for _ in 0..19 {
-            assert!(cooldowns.tick().is_empty());
+            assert_eq!(cooldowns.tick().len(), 0);
             assert!(cooldowns.is_on_cooldown(&stack));
         }
 

--- a/steel-core/src/player/movement/mod.rs
+++ b/steel-core/src/player/movement/mod.rs
@@ -920,7 +920,6 @@ impl Player {
 }
 
 #[cfg(test)]
-#[expect(clippy::float_cmp, reason = "exact match against vanilla test vectors")]
 mod tests {
     use super::*;
 

--- a/steel-core/src/player/player_data_storage/tests.rs
+++ b/steel-core/src/player/player_data_storage/tests.rs
@@ -276,7 +276,7 @@ async fn interrupted_first_known_player_publication_discards_its_temporary_file(
         .load_known_players()
         .await
         .expect("uncommitted known-player state should be ignored");
-    assert!(loaded.entries().is_empty());
+    assert_eq!(loaded.entries(), []);
     assert!(!path.exists());
     assert!(!temporary.exists());
 
@@ -300,7 +300,7 @@ async fn corrupt_known_player_cache_loads_as_empty() {
         .load_known_players()
         .await
         .expect("a corrupt optional cache should not prevent startup");
-    assert!(loaded.entries().is_empty());
+    assert_eq!(loaded.entries(), []);
     assert_eq!(
         fs::read(&path)
             .await
@@ -332,7 +332,7 @@ async fn incompatible_known_player_cache_version_loads_as_empty() {
         .load_known_players()
         .await
         .expect("an incompatible optional cache should not prevent startup");
-    assert!(loaded.entries().is_empty());
+    assert_eq!(loaded.entries(), []);
     assert!(loaded.by_uuid(uuid).is_none());
 
     fs::remove_dir_all(root)

--- a/steel-core/src/player/profile/known_players.rs
+++ b/steel-core/src/player/profile/known_players.rs
@@ -246,6 +246,6 @@ mod tests {
             players.resolve_name("Steve", 10),
             super::KnownPlayerNameLookup::Expired
         ));
-        assert!(players.entries().is_empty());
+        assert_eq!(players.entries(), []);
     }
 }

--- a/steel-core/src/player/tests.rs
+++ b/steel-core/src/player/tests.rs
@@ -637,11 +637,9 @@ fn death_removes_tracked_entities_from_dead_players_client() {
         vec![item.id()],
         "vanilla removes every entity pairing from a dead player's client"
     );
-    assert!(
-        world
-            .entity_tracker()
-            .tracking_player_ids(item.id())
-            .is_empty()
+    assert_eq!(
+        world.entity_tracker().tracking_player_ids(item.id()).len(),
+        0
     );
 }
 
@@ -1004,7 +1002,10 @@ fn living_tick_detects_raw_inventory_equipment_mutation() {
         }]
     );
     LivingEntity::detect_equipment_updates(player.as_ref());
-    assert!(LivingEntity::drain_dirty_equipment(player.as_ref()).is_empty());
+    assert_eq!(
+        LivingEntity::drain_dirty_equipment(player.as_ref()).len(),
+        0
+    );
 }
 
 #[test]
@@ -1074,7 +1075,10 @@ fn death_respawn_redetects_unchanged_kept_equipment() {
     );
 
     LivingEntity::detect_equipment_updates(player.as_ref());
-    assert!(LivingEntity::drain_dirty_equipment(player.as_ref()).is_empty());
+    assert_eq!(
+        LivingEntity::drain_dirty_equipment(player.as_ref()).len(),
+        0
+    );
 }
 
 #[test]
@@ -1146,7 +1150,10 @@ fn equipment_detection_suppresses_exact_hand_swap_packet() {
     assert!(player.inventory.lock().swap_hands());
     LivingEntity::detect_equipment_updates(player.as_ref());
 
-    assert!(LivingEntity::drain_dirty_equipment(player.as_ref()).is_empty());
+    assert_eq!(
+        LivingEntity::drain_dirty_equipment(player.as_ref()).len(),
+        0
+    );
 }
 
 #[test]

--- a/steel-core/src/server/player_admission.rs
+++ b/steel-core/src/server/player_admission.rs
@@ -105,18 +105,21 @@ impl Server {
         }
 
         let server = Arc::clone(self);
-        tokio::spawn(async move {
-            let state = server.prepare_player_join(&player).await;
-            server
-                .pending_player_joins
-                .send(PendingPlayerJoin { player, state });
-        });
+        tokio::spawn(Self::prepare_and_queue_player_join(server, player));
     }
 
-    async fn prepare_player_join(&self, player: &Player) -> Result<DomainPlayerState, String> {
-        let target_domain = self.load_join_domain(player).await?;
-        self.load_domain_player_state(player, &target_domain, None)
-            .await
+    async fn prepare_and_queue_player_join(server: Arc<Self>, player: Arc<Player>) {
+        let state = match server.load_join_domain(&player).await {
+            Ok(target_domain) => {
+                server
+                    .load_domain_player_state(&player, &target_domain, None)
+                    .await
+            }
+            Err(error) => Err(error),
+        };
+        server
+            .pending_player_joins
+            .send(PendingPlayerJoin { player, state });
     }
 
     pub(super) fn process_player_joins(self: &Arc<Self>) {

--- a/steel-core/src/server/tests.rs
+++ b/steel-core/src/server/tests.rs
@@ -810,7 +810,7 @@ fn domain_detach_invalidates_an_encoded_source_chunk_batch() {
             &player.connection,
             &player.chunk_send_epoch,
         );
-        assert!(committed.is_empty());
+        assert_eq!(committed.len(), 0);
         assert!(sent_packets.lock().is_empty());
         assert!(server.online_players.remove_player_sync(&player).is_some());
 
@@ -1627,7 +1627,7 @@ fn command_gameplay_availability_tracks_exact_domain_residence() {
             Ok(2),
             "administrative profile selectors retain globally online players"
         );
-        assert!(source.selector_player_names().is_empty());
+        assert_eq!(source.selector_player_names().len(), 0);
         assert_eq!(server.get_players().len(), 2);
         for _ in 0..2 {
             let Some(request) = server.command_requests.pop_front_runnable(|_| true) else {

--- a/steel-core/src/world/border.rs
+++ b/steel-core/src/world/border.rs
@@ -745,7 +745,7 @@ mod tests {
         let inside = WorldAabb::new(0.0, 0.0, -0.3, 0.6, 1.8, 0.3);
 
         assert_eq!(snapshot.collision_shapes_for(crossing_east).len(), 1);
-        assert!(snapshot.collision_shapes_for(inside).is_empty());
+        assert_eq!(snapshot.collision_shapes_for(inside).len(), 0);
     }
 
     #[test]

--- a/steel-core/src/world/clock.rs
+++ b/steel-core/src/world/clock.rs
@@ -366,10 +366,6 @@ mod tests {
     }
 
     #[test]
-    #[expect(
-        clippy::float_cmp,
-        reason = "paused and non-advancing clocks must report the exact zero network rate"
-    )]
     fn pause_and_advance_time_gate_network_rate_and_ticks() {
         init_vanilla_registry();
         let mut manager = WorldClockManager::new();

--- a/steel-core/src/world/player_index/area.rs
+++ b/steel-core/src/world/player_index/area.rs
@@ -219,7 +219,7 @@ mod tests {
             }
         }
         assert_eq!(map.len(), 0);
-        assert!(map.get_tracking_players(center).is_empty());
+        assert_eq!(map.get_tracking_players(center).len(), 0);
     }
 
     #[test]

--- a/steel-core/src/world/tests.rs
+++ b/steel-core/src/world/tests.rs
@@ -174,11 +174,7 @@ fn entity_breaker_is_available_to_chorus_flower_loot() {
     assert_eq!(drops.len(), 1);
     assert_eq!(drops[0].item(), &*vanilla_items::CHORUS_FLOWER);
     assert_eq!(drops[0].count(), 1);
-    assert!(
-        BlockLootContext::new(&world, pos)
-            .get_drops(state)
-            .is_empty()
-    );
+    assert_eq!(BlockLootContext::new(&world, pos).get_drops(state).len(), 0);
 }
 
 fn assert_vec3_close(left: DVec3, right: DVec3) {
@@ -497,14 +493,14 @@ fn navigating_mob_tracker_tracks_only_pathfinder_mobs() {
     ));
 
     tracker.track(&non_pathfinder);
-    assert!(tracker.ids().is_empty());
+    assert_eq!(tracker.ids().len(), 0);
 
     tracker.track(&pig);
     tracker.track(&pig);
     assert_eq!(tracker.ids(), [2]);
 
     tracker.untrack(2);
-    assert!(tracker.ids().is_empty());
+    assert_eq!(tracker.ids().len(), 0);
 }
 
 #[test]

--- a/steel-core/src/world/tick_scheduler/tests.rs
+++ b/steel-core/src/world/tick_scheduler/tests.rs
@@ -677,7 +677,7 @@ fn only_popped_containers_report_a_persistence_change() {
     let pending_pos = ChunkPos::new(1, 0);
     let scheduler = scheduler_with_block_lists([(empty_pos, empty), (pending_pos, pending)]);
     let before_deadline = begin_block_tick_at(&scheduler, 1, &[empty_pos, pending_pos], 1);
-    assert!(before_deadline.changed_containers.is_empty());
+    assert_eq!(before_deadline.changed_containers.len(), 0);
     let selected = begin_block_tick_at(&scheduler, 3, &[empty_pos, pending_pos], 1);
     assert_eq!(selected.changed_containers, vec![1]);
 }

--- a/steel-core/src/worldgen/carver/mask.rs
+++ b/steel-core/src/worldgen/carver/mask.rs
@@ -166,6 +166,6 @@ mod test {
     #[test]
     fn empty_packed_u64s_are_omitted() {
         let mask = CarvingMask::new(384, -64);
-        assert!(mask.to_packed_u64s().is_empty());
+        assert_eq!(mask.to_packed_u64s().len(), 0);
     }
 }

--- a/steel-core/src/worldgen/feature/features/tree/trunk.rs
+++ b/steel-core/src/worldgen/feature/features/tree/trunk.rs
@@ -1220,19 +1220,11 @@ mod tests {
     use super::*;
 
     #[test]
-    #[expect(
-        clippy::float_cmp,
-        reason = "fancy tree shape tests assert exact vanilla sentinel values"
-    )]
     fn fancy_tree_shape_rejects_lower_third() {
         assert_eq!(FeatureDecorationRunner::fancy_tree_shape(12, 3), -1.0);
     }
 
     #[test]
-    #[expect(
-        clippy::float_cmp,
-        reason = "fancy tree shape tests assert exact vanilla crown values"
-    )]
     fn fancy_tree_shape_uses_half_circle_crown() {
         assert_eq!(FeatureDecorationRunner::fancy_tree_shape(12, 6), 3.0);
         assert_eq!(FeatureDecorationRunner::fancy_tree_shape(12, 12), 0.0);

--- a/steel-core/src/worldgen/feature/tests.rs
+++ b/steel-core/src/worldgen/feature/tests.rs
@@ -168,7 +168,10 @@ fn structures_for_decoration_step_use_registry_order_inside_vanilla_step() {
             .iter()
             .all(|structure| structure.step.decoration_ordinal() == 7)
     );
-    assert!(FeatureDecorationRunner::structures_for_decoration_step(&registry, 0).is_empty());
+    assert_eq!(
+        FeatureDecorationRunner::structures_for_decoration_step(&registry, 0).len(),
+        0
+    );
 }
 
 #[test]

--- a/steel-core/src/worldgen/stages/light.rs
+++ b/steel-core/src/worldgen/stages/light.rs
@@ -341,7 +341,7 @@ mod tests {
 
         let (sky_updates, block_updates) = run_light_stage(&cache, &center_holder, false);
 
-        assert!(sky_updates.is_empty());
+        assert_eq!(sky_updates.len(), 0);
         assert!(block_updates.contains(&SectionPos::new(0, 0, 0)));
         assert_eq!(
             light_value(&center_holder, LightLayer::Block, source_pos),
@@ -426,7 +426,7 @@ mod tests {
 
         let (sky_updates, _block_updates) = run_loaded_light_stage(&cache, &center_holder, false);
 
-        assert!(sky_updates.is_empty());
+        assert_eq!(sky_updates.len(), 0);
         assert_eq!(light_value(&center_holder, LightLayer::Block, block_pos), 7);
     }
 

--- a/steel-math/src/noise_math/coordinate.rs
+++ b/steel-math/src/noise_math/coordinate.rs
@@ -163,13 +163,7 @@ mod wrap_tests {
         for case in cases {
             let wrapped = wrap_simd(f64x4::from_array(case)).to_array();
             for (input, actual) in case.into_iter().zip(wrapped) {
-                #[expect(
-                    clippy::float_cmp,
-                    reason = "SIMD wrap must be bit-identical to scalar wrap per lane"
-                )]
-                {
-                    assert_eq!(actual, wrap(input));
-                }
+                assert_eq!(actual, wrap(input));
             }
         }
     }

--- a/steel-math/src/trig.rs
+++ b/steel-math/src/trig.rs
@@ -58,10 +58,6 @@ pub fn cos(angle: f64) -> f32 {
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::float_cmp,
-    reason = "tests compare exact f32 table entries, not approximations"
-)]
 mod test {
     use super::*;
 

--- a/steel-protocol/src/lib.rs
+++ b/steel-protocol/src/lib.rs
@@ -12,9 +12,8 @@
 #![cfg_attr(
     test,
     expect(
-        clippy::float_cmp,
         clippy::unwrap_used,
-        reason = "packet round-trip tests compare exact serialized float values and unwrap known-good buffers"
+        reason = "packet round-trip tests unwrap known-good buffers"
     )
 )]
 

--- a/steel-registry/src/blocks/mod.rs
+++ b/steel-registry/src/blocks/mod.rs
@@ -1403,7 +1403,7 @@ mod tests {
             .expect("Should find state");
 
         let retrieved = registry.get_properties(state_id);
-        assert!(retrieved.is_empty());
+        assert_eq!(retrieved.len(), 0);
     }
 
     #[test]

--- a/steel-registry/src/data_components/vanilla_components/tests.rs
+++ b/steel-registry/src/data_components/vanilla_components/tests.rs
@@ -243,7 +243,7 @@ fn unit_component_network_codecs_match_vanilla() {
 
     let mut expected = Vec::new();
     NbtTag::Compound(NbtCompound::new()).write(&mut expected);
-    assert!(!expected.is_empty());
+    assert_ne!(expected.len(), 0);
     assert_eq!(encoded, expected);
 
     let mut cursor = Cursor::new(encoded.as_slice());

--- a/steel-registry/src/lib.rs
+++ b/steel-registry/src/lib.rs
@@ -19,14 +19,6 @@
     clippy::unused_self,
     reason = "registry model code mirrors vanilla/generated data and keeps existing panic-heavy registry invariants"
 )]
-#![cfg_attr(
-    test,
-    expect(
-        clippy::float_cmp,
-        reason = "registry tests compare exact extracted floating-point constants"
-    )
-)]
-
 pub mod attribute;
 pub mod banner_pattern;
 pub mod biome;

--- a/steel-registry/src/particle_type.rs
+++ b/steel-registry/src/particle_type.rs
@@ -895,7 +895,7 @@ mod tests {
         let result = particle.write(&mut encoded);
 
         assert!(result.is_err());
-        assert!(encoded.is_empty());
+        assert_eq!(encoded.len(), 0);
     }
 
     #[test]
@@ -926,7 +926,7 @@ mod tests {
         let mut encoded = Vec::new();
         let result = BlockParticleOption::new(invalid_state).write_network(&mut encoded);
         assert!(result.is_err());
-        assert!(encoded.is_empty());
+        assert_eq!(encoded.len(), 0);
     }
 
     #[test]

--- a/steel-registry/src/position_source.rs
+++ b/steel-registry/src/position_source.rs
@@ -316,7 +316,7 @@ mod tests {
         let result = source.write(&mut encoded);
 
         assert!(result.is_err());
-        assert!(encoded.is_empty());
+        assert_eq!(encoded.len(), 0);
     }
 
     #[test]

--- a/steel-utils/src/geometry.rs
+++ b/steel-utils/src/geometry.rs
@@ -619,10 +619,6 @@ impl Aabb<IVec3, Structure> {
 }
 
 #[cfg(test)]
-#[expect(
-    clippy::float_cmp,
-    reason = "geometry constructors use exact test values"
-)]
 mod tests {
     use super::*;
 

--- a/steel-utils/src/random/legacy_random.rs
+++ b/steel-utils/src/random/legacy_random.rs
@@ -288,7 +288,6 @@ mod test {
     }
 
     #[test]
-    #[expect(clippy::float_cmp, reason = "exact match against vanilla test vectors")]
     fn test_next_f64() {
         let mut rand = LegacyRandom::from_seed(0);
 
@@ -314,7 +313,6 @@ mod test {
     }
 
     #[test]
-    #[expect(clippy::float_cmp, reason = "exact match against vanilla test vectors")]
     fn test_next_f32() {
         let mut rand = LegacyRandom::from_seed(0);
 
@@ -372,7 +370,6 @@ mod test {
     }
 
     #[test]
-    #[expect(clippy::float_cmp, reason = "exact match against vanilla test vectors")]
     fn test_next_gaussian() {
         let mut rand = LegacyRandom::from_seed(0);
 
@@ -395,7 +392,6 @@ mod test {
     }
 
     #[test]
-    #[expect(clippy::float_cmp, reason = "exact match against vanilla test vectors")]
     fn test_triangle() {
         let mut rand = LegacyRandom::from_seed(0);
 

--- a/steel-utils/src/random/worldgen_random.rs
+++ b/steel-utils/src/random/worldgen_random.rs
@@ -153,10 +153,6 @@ mod tests {
     }
 
     #[test]
-    #[expect(
-        clippy::float_cmp,
-        reason = "gaussian cache parity must match vanilla exactly"
-    )]
     fn feature_seed_preserves_pending_gaussian() {
         let mut random = WorldgenRandom::from_seed(123);
         let _ = random.next_gaussian();

--- a/steel-utils/src/random/xoroshiro.rs
+++ b/steel-utils/src/random/xoroshiro.rs
@@ -178,7 +178,6 @@ impl PositionalRandom for XoroshiroSplitter {
 #[expect(
     clippy::unreadable_literal,
     clippy::cast_sign_loss,
-    clippy::float_cmp,
     reason = "test vectors from vanilla Java; raw literals and casts are intentional"
 )]
 mod tests {

--- a/steel-utils/src/value_providers/tests.rs
+++ b/steel-utils/src/value_providers/tests.rs
@@ -1,7 +1,6 @@
 #![expect(
     clippy::unwrap_used,
-    clippy::float_cmp,
-    reason = "test assertions: unwrap panics on parse failures, float equality is the check"
+    reason = "test assertions: unwrap panics on parse failures"
 )]
 
 use super::*;

--- a/steel-worldgen/src/noise/improved_noise.rs
+++ b/steel-worldgen/src/noise/improved_noise.rs
@@ -853,15 +853,9 @@ mod tests {
         let noise2 = ImprovedNoise::new(&mut rng2);
 
         // Same seed should produce same noise
-        #[expect(
-            clippy::float_cmp,
-            reason = "determinism test: identical seeds must produce bit-identical offsets"
-        )]
-        {
-            assert_eq!(noise1.xo, noise2.xo);
-            assert_eq!(noise1.yo, noise2.yo);
-            assert_eq!(noise1.zo, noise2.zo);
-        }
+        assert_eq!(noise1.xo, noise2.xo);
+        assert_eq!(noise1.yo, noise2.yo);
+        assert_eq!(noise1.zo, noise2.zo);
         assert_eq!(noise1.p, noise2.p);
 
         // Same coordinates should produce same values
@@ -914,14 +908,8 @@ mod tests {
         ];
 
         for &(a, b) in &samples {
-            #[expect(
-                clippy::float_cmp,
-                reason = "zero-axis helpers must be bit-identical to the full scalar path"
-            )]
-            {
-                assert_eq!(noise.noise_xz(a, b), noise.noise(a, 0.0, b));
-                assert_eq!(noise.noise_xy(a, b), noise.noise(a, b, 0.0));
-            }
+            assert_eq!(noise.noise_xz(a, b), noise.noise(a, 0.0, b));
+            assert_eq!(noise.noise_xy(a, b), noise.noise(a, b, 0.0));
         }
     }
 

--- a/steel-worldgen/src/noise/normal_noise.rs
+++ b/steel-worldgen/src/noise/normal_noise.rs
@@ -361,14 +361,8 @@ mod tests {
         ];
 
         for &(a, b) in &samples {
-            #[expect(
-                clippy::float_cmp,
-                reason = "zero-axis helpers must be bit-identical to the full scalar path"
-            )]
-            {
-                assert_eq!(noise.get_value_xz(a, b), noise.get_value(a, 0.0, b));
-                assert_eq!(noise.get_value_xy(a, b), noise.get_value(a, b, 0.0));
-            }
+            assert_eq!(noise.get_value_xz(a, b), noise.get_value(a, 0.0, b));
+            assert_eq!(noise.get_value_xy(a, b), noise.get_value(a, b, 0.0));
         }
     }
 

--- a/steel-worldgen/src/noise/perlin_noise.rs
+++ b/steel-worldgen/src/noise/perlin_noise.rs
@@ -567,14 +567,8 @@ mod tests {
         ];
 
         for &(a, b) in &samples {
-            #[expect(
-                clippy::float_cmp,
-                reason = "zero-axis helpers must be bit-identical to the full scalar path"
-            )]
-            {
-                assert_eq!(noise.get_value_xz(a, b), noise.get_value(a, 0.0, b));
-                assert_eq!(noise.get_value_xy(a, b), noise.get_value(a, b, 0.0));
-            }
+            assert_eq!(noise.get_value_xz(a, b), noise.get_value(a, 0.0, b));
+            assert_eq!(noise.get_value_xy(a, b), noise.get_value(a, b, 0.0));
         }
     }
 }

--- a/steel-worldgen/src/noise/simplex_noise.rs
+++ b/steel-worldgen/src/noise/simplex_noise.rs
@@ -183,14 +183,8 @@ mod tests {
         for i in 0..10 {
             let x = f64::from(i) * 13.7;
             let z = f64::from(i) * 7.3;
-            #[expect(
-                clippy::float_cmp,
-                reason = "determinism test: identical inputs must produce bit-identical outputs"
-            )]
             // Determinism test: identical inputs must produce identical outputs
-            {
-                assert_eq!(noise1.get_value_2d(x, z), noise2.get_value_2d(x, z));
-            }
+            assert_eq!(noise1.get_value_2d(x, z), noise2.get_value_2d(x, z));
         }
     }
 

--- a/steel-worldgen/src/structure/desert_pyramid.rs
+++ b/steel-worldgen/src/structure/desert_pyramid.rs
@@ -136,7 +136,7 @@ mod tests {
         };
         assert_eq!(data.height_position, None);
         assert_eq!(data.has_placed_chest, [false; 4]);
-        assert!(data.potential_suspicious_sand_world_positions.is_empty());
+        assert_eq!(data.potential_suspicious_sand_world_positions.len(), 0);
         assert_eq!(data.random_collapsed_roof_pos, BlockPos::new(0, 0, 0));
     }
 }

--- a/steel-worldgen/src/structure/mineshaft.rs
+++ b/steel-worldgen/src/structure/mineshaft.rs
@@ -831,7 +831,7 @@ mod tests {
         else {
             panic!("first mineshaft piece should be the start room");
         };
-        assert!(!child_entrance_boxes.is_empty());
+        assert_ne!(child_entrance_boxes.len(), 0);
 
         let corridor = result
             .pieces

--- a/steel-worldgen/src/structure/ocean_monument.rs
+++ b/steel-worldgen/src/structure/ocean_monument.rs
@@ -965,7 +965,7 @@ mod tests {
         else {
             panic!("ocean monument should use its procedural payload");
         };
-        assert!(!data.child_pieces.is_empty());
+        assert_ne!(data.child_pieces.len(), 0);
         assert!(matches!(
             data.child_pieces[0].kind,
             OceanMonumentChildPieceKind::EntryRoom { .. }

--- a/steel-worldgen/src/structure/placement.rs
+++ b/steel-worldgen/src/structure/placement.rs
@@ -704,7 +704,7 @@ mod tests {
         let positions = generate_ring_positions::<
             fn(i32, i32, &mut LegacyRandom) -> Option<(i32, i32)>,
         >(0, 32, 3, 0, None, &thread_pool);
-        assert!(positions.is_empty());
+        assert_eq!(positions.len(), 0);
     }
 
     #[test]


### PR DESCRIPTION
<!--
PR template
-->

## Type of change

- [ ] Block implementation
- [ ] Item implementation
- [ ] Command implementation
- [ ] Entity implementation
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [ ] Performance improvement
- [ ] Documentation
- [ ] Chore / tooling

## Description

it bump nightly and fix the new recursion warning as mentionned in https://github.com/Steel-Foundation/SteelMC/pull/448

## How this was tested

it compile

## Screenshots / logs

```
warning: overflow evaluating the requirement `{async block@steel-core/src/server/player_admission.rs:108:22: 108:32}: std::marker::Send`
   --> steel-core/src/server/player_admission.rs:108:9
    |
108 | /         tokio::spawn(async move {
109 | |             let state = server.prepare_player_join(&player).await;
110 | |             server
111 | |                 .pending_player_joins
112 | |                 .send(PendingPlayerJoin { player, state });
113 | |         });
    | |__________^
    |
    = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`steel_core`)
    = help: or consider adding a manual `impl` of auto traits like `Send` for intermediate types, if auto traits are involved
    = note: this lint is attached to the whole crate and can't be disabled on a per-function basis
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #159228 <https://github.com/rust-lang/rust/issues/159228>
    = note: `#[warn(recursion_depth_exceeding_limit)]` (part of `#[warn(future_incompatible)]`) on by default

warning: overflow evaluating the requirement `{async block@steel-core/src/server/player_admission.rs:108:22: 108:32}: std::marker::Send`
  |
  = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`steel_core`)
  = help: or consider adding a manual `impl` of auto traits like `Send` for intermediate types, if auto traits are involved
  = note: this lint is attached to the whole crate and can't be disabled on a per-function basis
  = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
  = note: for more information, see issue #159228 <https://github.com/rust-lang/rust/issues/159228>

```

## Checklist

- [x] Code builds w/o errors or warnings
- [x] Self-reviewed the diff
- [ ] Docs updated (if applicable)
- [x] No leftover debug code / comments

## Additional notes

<!-- Anything else reviewers should know -->
