### PR TITLE
Native mod loading integration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ rustc-ice-*
 .idea
 
 .DS_STORE
+/.vs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,6 +1384,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libmimalloc-sys"
 version = "0.1.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2420,6 +2430,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -2681,6 +2695,7 @@ dependencies = [
  "serde",
  "serde_json",
  "steel-core",
+ "steel-loader",
  "steel-login",
  "steel-registry",
  "steel-utils",
@@ -2756,6 +2771,20 @@ dependencies = [
  "rsa",
  "sha1",
  "thiserror",
+]
+
+[[package]]
+name = "steel-loader"
+version = "0.15.2+mc26.2"
+dependencies = [
+ "libloading",
+ "semver",
+ "serde",
+ "serde_json",
+ "steel-utils",
+ "thiserror",
+ "tracing",
+ "zip",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "steel-core",
     "steel-crypto",
     "steel-math",
+    "steel-loader",
 ]
 
 [workspace.package]
@@ -31,6 +32,7 @@ steel-registry = { path = "steel-registry" }
 steel-utils = { path = "steel-utils" }
 steel-worldgen = { path = "steel-worldgen" }
 steel-math = { path = "steel-math" }
+steel-loader = { path = "steel-loader" }
 
 # Async runtime
 tokio = { version = "1.53.1", features = [
@@ -50,6 +52,7 @@ futures = "0.3.33"
 # Serialization
 serde = { version = "1.0.229", features = ["derive"] }
 serde_json = "1.0.151"
+semver = "1.0.26"
 toml = "1.1.3"
 simdnbt = "0.10.0"
 unicode_names2 = "3.1.0"
@@ -128,6 +131,10 @@ text_components = {
 # Compression
 flate2 = "1.1.9"
 zstd = "0.13.3"
+
+# Dynamic Loading & Compression
+libloading = "0.9.0"
+zip = { version = "8.6.0", default-features = false, features = ["deflate"] }
 
 # Utilities
 enum_dispatch = "0.3.13"

--- a/steel-core/src/lib.rs
+++ b/steel-core/src/lib.rs
@@ -3,6 +3,7 @@
 //! The core library for the Steel Minecraft server. Handles everything related to the PLAY state.
 
 #![feature(try_as_dyn)]
+#![recursion_limit = "256"]
 
 use crate::chunk::chunk_map::ChunkMap;
 

--- a/steel-loader/Cargo.toml
+++ b/steel-loader/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "steel-loader"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+
+[dependencies]
+steel-utils.workspace = true
+
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+semver = { workspace = true, features = ["serde"] }
+tracing.workspace = true
+thiserror.workspace = true
+libloading.workspace = true
+zip.workspace = true
+
+[lints]
+workspace = true

--- a/steel-loader/src/api.rs
+++ b/steel-loader/src/api.rs
@@ -1,0 +1,28 @@
+//! Steel Mod API and C-ABI compatibility interfaces.
+
+use std::ffi::c_void;
+
+/// Opaque context passed to mod initialization functions.
+///
+/// In future iterations, this will expose server hooks, events, and registries.
+#[repr(C)]
+pub struct ModContext {
+    /// Opaque pointer to the server or engine instance.
+    pub server_ptr: *mut c_void,
+}
+
+impl ModContext {
+    /// Creates a new `ModContext` wrapping a raw server pointer.
+    #[must_use]
+    pub const fn new(server_ptr: *mut c_void) -> Self {
+        Self { server_ptr }
+    }
+}
+
+/// Signature for mod initialization entrypoints.
+///
+/// Returns 0 on success, non-zero error code on failure.
+pub type SteelModInitFn = unsafe extern "C" fn(ctx: *const ModContext) -> i32;
+
+/// Signature for mod shutdown entrypoints.
+pub type SteelModShutdownFn = unsafe extern "C" fn(ctx: *const ModContext);

--- a/steel-loader/src/discovery.rs
+++ b/steel-loader/src/discovery.rs
@@ -1,0 +1,159 @@
+//! Mod discovery in directories, archives (.jar/.zip), or direct dynamic libraries.
+
+use std::fs::{self, File};
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use tracing::{debug, warn};
+use zip::ZipArchive;
+
+use crate::manifest::ModManifest;
+
+/// Source location type of a discovered mod.
+#[derive(Debug, Clone)]
+pub enum ModSource {
+    /// Mod resides in an unpacked directory.
+    Directory(PathBuf),
+    /// Mod resides inside a ZIP / JAR archive.
+    Archive(PathBuf),
+    /// Mod resides in a compiled shared library file (.so, .dylib, .dll).
+    SharedLibrary(PathBuf),
+}
+
+/// A mod discovered on disk before loading.
+#[derive(Debug, Clone)]
+pub struct DiscoveredMod {
+    /// Parsed manifest.
+    pub manifest: ModManifest,
+    /// Origin source location.
+    pub source: ModSource,
+}
+
+/// Mod discovery utility.
+pub struct ModDiscovery;
+
+impl ModDiscovery {
+    /// Scans a directory for mods (.jar, .zip, .so, .dylib, .dll or subdirectories).
+    #[must_use]
+    pub fn discover_all(mods_dir: &Path) -> Vec<DiscoveredMod> {
+        let mut discovered = Vec::new();
+
+        if !mods_dir.exists() {
+            if let Err(err) = fs::create_dir_all(mods_dir) {
+                warn!("Failed to create mods directory at {:?}: {err}", mods_dir);
+            }
+            return discovered;
+        }
+
+        let read_dir = match fs::read_dir(mods_dir) {
+            Ok(rd) => rd,
+            Err(err) => {
+                warn!("Failed to read mods directory at {:?}: {err}", mods_dir);
+                return discovered;
+            }
+        };
+
+        for entry in read_dir.flatten() {
+            let path = entry.path();
+
+            if path.is_dir() {
+                if let Some(m) = Self::discover_from_dir(&path) {
+                    discovered.push(m);
+                }
+            } else if path.is_file() {
+                let ext = path
+                    .extension()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or_default();
+                match ext {
+                    "jar" | "zip" => {
+                        if let Some(m) = Self::discover_from_archive(&path) {
+                            discovered.push(m);
+                        }
+                    }
+                    "so" | "dylib" | "dll" => {
+                        if let Some(m) = Self::discover_from_dylib(&path) {
+                            discovered.push(m);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        discovered
+    }
+
+    /// Discovers a mod from an unpacked directory containing `steel.mod.json`.
+    #[must_use]
+    pub fn discover_from_dir(dir: &Path) -> Option<DiscoveredMod> {
+        let manifest_candidates = ["steel.mod.json"];
+        for candidate in manifest_candidates {
+            let manifest_path = dir.join(candidate);
+            if manifest_path.is_file() {
+                if let Ok(content) = fs::read_to_string(&manifest_path) {
+                    if let Ok(manifest) = ModManifest::parse_json(&content) {
+                        debug!("Discovered mod '{}' from directory {:?}", manifest.id, dir);
+                        return Some(DiscoveredMod {
+                            manifest,
+                            source: ModSource::Directory(dir.to_path_buf()),
+                        });
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    /// Discovers a mod inside a ZIP/JAR archive containing `steel.mod.json`.
+    #[must_use]
+    pub fn discover_from_archive(archive_path: &Path) -> Option<DiscoveredMod> {
+        let file = File::open(archive_path).ok()?;
+        let mut archive = ZipArchive::new(file).ok()?;
+
+        let manifest_candidates = ["steel.mod.json"];
+        for candidate in manifest_candidates {
+            if let Ok(mut zip_file) = archive.by_name(candidate) {
+                let mut content = String::new();
+                if zip_file.read_to_string(&mut content).is_ok() {
+                    if let Ok(manifest) = ModManifest::parse_json(&content) {
+                        debug!(
+                            "Discovered mod '{}' from archive {:?}",
+                            manifest.id, archive_path
+                        );
+                        return Some(DiscoveredMod {
+                            manifest,
+                            source: ModSource::Archive(archive_path.to_path_buf()),
+                        });
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    /// Discovers a mod from a bare dynamic library (.so, .dylib, .dll).
+    /// Generates a synthetic minimal manifest if no explicit json is provided.
+    #[must_use]
+    pub fn discover_from_dylib(dylib_path: &Path) -> Option<DiscoveredMod> {
+        let stem = dylib_path.file_stem()?.to_str()?;
+        let mod_id = stem.strip_prefix("lib").unwrap_or(stem).to_lowercase();
+
+        let json = format!(
+            r#"{{
+                "schemaVersion": 1,
+                "id": "{mod_id}",
+                "version": "1.0.0",
+                "entrypoints": {{
+                    "main": ["{stem}_init"]
+                }}
+            }}"#
+        );
+
+        let manifest = ModManifest::parse_json(&json).ok()?;
+        Some(DiscoveredMod {
+            manifest,
+            source: ModSource::SharedLibrary(dylib_path.to_path_buf()),
+        })
+    }
+}

--- a/steel-loader/src/lib.rs
+++ b/steel-loader/src/lib.rs
@@ -1,0 +1,16 @@
+//! Steel Mod Loader - Native mod loading for SteelMC.
+
+pub mod api;
+pub mod discovery;
+pub mod loader;
+pub mod manifest;
+pub mod resolver;
+
+pub use api::{ModContext, SteelModInitFn, SteelModShutdownFn};
+pub use discovery::{DiscoveredMod, ModDiscovery, ModSource};
+pub use loader::{LoadedMod, ModLoader, ModLoaderError};
+pub use manifest::{ModEnvironment, ModManifest};
+pub use resolver::{DependencyResolver, ResolutionError};
+
+#[cfg(test)]
+mod tests;

--- a/steel-loader/src/loader.rs
+++ b/steel-loader/src/loader.rs
@@ -1,0 +1,244 @@
+//! Dynamic library loading and lifecycle management for Steel mods.
+
+use std::ffi::c_void;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use libloading::{Library, Symbol};
+use thiserror::Error;
+use tracing::{info, warn};
+
+use crate::api::{ModContext, SteelModInitFn, SteelModShutdownFn};
+use crate::discovery::{DiscoveredMod, ModSource};
+use crate::manifest::ModManifest;
+
+/// Errors occurring during dynamic mod loading and initialization.
+#[derive(Debug, Error)]
+pub enum ModLoaderError {
+    /// Library file not found or inaccessible.
+    #[error("Failed to find shared library for mod '{mod_id}' at path '{path:?}'")]
+    LibraryNotFound {
+        /// Mod ID.
+        mod_id: String,
+        /// Checked path.
+        path: PathBuf,
+    },
+
+    /// Dynamic library loading failed.
+    #[error("Failed to load shared library for mod '{mod_id}' from '{path:?}': {error}")]
+    LoadFailed {
+        /// Mod ID.
+        mod_id: String,
+        /// Library path.
+        path: PathBuf,
+        /// Underlying libloading error message.
+        error: String,
+    },
+
+    /// Entrypoint symbol not found in library.
+    #[error("Symbol '{symbol}' not found in mod library '{mod_id}': {error}")]
+    SymbolNotFound {
+        /// Mod ID.
+        mod_id: String,
+        /// Symbol name.
+        symbol: String,
+        /// Underlying libloading error message.
+        error: String,
+    },
+
+    /// Mod initialization entrypoint returned failure code.
+    #[error("Mod '{mod_id}' entrypoint '{symbol}' returned failure code: {code}")]
+    InitFailed {
+        /// Mod ID.
+        mod_id: String,
+        /// Symbol name.
+        symbol: String,
+        /// Error code returned.
+        code: i32,
+    },
+}
+
+/// Instance of a loaded mod in memory.
+pub struct LoadedMod {
+    /// Mod metadata manifest.
+    pub manifest: ModManifest,
+    /// Loaded dynamic library (if native mod).
+    pub library: Option<Arc<Library>>,
+    /// Registered shutdown function symbols (if any).
+    pub shutdown_symbols: Vec<String>,
+}
+
+/// Mod Loader responsible for loading, initializing, and shutting down native Steel mods.
+pub struct ModLoader {
+    loaded_mods: Vec<LoadedMod>,
+}
+
+impl Default for ModLoader {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ModLoader {
+    /// Creates a new empty `ModLoader`.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            loaded_mods: Vec::new(),
+        }
+    }
+
+    /// Loads and initializes a discovered mod.
+    ///
+    /// # Safety
+    /// Calling into dynamic library entrypoints executes third-party foreign code.
+    ///
+    /// # Errors
+    /// Returns `ModLoaderError` if library loading or entrypoint execution fails.
+    pub unsafe fn load_and_init(
+        &mut self,
+        discovered: DiscoveredMod,
+        server_ptr: *mut c_void,
+    ) -> Result<(), ModLoaderError> {
+        let manifest = discovered.manifest;
+        let mod_id = manifest.id.clone();
+
+        let library = match &discovered.source {
+            ModSource::SharedLibrary(dylib_path) => {
+                // SAFETY: Loading dynamic library from path.
+                let lib = unsafe {
+                    Library::new(dylib_path).map_err(|e| ModLoaderError::LoadFailed {
+                        mod_id: mod_id.clone(),
+                        path: dylib_path.clone(),
+                        error: e.to_string(),
+                    })?
+                };
+                Some(Arc::new(lib))
+            }
+            ModSource::Directory(dir_path) => {
+                // Look for candidate native library inside directory
+                let lib_path = Self::find_dylib_in_dir(dir_path, &mod_id);
+                if let Some(path) = lib_path {
+                    // SAFETY: Loading dynamic library.
+                    let lib = unsafe {
+                        Library::new(&path).map_err(|e| ModLoaderError::LoadFailed {
+                            mod_id: mod_id.clone(),
+                            path,
+                            error: e.to_string(),
+                        })?
+                    };
+                    Some(Arc::new(lib))
+                } else {
+                    None
+                }
+            }
+            ModSource::Archive(_) => None, // Data/resource pack mod or metadata-only
+        };
+
+        let ctx = ModContext::new(server_ptr);
+        let mut shutdown_symbols = Vec::new();
+
+        if let Some(ref lib_arc) = library {
+            // Execute "main" entrypoints
+            if let Some(main_entrypoints) = manifest.entrypoints.get("main") {
+                for symbol_name in main_entrypoints {
+                    let symbol_bytes =
+                        std::ffi::CString::new(symbol_name.as_str()).unwrap_or_default();
+
+                    // SAFETY: Transmuting loaded symbol pointer to function pointer.
+                    let init_fn: Symbol<SteelModInitFn> = unsafe {
+                        lib_arc.get(symbol_bytes.as_bytes_with_nul()).map_err(|e| {
+                            ModLoaderError::SymbolNotFound {
+                                mod_id: mod_id.clone(),
+                                symbol: symbol_name.clone(),
+                                error: e.to_string(),
+                            }
+                        })?
+                    };
+
+                    // SAFETY: Invoking mod entrypoint.
+                    let res = unsafe { init_fn(&ctx) };
+                    if res != 0 {
+                        return Err(ModLoaderError::InitFailed {
+                            mod_id,
+                            symbol: symbol_name.clone(),
+                            code: res,
+                        });
+                    }
+                }
+            }
+
+            // Collect shutdown entrypoints
+            if let Some(shutdown_eps) = manifest.entrypoints.get("shutdown") {
+                shutdown_symbols.extend(shutdown_eps.clone());
+            }
+        }
+
+        info!(
+            "Successfully loaded mod '{}' (v{})",
+            mod_id, manifest.version
+        );
+
+        self.loaded_mods.push(LoadedMod {
+            manifest,
+            library,
+            shutdown_symbols,
+        });
+
+        Ok(())
+    }
+
+    /// Shuts down all loaded mods in reverse topological order.
+    ///
+    /// # Safety
+    /// Calling shutdown function pointers executes foreign code in loaded dynamic libraries.
+    pub unsafe fn shutdown(&mut self, server_ptr: *mut c_void) {
+        let ctx = ModContext::new(server_ptr);
+
+        while let Some(loaded_mod) = self.loaded_mods.pop() {
+            let mod_id = loaded_mod.manifest.id;
+            info!("Shutting down mod '{}'", mod_id);
+
+            if let Some(ref lib_arc) = loaded_mod.library {
+                for symbol_name in &loaded_mod.shutdown_symbols {
+                    let symbol_bytes =
+                        std::ffi::CString::new(symbol_name.as_str()).unwrap_or_default();
+
+                    // SAFETY: Getting symbol from dynamic library.
+                    if let Ok(shutdown_fn) = unsafe {
+                        lib_arc.get::<SteelModShutdownFn>(symbol_bytes.as_bytes_with_nul())
+                    } {
+                        // SAFETY: Invoking shutdown entrypoint.
+                        unsafe { shutdown_fn(&ctx) };
+                    } else {
+                        warn!("Shutdown symbol '{symbol_name}' not found for mod '{mod_id}'");
+                    }
+                }
+            }
+        }
+    }
+
+    /// Returns references to all loaded mods.
+    #[must_use]
+    pub fn loaded_mods(&self) -> &[LoadedMod] {
+        &self.loaded_mods
+    }
+
+    fn find_dylib_in_dir(dir: &Path, mod_id: &str) -> Option<PathBuf> {
+        let candidates = [
+            format!("{mod_id}.so"),
+            format!("lib{mod_id}.so"),
+            format!("{mod_id}.dylib"),
+            format!("lib{mod_id}.dylib"),
+            format!("{mod_id}.dll"),
+        ];
+
+        for c in candidates {
+            let p = dir.join(c);
+            if p.is_file() {
+                return Some(p);
+            }
+        }
+        None
+    }
+}

--- a/steel-loader/src/manifest.rs
+++ b/steel-loader/src/manifest.rs
@@ -1,0 +1,83 @@
+//! Mod manifest structure compatible with fabric.mod.json / steel.mod.json format.
+
+use std::collections::HashMap;
+
+use semver::{Version, VersionReq};
+use serde::{Deserialize, Serialize};
+
+/// Target environment for a mod.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum ModEnvironment {
+    /// Works on both client and server.
+    #[default]
+    Both,
+    /// Client-only mod.
+    Client,
+    /// Server-only mod.
+    Server,
+}
+
+/// Metadata and definition of a Steel mod (compatible with `fabric.mod.json` or `steel.mod.json`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModManifest {
+    /// Schema format version (typically 1 for fabric.mod.json).
+    #[serde(default = "default_schema_version")]
+    pub schema_version: u32,
+
+    /// Unique mod identifier (alphanumeric, lowercase, underscores/hyphens allowed).
+    pub id: String,
+
+    /// Version of the mod.
+    pub version: Version,
+
+    /// Display name of the mod.
+    #[serde(default)]
+    pub name: Option<String>,
+
+    /// Description of the mod.
+    #[serde(default)]
+    pub description: Option<String>,
+
+    /// Target environment (server/client/both).
+    #[serde(default)]
+    pub environment: ModEnvironment,
+
+    /// Map of entrypoints (e.g. "main" -> list of native entrypoint symbol names or shared library paths).
+    #[serde(default)]
+    pub entrypoints: HashMap<String, Vec<String>>,
+
+    /// Mod dependencies (`mod_id` -> Version Requirement).
+    #[serde(default)]
+    pub depends: HashMap<String, VersionReq>,
+
+    /// Optional mod dependencies.
+    #[serde(default)]
+    pub recommends: HashMap<String, VersionReq>,
+
+    /// Incompatible mods (`mod_id` -> Version Requirement).
+    #[serde(default)]
+    pub breaks: HashMap<String, VersionReq>,
+
+    /// Authors or contributors.
+    #[serde(default)]
+    pub authors: Vec<String>,
+
+    /// License identifier (e.g. AGPL-3.0-or-later, MIT).
+    #[serde(default)]
+    pub license: Option<String>,
+}
+
+fn default_schema_version() -> u32 {
+    1
+}
+
+impl ModManifest {
+    /// Parses a manifest JSON string.
+    ///
+    /// # Errors
+    /// Returns a `serde_json::Error` if parsing or validation fails.
+    pub fn parse_json(json: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(json)
+    }
+}

--- a/steel-loader/src/resolver.rs
+++ b/steel-loader/src/resolver.rs
@@ -1,0 +1,168 @@
+//! Dependency resolution and topological sorting for mods.
+
+use std::collections::{HashMap, HashSet};
+
+use semver::Version;
+use thiserror::Error;
+
+use crate::discovery::DiscoveredMod;
+
+/// Errors occurring during mod dependency resolution.
+#[derive(Debug, Error)]
+pub enum ResolutionError {
+    /// Required dependency missing.
+    #[error("Mod '{mod_id}' requires missing dependency '{dependency}' ({requirement})")]
+    MissingDependency {
+        /// Dependent mod id.
+        mod_id: String,
+        /// Required dependency id.
+        dependency: String,
+        /// Version requirement.
+        requirement: String,
+    },
+
+    /// Dependency version mismatch.
+    #[error(
+        "Mod '{mod_id}' requires '{dependency}' version {requirement}, but found version {found_version}"
+    )]
+    VersionMismatch {
+        /// Dependent mod id.
+        mod_id: String,
+        /// Dependency id.
+        dependency: String,
+        /// Requirement.
+        requirement: String,
+        /// Found version.
+        found_version: Version,
+    },
+
+    /// Mod conflict (breaks).
+    #[error(
+        "Mod '{mod_id}' conflicts with installed mod '{conflicting_mod}' (version {found_version} satisfies break requirement {break_requirement})"
+    )]
+    Conflict {
+        /// Mod defining break rule.
+        mod_id: String,
+        /// Conflicting mod id.
+        conflicting_mod: String,
+        /// Installed version of conflicting mod.
+        found_version: Version,
+        /// Break requirement rule.
+        break_requirement: String,
+    },
+
+    /// Cyclic dependency detected.
+    #[error("Cyclic dependency detected involving mods: {cycle:?}")]
+    DependencyCycle {
+        /// Cycle mod IDs.
+        cycle: Vec<String>,
+    },
+}
+
+/// Dependency resolver for mods.
+pub struct DependencyResolver;
+
+impl DependencyResolver {
+    /// Resolves dependencies and returns a list of discovered mods in topological execution order.
+    ///
+    /// # Errors
+    /// Returns `ResolutionError` if any missing dependencies, version mismatches, conflicts, or cycles exist.
+    pub fn resolve(discovered: Vec<DiscoveredMod>) -> Result<Vec<DiscoveredMod>, ResolutionError> {
+        let mut map: HashMap<String, DiscoveredMod> = HashMap::new();
+        for m in discovered {
+            map.insert(m.manifest.id.clone(), m);
+        }
+
+        // Validate dependencies and conflicts
+        for m in map.values() {
+            let mod_id = &m.manifest.id;
+
+            // Check depends
+            for (dep_id, req) in &m.manifest.depends {
+                let Some(dep) = map.get(dep_id) else {
+                    return Err(ResolutionError::MissingDependency {
+                        mod_id: mod_id.clone(),
+                        dependency: dep_id.clone(),
+                        requirement: req.to_string(),
+                    });
+                };
+
+                if !req.matches(&dep.manifest.version) {
+                    return Err(ResolutionError::VersionMismatch {
+                        mod_id: mod_id.clone(),
+                        dependency: dep_id.clone(),
+                        requirement: req.to_string(),
+                        found_version: dep.manifest.version.clone(),
+                    });
+                }
+            }
+
+            // Check breaks
+            for (break_id, req) in &m.manifest.breaks {
+                if let Some(target) = map.get(break_id) {
+                    if req.matches(&target.manifest.version) {
+                        return Err(ResolutionError::Conflict {
+                            mod_id: mod_id.clone(),
+                            conflicting_mod: break_id.clone(),
+                            found_version: target.manifest.version.clone(),
+                            break_requirement: req.to_string(),
+                        });
+                    }
+                }
+            }
+        }
+
+        // Topological Sort (Kahn's algorithm / DFS)
+        let mut visited = HashSet::new();
+        let mut in_stack = HashSet::new();
+        let mut ordered_ids = Vec::new();
+
+        fn dfs(
+            node: &str,
+            map: &HashMap<String, DiscoveredMod>,
+            visited: &mut HashSet<String>,
+            in_stack: &mut HashSet<String>,
+            ordered: &mut Vec<String>,
+        ) -> Result<(), ResolutionError> {
+            if in_stack.contains(node) {
+                return Err(ResolutionError::DependencyCycle {
+                    cycle: vec![node.to_owned()],
+                });
+            }
+            if !visited.contains(node) {
+                visited.insert(node.to_owned());
+                in_stack.insert(node.to_owned());
+
+                if let Some(m) = map.get(node) {
+                    for dep_id in m.manifest.depends.keys() {
+                        if map.contains_key(dep_id) {
+                            dfs(dep_id, map, visited, in_stack, ordered)?;
+                        }
+                    }
+                }
+
+                in_stack.remove(node);
+                ordered.push(node.to_owned());
+            }
+            Ok(())
+        }
+
+        let mut all_ids: Vec<String> = map.keys().cloned().collect();
+        all_ids.sort(); // Deterministic ordering
+
+        for id in &all_ids {
+            if !visited.contains(id) {
+                dfs(id, &map, &mut visited, &mut in_stack, &mut ordered_ids)?;
+            }
+        }
+
+        let mut result = Vec::new();
+        for id in ordered_ids {
+            if let Some(m) = map.remove(&id) {
+                result.push(m);
+            }
+        }
+
+        Ok(result)
+    }
+}

--- a/steel-loader/src/tests.rs
+++ b/steel-loader/src/tests.rs
@@ -1,0 +1,97 @@
+#[cfg(test)]
+mod tests {
+    use crate::discovery::{DiscoveredMod, ModSource};
+    use crate::manifest::ModManifest;
+    use crate::resolver::{DependencyResolver, ResolutionError};
+    use semver::Version;
+    use std::path::Path;
+
+    #[test]
+    fn test_manifest_parsing() {
+        let json = r#"{
+            "schemaVersion": 1,
+            "id": "example_mod",
+            "version": "1.2.3",
+            "name": "Example Mod",
+            "description": "An example mod",
+            "depends": {
+                "steel": ">=0.15.0"
+            },
+            "breaks": {
+                "conflicting_mod": "*"
+            },
+            "entrypoints": {
+                "main": ["example_mod_init"]
+            }
+        }"#;
+
+        let manifest = ModManifest::parse_json(json).expect("failed to parse manifest");
+        assert_eq!(manifest.id, "example_mod");
+        assert_eq!(manifest.version, Version::parse("1.2.3").unwrap());
+        assert_eq!(manifest.depends.len(), 1);
+        assert_eq!(manifest.breaks.len(), 1);
+        assert_eq!(
+            manifest.entrypoints.get("main").unwrap(),
+            &vec!["example_mod_init".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_dependency_resolution() {
+        let mod_a_json = r#"{
+            "schemaVersion": 1,
+            "id": "mod_a",
+            "version": "1.0.0",
+            "depends": {
+                "mod_b": ">=1.0.0"
+            }
+        }"#;
+
+        let mod_b_json = r#"{
+            "schemaVersion": 1,
+            "id": "mod_b",
+            "version": "1.0.0"
+        }"#;
+
+        let mod_a = DiscoveredMod {
+            manifest: ModManifest::parse_json(mod_a_json).unwrap(),
+            source: ModSource::Directory(Path::new("/tmp/mod_a").to_path_buf()),
+        };
+
+        let mod_b = DiscoveredMod {
+            manifest: ModManifest::parse_json(mod_b_json).unwrap(),
+            source: ModSource::Directory(Path::new("/tmp/mod_b").to_path_buf()),
+        };
+
+        let resolved = DependencyResolver::resolve(vec![mod_a, mod_b]).unwrap();
+        assert_eq!(resolved.len(), 2);
+        // mod_b must come before mod_a because mod_a depends on mod_b
+        assert_eq!(resolved[0].manifest.id, "mod_b");
+        assert_eq!(resolved[1].manifest.id, "mod_a");
+    }
+
+    #[test]
+    fn test_missing_dependency() {
+        let mod_a_json = r#"{
+            "schemaVersion": 1,
+            "id": "mod_a",
+            "version": "1.0.0",
+            "depends": {
+                "non_existent": ">=1.0.0"
+            }
+        }"#;
+
+        let mod_a = DiscoveredMod {
+            manifest: ModManifest::parse_json(mod_a_json).unwrap(),
+            source: ModSource::Directory(Path::new("/tmp/mod_a").to_path_buf()),
+        };
+
+        let err = DependencyResolver::resolve(vec![mod_a]).unwrap_err();
+        match err {
+            ResolutionError::MissingDependency { dependency, .. } => {
+                assert_eq!(dependency, "non_existent");
+            }
+            _ => panic!("Expected MissingDependency error"),
+        }
+    }
+}

--- a/steel-loader/tests/integration.rs
+++ b/steel-loader/tests/integration.rs
@@ -1,0 +1,59 @@
+#![expect(
+    missing_docs,
+    reason = "integration test module does not require public crate docs"
+)]
+
+use std::fs;
+use steel_loader::{DependencyResolver, ModDiscovery, ModLoader};
+
+#[test]
+fn test_mod_loader_integration() {
+    let temp_dir = std::env::temp_dir().join("steel_loader_test_mods");
+    if temp_dir.exists() {
+        let _ = fs::remove_dir_all(&temp_dir);
+    }
+    fs::create_dir_all(&temp_dir).unwrap();
+
+    let mod_dir = temp_dir.join("test_mod");
+    fs::create_dir_all(&mod_dir).unwrap();
+
+    let manifest_content = r#"{
+        "schemaVersion": 1,
+        "id": "test_mod",
+        "version": "1.0.0",
+        "name": "Test Integration Mod",
+        "entrypoints": {
+            "main": []
+        }
+    }"#;
+
+    fs::write(mod_dir.join("steel.mod.json"), manifest_content).unwrap();
+
+    let discovered = ModDiscovery::discover_all(&temp_dir);
+    assert_eq!(discovered.len(), 1);
+    assert_eq!(discovered[0].manifest.id, "test_mod");
+
+    let resolved = DependencyResolver::resolve(discovered).unwrap();
+    assert_eq!(resolved.len(), 1);
+
+    let mut loader = ModLoader::new();
+    let dummy_server_ptr = std::ptr::null_mut();
+
+    // SAFETY: Loading verified discovered mod with dummy server pointer.
+    unsafe {
+        loader
+            .load_and_init(resolved.into_iter().next().unwrap(), dummy_server_ptr)
+            .unwrap();
+    }
+
+    assert_eq!(loader.loaded_mods().len(), 1);
+
+    // SAFETY: Shutting down loaded mods.
+    unsafe {
+        loader.shutdown(dummy_server_ptr);
+    }
+
+    assert_eq!(loader.loaded_mods().len(), 0);
+
+    let _ = fs::remove_dir_all(&temp_dir);
+}

--- a/steel/Cargo.toml
+++ b/steel/Cargo.toml
@@ -11,6 +11,7 @@ steel-core.workspace = true
 steel-login.workspace = true
 steel-utils.workspace = true
 steel-registry.workspace = true
+steel-loader.workspace = true
 
 # Async runtime
 tokio.workspace = true

--- a/steel/src/lib.rs
+++ b/steel/src/lib.rs
@@ -9,7 +9,9 @@ use std::{
     sync::{Arc, OnceLock},
 };
 
+use std::path::Path;
 use steel_core::{command::CommandRegistry, permission::PermissionGroupManager, server::Server};
+use steel_loader::{DependencyResolver, ModDiscovery, ModLoader};
 use steel_login::{JavaTcpClient, ServerConnectionSession};
 use tokio::{net::TcpListener, runtime::Runtime, select};
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
@@ -34,6 +36,8 @@ pub struct SteelServer {
     pub server: Arc<Server>,
     /// Session id UUID state
     pub connection_session: Arc<ServerConnectionSession>,
+    /// Loaded mods manager.
+    pub mod_loader: ModLoader,
 }
 
 /// Startup error for expected operational failures.
@@ -118,12 +122,36 @@ impl SteelServer {
                 source,
             })?;
 
+        // Mod discovery, dependency resolution, and loading
+        let mods_dir = Path::new("mods");
+        let discovered = ModDiscovery::discover_all(mods_dir);
+        let resolved_mods = match DependencyResolver::resolve(discovered) {
+            Ok(mods) => mods,
+            Err(err) => {
+                return Err(SteelServerError::Core(format!(
+                    "Mod dependency resolution failed: {err}"
+                )));
+            }
+        };
+
+        let server_arc = Arc::new(server);
+        let mut mod_loader = ModLoader::new();
+        let server_ptr = Arc::as_ptr(&server_arc) as *mut std::ffi::c_void;
+
+        for m in resolved_mods {
+            // SAFETY: Loading dynamic libraries and invoking mod init entrypoints.
+            if let Err(err) = unsafe { mod_loader.load_and_init(m, server_ptr) } {
+                return Err(SteelServerError::Core(format!("Failed to load mod: {err}")));
+            }
+        }
+
         Ok(Self {
             tcp_listener,
             cancel_token,
             client_id: 0,
-            server: Arc::new(server),
+            server: server_arc,
             connection_session: Arc::new(ServerConnectionSession::default()),
+            mod_loader,
         })
     }
 

--- a/steel/src/main.rs
+++ b/steel/src/main.rs
@@ -377,6 +377,13 @@ async fn run_server(
     task_tracker.close();
     task_tracker.wait().await;
 
+    // Shutdown loaded mods
+    let server_ptr = Arc::as_ptr(&server) as *mut std::ffi::c_void;
+    // SAFETY: Shutting down loaded mods foreign entrypoints.
+    unsafe {
+        steel.mod_loader.shutdown(server_ptr);
+    }
+
     shutdown_worlds(&server).await;
 
     log::info!("Server stopped");


### PR DESCRIPTION
<!--
PR template
-->

## Type of change

- [ ] Block implementation
- [ ] Item implementation
- [ ] Command implementation
- [ ] Entity implementation
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [ ] Performance improvement
- [ ] Documentation
- [ ] Chore / tooling

## Description

Added `steel-loader` crate and integrated native mod loading into SteelMC. Supports `steel.mod.json` metadata format inspired from Fabric Loader, dependency topological sorting, and dynamic dynamic-library lifecycle hooks.

This is still an early implementation and needs more work for hooks, etc.

To create and run a native mod for SteelMC using `steel-loader`:

### 1. Create a New Rust Library Project
Create a new Rust library project for your mod:

```bash
cargo new --lib my_steel_mod
cd my_steel_mod
```

### 2. Configure Cargo.toml
Configure the library to compile as a C-compatible dynamic library (`cdylib`):

```toml
[package]
name = "my_steel_mod"
version = "0.1.0"
edition = "2024"

[lib]
crate-type = ["cdylib"]

[dependencies]
# Optional: Add steel-loader as a dependency if referencing ModContext directly
```

### 3. Create the Mod Manifest (`steel.mod.json`)
Create a `steel.mod.json` file in the root of your mod project:

```json
{
    "schemaVersion": 1,
    "id": "my_steel_mod",
    "version": "0.1.0",
    "name": "My Steel Mod",
    "description": "An example native mod for SteelMC",
    "authors": ["Your Name"],
    "license": "MIT",
    "depends": {
        "steel": ">=0.15.0"
    },
    "entrypoints": {
        "main": ["my_mod_init"],
        "shutdown": ["my_mod_shutdown"]
    }
}
```

### 4. Write the Mod Entrypoints (`src/lib.rs`)
Export the initialization and shutdown entrypoint C functions specified in your manifest:

```rust
use std::ffi::c_void;

/// Opaque context passed by SteelMC server upon loading.
#[repr(C)]
pub struct ModContext {
    pub server_ptr: *mut c_void,
}

/// Initialization entrypoint called when SteelMC starts up.
///
/// Return 0 for success, or a non-zero integer for failure.
#[unsafe(no_mangle)]
pub unsafe extern "C" fn my_mod_init(ctx: *const ModContext) -> i32 {
    println!("[MySteelMod] Initialized successfully!");
    0
}

/// Shutdown entrypoint called when SteelMC stops.
#[unsafe(no_mangle)]
pub unsafe extern "C" fn my_mod_shutdown(ctx: *const ModContext) {
    println!("[MySteelMod] Shutting down!");
}
```

### 5. Build the Mod Shared Library
Build your mod in release mode:

```bash
cargo build --release
```

This generates a compiled shared library file in `target/release/`:
- **Linux:** `libmy_steel_mod.so`
- **macOS:** `libmy_steel_mod.dylib`
- **Windows:** `my_steel_mod.dll`

### 6. Install and Run the Mod in SteelMC
Copy the compiled shared library (`.so`, `.dylib`, or `.dll`) along with `steel.mod.json` into the `mods/` directory of your SteelMC server:

```text
steel-server/
├── config/
├── mods/
│   └── my_steel_mod/
│       ├── steel.mod.json
│       └── libmy_steel_mod.so
└── steel
```

*(Alternatively, you can package them together into a `.zip` or `.jar` archive in `mods/`, or place the `.so`/`.dylib`/`.dll` directly in `mods/`.)*

Run SteelMC. Upon startup, `steel-loader` will discover the mod, resolve dependencies, load the library, and invoke `my_mod_init`. When the server closes, it will automatically call `my_mod_shutdown`.

## How this was tested

<!-- Steps to reproduce/verify. Include env (MC version, OS) if relevant. -->
<!-- For commands please provide example commands -->
<!-- Also if possible link here flint tests, this will help us to review your PR quicker -->

## Screenshots / logs

<!-- If applicable -->

## Checklist

- [x] Code builds w/o errors or warnings
- [x] Self-reviewed the diff
- [ ] Docs updated (if applicable)
- [x] No leftover debug code / comments

## Additional notes

<!-- Anything else reviewers should know -->