### PR TITLE
feat: implement smithing table, recipes, and recipe sync

### DIFF
--- a/steel-core/src/behavior/blocks/container/mod.rs
+++ b/steel-core/src/behavior/blocks/container/mod.rs
@@ -3,9 +3,11 @@ mod barrel_block;
 mod beehive_block;
 mod chiseled_bookshelf_block;
 mod crafting_table_block;
+mod smithing_table_block;
 
 pub use anvil_block::AnvilBlock;
 pub use barrel_block::BarrelBlock;
 pub use beehive_block::BeehiveBlock;
 pub use chiseled_bookshelf_block::ChiseledBookShelfBlock;
 pub use crafting_table_block::CraftingTableBlock;
+pub use smithing_table_block::SmithingTableBlock;

--- a/steel-core/src/behavior/blocks/container/smithing_table_block.rs
+++ b/steel-core/src/behavior/blocks/container/smithing_table_block.rs
@@ -1,0 +1,53 @@
+use std::sync::Arc;
+
+use steel_macros::block_behavior;
+use steel_registry::blocks::BlockRef;
+use steel_registry::items::item::BlockHitResult;
+use steel_registry::vanilla_custom_stats;
+use steel_utils::{BlockPos, BlockStateId, translations};
+use text_components::TextComponent;
+
+use crate::{
+    behavior::{BlockBehavior, BlockPlaceContext, InteractionResult, InventoryAccess},
+    inventory::menu::kinds::smithing,
+    player::Player,
+    world::World,
+};
+
+/// Vanilla `SmithingTableBlock`.
+#[block_behavior]
+pub struct SmithingTableBlock {
+    block: BlockRef,
+}
+
+impl SmithingTableBlock {
+    /// Creates a new smithing table block behavior.
+    #[must_use]
+    pub const fn new(block: BlockRef) -> Self {
+        Self { block }
+    }
+}
+
+impl BlockBehavior for SmithingTableBlock {
+    fn get_state_for_placement(&self, _context: &BlockPlaceContext<'_>) -> Option<BlockStateId> {
+        Some(self.block.default_state())
+    }
+
+    fn use_without_item(
+        &self,
+        _state: BlockStateId,
+        _world: &Arc<World>,
+        pos: BlockPos,
+        player: &Player,
+        _hit_result: &BlockHitResult,
+        _inv: &mut InventoryAccess,
+    ) -> InteractionResult {
+        let inventory = player.inventory.clone();
+        player.open_menu(
+            TextComponent::translated(translations::CONTAINER_UPGRADE.msg()),
+            move |context| smithing(inventory, context.container_id, pos, context.world),
+        );
+        player.award_custom_stat(&vanilla_custom_stats::INTERACT_WITH_SMITHING_TABLE);
+        InteractionResult::Success
+    }
+}

--- a/steel-core/src/behavior/blocks/mod.rs
+++ b/steel-core/src/behavior/blocks/mod.rs
@@ -29,6 +29,7 @@ pub use building::{
 pub use colored::StainedGlassPaneBlock;
 pub use container::{
     AnvilBlock, BarrelBlock, BeehiveBlock, ChiseledBookShelfBlock, CraftingTableBlock,
+    SmithingTableBlock,
 };
 pub use decoration::{
     BannerBlock, CakeBlock, CandleBlock, CandleCakeBlock, CeilingHangingSignBlock, ChainBlock,

--- a/steel-core/src/inventory/menu/kinds/mod.rs
+++ b/steel-core/src/inventory/menu/kinds/mod.rs
@@ -5,9 +5,11 @@ mod basic_menu;
 mod chest_menu;
 mod crafting_menu;
 mod inventory_menu;
+mod smithing_menu;
 
 pub use anvil_menu::{AnvilKind, anvil};
 pub use basic_menu::BasicKind;
 pub use chest_menu::{ChestKind, chest};
 pub use crafting_menu::{CraftingKind, crafting};
 pub use inventory_menu::{INVENTORY_MENU_CONTAINER_ID, InventoryKind, inventory_menu};
+pub use smithing_menu::{SmithingKind, smithing};

--- a/steel-core/src/inventory/menu/kinds/smithing_menu.rs
+++ b/steel-core/src/inventory/menu/kinds/smithing_menu.rs
@@ -1,0 +1,361 @@
+//! Smithing table menu (template, base, addition, result).
+
+use std::sync::Arc;
+
+use steel_registry::REGISTRY;
+use steel_registry::item_stack::ItemStack;
+use steel_registry::level_events;
+use steel_registry::vanilla_blocks;
+use steel_registry::vanilla_menu_types;
+use steel_utils::locks::{IntoShared, Shared};
+use steel_utils::{BlockPos, DowncastType, DowncastTypeKey};
+
+use crate::inventory::container::{ResultContainer, SimpleContainer};
+use crate::inventory::prelude::*;
+use crate::inventory::slots::ResultHandler;
+use crate::player::player_inventory::PlayerInventory;
+use crate::world::World;
+use steel_registry::blocks::block_state_ext::BlockStateExt as _;
+
+const TEMPLATE_SLOT: usize = 0;
+const RESULT_SLOT: usize = 3;
+const PLAYER_INV_START: usize = 4;
+const PLAYER_INV_END: usize = 31;
+const HOTBAR_START: usize = 31;
+const HOTBAR_END: usize = 40;
+
+/// Builds the smithing table menu.
+#[must_use]
+pub fn smithing(
+    inventory: Shared<PlayerInventory>,
+    container_id: u8,
+    block_pos: BlockPos,
+    world: &Arc<World>,
+) -> Menu {
+    let input_container = SimpleContainer::new(3).into_shared();
+    let result_container = ResultContainer::new().into_shared();
+    let handler = SmithingHandler {
+        input_container: input_container.clone(),
+        result_container: result_container.clone(),
+        block_pos,
+        world: Arc::clone(world),
+    };
+
+    let mut builder = MenuBuilder::new(&vanilla_menu_types::SMITHING, container_id);
+    let mut inputs = builder.split(&input_container);
+    let template = builder.section_with(
+        &mut inputs,
+        1,
+        SectionKind::restricted(|_, stack| REGISTRY.recipes.smithing_accepts_template(stack)),
+    );
+    let base = builder.section_with(
+        &mut inputs,
+        1,
+        SectionKind::restricted(|_, stack| REGISTRY.recipes.smithing_accepts_base(stack)),
+    );
+    let addition = builder.section_with(
+        &mut inputs,
+        1,
+        SectionKind::restricted(|_, stack| REGISTRY.recipes.smithing_accepts_addition(stack)),
+    );
+    let result = builder.result_slot(handler);
+    let player = builder.player_inventory(&inventory);
+    let has_recipe_error = builder.data_slot(0);
+
+    builder.route_with_remainder_policy(
+        result,
+        player.all(),
+        FillDirection::Backward,
+        FakeResultRemainderPolicy::Discard,
+    );
+    builder.route(template, player.all(), FillDirection::Forward);
+    builder.route(base, player.all(), FillDirection::Forward);
+    builder.route(addition, player.all(), FillDirection::Forward);
+    builder.drain(template);
+    builder.drain(base);
+    builder.drain(addition);
+
+    builder.build(SmithingKind {
+        input_container,
+        result_container,
+        block_pos,
+        world: Arc::clone(world),
+        result,
+        has_recipe_error,
+    })
+}
+
+/// Per-menu smithing state.
+pub struct SmithingKind {
+    pub(crate) input_container: Shared<SimpleContainer>,
+    pub(crate) result_container: Shared<ResultContainer>,
+    block_pos: BlockPos,
+    world: Arc<World>,
+    result: Section,
+    has_recipe_error: DataSlot,
+}
+
+// SAFETY: This Steel-owned key uniquely identifies the concrete menu kind
+// within the process.
+unsafe impl DowncastType for SmithingKind {
+    const TYPE_KEY: DowncastTypeKey = DowncastTypeKey::new("steel:menu/smithing");
+}
+
+impl SmithingKind {
+    fn create_result(&self, behavior: &mut MenuBehavior, guard: &mut ContainerLockGuard) {
+        let (template, base, addition) = {
+            let input = guard
+                .get_typed::<SimpleContainer>(ContainerId::from_arc(&self.input_container))
+                .expect("smithing input is registered");
+            (
+                input.get_item(0).clone(),
+                input.get_item(1).clone(),
+                input.get_item(2).clone(),
+            )
+        };
+        let result = REGISTRY
+            .recipes
+            .find_smithing_recipe(&template, &base, &addition)
+            .map_or_else(ItemStack::empty, |recipe| {
+                recipe.assemble(&template, &base, &addition)
+            });
+        guard
+            .get_typed_mut::<ResultContainer>(ContainerId::from_arc(&self.result_container))
+            .expect("smithing result is registered")
+            .set_item(0, result.clone());
+
+        let has_error =
+            !template.is_empty() && !base.is_empty() && !addition.is_empty() && result.is_empty();
+        self.has_recipe_error.set(behavior, i16::from(has_error));
+    }
+}
+
+impl MenuKind for SmithingKind {
+    fn still_valid(&self, _behavior: &MenuBehavior, player: &Player) -> bool {
+        self.world.get_block_state(self.block_pos).get_block() == &vanilla_blocks::SMITHING_TABLE
+            && player.is_within_block_interaction_range_with_buffer(self.block_pos, 4.0)
+    }
+
+    fn can_take_item_for_pick_all(&self, _carried: &ItemStack, slot_index: usize) -> bool {
+        !self.result.contains(slot_index)
+    }
+
+    fn removed(&mut self, _behavior: &mut MenuBehavior, _player: &Player) {
+        self.result_container.lock().set_item(0, ItemStack::empty());
+    }
+
+    fn slots_changed(
+        &mut self,
+        behavior: &mut MenuBehavior,
+        guard: &mut ContainerLockGuard,
+        _player: &Player,
+    ) {
+        self.create_result(behavior, guard);
+    }
+
+    fn quick_move(
+        &mut self,
+        behavior: &mut MenuBehavior,
+        guard: &mut ContainerLockGuard,
+        slot_index: usize,
+        player: &Player,
+    ) -> Option<ItemStack> {
+        let clicked = behavior.slots()[slot_index].get_item(guard).clone();
+        if clicked.is_empty() {
+            return Some(ItemStack::empty());
+        }
+        let mut remaining = clicked.clone();
+        let moved = if slot_index == RESULT_SLOT {
+            behavior.move_item_stack_to(
+                guard,
+                slot_index,
+                &mut remaining,
+                PLAYER_INV_START,
+                HOTBAR_END,
+                FillDirection::Backward,
+            )
+        } else if slot_index < RESULT_SLOT {
+            behavior.move_item_stack_to(
+                guard,
+                slot_index,
+                &mut remaining,
+                PLAYER_INV_START,
+                HOTBAR_END,
+                FillDirection::Forward,
+            )
+        } else if can_move_into_inputs(guard, &self.input_container, &clicked) {
+            behavior.move_item_stack_to(
+                guard,
+                slot_index,
+                &mut remaining,
+                TEMPLATE_SLOT,
+                RESULT_SLOT,
+                FillDirection::Forward,
+            )
+        } else if (PLAYER_INV_START..PLAYER_INV_END).contains(&slot_index) {
+            behavior.move_item_stack_to(
+                guard,
+                slot_index,
+                &mut remaining,
+                HOTBAR_START,
+                HOTBAR_END,
+                FillDirection::Forward,
+            )
+        } else if (HOTBAR_START..HOTBAR_END).contains(&slot_index) {
+            behavior.move_item_stack_to(
+                guard,
+                slot_index,
+                &mut remaining,
+                PLAYER_INV_START,
+                PLAYER_INV_END,
+                FillDirection::Forward,
+            )
+        } else {
+            false
+        };
+
+        if !moved {
+            return Some(ItemStack::empty());
+        }
+        behavior.update_quick_move_source(guard, slot_index, &remaining, &clicked);
+        if remaining.count == clicked.count {
+            return Some(ItemStack::empty());
+        }
+        if let Some(remainder) = behavior.slots()[slot_index].on_take(guard, &mut remaining, player) {
+            player.add_item_or_drop_with_guard(guard, remainder);
+        }
+        Some(clicked)
+    }
+}
+
+fn can_move_into_inputs(
+    guard: &ContainerLockGuard,
+    input_container: &Shared<SimpleContainer>,
+    stack: &ItemStack,
+) -> bool {
+    let input = guard
+        .get_typed::<SimpleContainer>(ContainerId::from_arc(input_container))
+        .expect("smithing input is registered");
+    (REGISTRY.recipes.smithing_accepts_template(stack) && input.get_item(0).is_empty())
+        || (REGISTRY.recipes.smithing_accepts_base(stack) && input.get_item(1).is_empty())
+        || (REGISTRY.recipes.smithing_accepts_addition(stack) && input.get_item(2).is_empty())
+}
+
+struct SmithingHandler {
+    input_container: Shared<SimpleContainer>,
+    result_container: Shared<ResultContainer>,
+    block_pos: BlockPos,
+    world: Arc<World>,
+}
+
+impl ResultHandler for SmithingHandler {
+    fn result_container(&self) -> ContainerRef {
+        ContainerRef::from(self.result_container.clone())
+    }
+
+    fn dependencies(&self) -> Vec<ContainerRef> {
+        vec![ContainerRef::from(self.input_container.clone())]
+    }
+
+    fn update_result(&self, _guard: &mut ContainerLockGuard) {}
+
+    fn on_result_taken(
+        &self,
+        guard: &mut ContainerLockGuard,
+        _player: &Player,
+    ) -> Option<ItemStack> {
+        let input = guard
+            .get_typed_mut::<SimpleContainer>(ContainerId::from_arc(&self.input_container))
+            .expect("smithing input is registered");
+        for slot in 0..3 {
+            let stack = input.get_item_mut(slot);
+            if !stack.is_empty() {
+                stack.shrink(1);
+            }
+        }
+        self.world.level_event(
+            level_events::SOUND_SMITHING_TABLE_USED,
+            self.block_pos,
+            0,
+            None,
+        );
+        None
+    }
+
+    fn is_result_valid(&self, guard: &ContainerLockGuard, _player: &Player) -> bool {
+        !guard
+            .get_typed::<ResultContainer>(ContainerId::from_arc(&self.result_container))
+            .expect("smithing result is registered")
+            .get_item(0)
+            .is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::{SmithingKind, smithing};
+    use crate::{
+        behavior::init_behaviors,
+        entity::Entity as _,
+        inventory::{
+            click::{Click, MouseButton},
+            container::Container as _,
+        },
+        test_support::{TestPlayerBuilder, fresh_test_world, insert_ready_full_chunk},
+    };
+    use glam::DVec3;
+    use steel_registry::{
+        init_vanilla_registry, item_stack::ItemStack, vanilla_blocks, vanilla_items,
+    };
+    use steel_utils::types::UpdateFlags;
+    use steel_utils::{BlockPos, ChunkPos, Downcast as _};
+
+    #[test]
+    fn netherite_upgrade_converts_diamond_chestplate() {
+        init_vanilla_registry();
+        init_behaviors();
+        let world = fresh_test_world("smithing_netherite");
+        let pos = BlockPos::new(0, 64, 0);
+        insert_ready_full_chunk(&world, ChunkPos::from_block_pos(pos));
+        assert!(world.set_block(
+            pos,
+            vanilla_blocks::SMITHING_TABLE.default_state(),
+            UpdateFlags::UPDATE_ALL,
+        ));
+        let player = TestPlayerBuilder::new(Arc::clone(&world), "Smith", 1).build();
+        player.base().set_position_local(DVec3::new(0.5, 64.0, 0.5));
+        let mut menu = smithing(Arc::clone(&player.inventory), 1, pos, &world);
+
+        *menu.behavior_mut().carried_mut() =
+            ItemStack::new(&vanilla_items::NETHERITE_UPGRADE_SMITHING_TEMPLATE);
+        menu.clicked(
+            Click::Pickup {
+                slot: 0,
+                button: MouseButton::Left,
+            },
+            &player,
+        );
+        *menu.behavior_mut().carried_mut() = ItemStack::new(&vanilla_items::DIAMOND_CHESTPLATE);
+        menu.clicked(
+            Click::Pickup {
+                slot: 1,
+                button: MouseButton::Left,
+            },
+            &player,
+        );
+        *menu.behavior_mut().carried_mut() = ItemStack::new(&vanilla_items::NETHERITE_INGOT);
+        menu.clicked(
+            Click::Pickup {
+                slot: 2,
+                button: MouseButton::Left,
+            },
+            &player,
+        );
+
+        let kind = menu.kind().downcast_ref::<SmithingKind>().unwrap();
+        let result = kind.result_container.lock().get_item(0).clone();
+        assert!(result.is(&vanilla_items::NETHERITE_CHESTPLATE));
+    }
+}

--- a/steel-core/src/server/mod.rs
+++ b/steel-core/src/server/mod.rs
@@ -87,7 +87,7 @@ use steel_crypto::{key_store::KeyStore, signature::ProfileKeyValidator};
 use steel_protocol::packet_traits::{ClientPacket, EncodedPacket};
 use steel_protocol::packets::game::{
     CCommandSuggestions, CEntityEvent, CLogin, CPlayerInfoUpdate, CRemovePlayerInfo,
-    CSetDefaultSpawnPosition, CSystemChat, CTabList, CTickingState, CTickingStep,
+    CSetDefaultSpawnPosition, CSystemChat, CTabList, CTickingState, CTickingStep, CUpdateRecipes,
     CommonPlayerSpawnInfo, RelativeMovement,
 };
 use steel_protocol::utils::ConnectionProtocol;

--- a/steel-core/src/server/player_lifecycle.rs
+++ b/steel-core/src/server/player_lifecycle.rs
@@ -3,12 +3,12 @@ use std::ptr;
 use crate::player::connection::NetworkConnection;
 
 use super::{
-    Arc, CLogin, CSetDefaultSpawnPosition, CommonPlayerSpawnInfo, DVec3, DomainPlayerData,
-    DomainPlayerState, DomainResidenceToken, EnderPearlRestoreJob, Entity, IMMEDIATE_RESPAWN,
-    Identifier, LIMITED_CRAFTING, PersistentEnderPearl, PersistentRootVehicle, Player,
-    PreparedSpawn, REDUCED_DEBUG_INFO, RegistryEntry, RespawnData, RootVehicleRestoreJob, Server,
-    UnpreparedDomainPlayerData, UnpreparedDomainPlayerState, Uuid, World, apply_default_spawn,
-    local_respawn_data_for_world,
+    Arc, CLogin, CSetDefaultSpawnPosition, CUpdateRecipes, CommonPlayerSpawnInfo, DVec3,
+    DomainPlayerData, DomainPlayerState, DomainResidenceToken, EnderPearlRestoreJob, Entity,
+    IMMEDIATE_RESPAWN, Identifier, LIMITED_CRAFTING, PersistentEnderPearl, PersistentRootVehicle,
+    Player, PreparedSpawn, REDUCED_DEBUG_INFO, RegistryEntry, RespawnData, RootVehicleRestoreJob,
+    Server, UnpreparedDomainPlayerData, UnpreparedDomainPlayerState, Uuid, World,
+    apply_default_spawn, local_respawn_data_for_world,
 };
 
 pub(super) struct PreparedDomainRestores {
@@ -417,6 +417,7 @@ impl Server {
             online_mode: self.config.online_mode,
             enforces_secure_chat: self.enforces_secure_chat(),
         });
+        player.send_packet(CUpdateRecipes::from_registry());
     }
 
     /// Gets all the players on the server

--- a/steel-protocol/src/packets/game/c_update_recipes.rs
+++ b/steel-protocol/src/packets/game/c_update_recipes.rs
@@ -1,0 +1,77 @@
+//! Clientbound recipe sync (`ClientboundUpdateRecipesPacket`).
+
+use std::io::{Result, Write};
+
+use steel_macros::ClientPacket;
+use steel_registry::RegistryEntry;
+use steel_registry::items::ItemRef;
+use steel_registry::packets::play::C_UPDATE_RECIPES;
+use steel_utils::Identifier;
+use steel_utils::codec::VarInt;
+use steel_utils::serial::WriteTo;
+
+const SMITHING_BASE: Identifier = Identifier::vanilla_static("smithing_base");
+const SMITHING_TEMPLATE: Identifier = Identifier::vanilla_static("smithing_template");
+const SMITHING_ADDITION: Identifier = Identifier::vanilla_static("smithing_addition");
+const FURNACE_INPUT: Identifier = Identifier::vanilla_static("furnace_input");
+const BLAST_FURNACE_INPUT: Identifier = Identifier::vanilla_static("blast_furnace_input");
+const SMOKER_INPUT: Identifier = Identifier::vanilla_static("smoker_input");
+const CAMPFIRE_INPUT: Identifier = Identifier::vanilla_static("campfire_input");
+
+/// Recipe property sets and selectable recipe lists sent after login.
+#[derive(ClientPacket, Clone, Debug)]
+#[packet_id(Play = C_UPDATE_RECIPES)]
+pub struct CUpdateRecipes {
+    smithing_template: Vec<ItemRef>,
+    smithing_base: Vec<ItemRef>,
+    smithing_addition: Vec<ItemRef>,
+    furnace_input: Vec<ItemRef>,
+}
+
+impl CUpdateRecipes {
+    /// Syncs smithing and furnace property sets. Stonecutter recipes are empty
+    /// until that menu exists.
+    #[must_use]
+    pub fn from_registry() -> Self {
+        Self {
+            smithing_template: steel_registry::REGISTRY.recipes.smithing_template_items(),
+            smithing_base: steel_registry::REGISTRY.recipes.smithing_base_items(),
+            smithing_addition: steel_registry::REGISTRY.recipes.smithing_addition_items(),
+            furnace_input: steel_registry::REGISTRY.recipes.furnace_input_items(),
+        }
+    }
+}
+
+impl WriteTo for CUpdateRecipes {
+    fn write(&self, writer: &mut impl Write) -> Result<()> {
+        VarInt(7).write(writer)?;
+        write_property_set(writer, &SMITHING_TEMPLATE, &self.smithing_template)?;
+        write_property_set(writer, &SMITHING_BASE, &self.smithing_base)?;
+        write_property_set(writer, &SMITHING_ADDITION, &self.smithing_addition)?;
+        write_property_set(writer, &FURNACE_INPUT, &self.furnace_input)?;
+        write_property_set(writer, &BLAST_FURNACE_INPUT, &[])?;
+        write_property_set(writer, &SMOKER_INPUT, &[])?;
+        write_property_set(writer, &CAMPFIRE_INPUT, &[])?;
+        VarInt(0).write(writer)?;
+        Ok(())
+    }
+}
+
+fn write_property_set(writer: &mut impl Write, key: &Identifier, items: &[ItemRef]) -> Result<()> {
+    key.write(writer)?;
+    let count = i32::try_from(items.len())
+        .map_err(|_| std::io::Error::other("recipe property set exceeds protocol range"))?;
+    VarInt(count).write(writer)?;
+    for item in items {
+        let id = item.try_id().ok_or_else(|| {
+            std::io::Error::other(format!(
+                "unregistered item in recipe property set: {}",
+                item.key
+            ))
+        })?;
+        let id = i32::try_from(id)
+            .map_err(|_| std::io::Error::other(format!("item id out of protocol range: {id}")))?;
+        VarInt(id).write(writer)?;
+    }
+    Ok(())
+}

--- a/steel-protocol/src/packets/game/mod.rs
+++ b/steel-protocol/src/packets/game/mod.rs
@@ -59,6 +59,7 @@ mod c_ticking_state;
 mod c_ticking_step;
 mod c_update_attributes;
 mod c_update_mob_effect;
+mod c_update_recipes;
 mod chat;
 mod chunk;
 mod s_accept_teleportation;
@@ -164,6 +165,7 @@ pub use c_update_attributes::{
     AttributeModifierData, AttributeModifierOperation, AttributeSnapshot, CUpdateAttributes,
 };
 pub use c_update_mob_effect::{CUpdateMobEffect, MobEffectPacketFlags};
+pub use c_update_recipes::CUpdateRecipes;
 pub use chat::{
     ArgumentSignature, CDisguisedChat, CPlayerChat, CSystemChat, ChatTypeBound, FilterType,
     LastSeenMessagesUpdate, PreviousMessage, ProtocolRemoteChatSessionData, SChat, SChatAck,

--- a/steel-registry/build/recipes.rs
+++ b/steel-registry/build/recipes.rs
@@ -32,7 +32,7 @@ struct RecipeJson {
     #[serde(default)]
     key: Option<serde_json::Map<String, Value>>,
     #[serde(default)]
-    pattern: Option<Vec<String>>,
+    pattern: Option<Value>,
     // Shapeless recipe fields
     #[serde(default)]
     ingredients: Option<Vec<Value>>,
@@ -48,6 +48,12 @@ struct RecipeJson {
     result: Option<RecipeResult>,
     #[serde(default)]
     show_notification: Option<bool>,
+    #[serde(default)]
+    template: Option<Value>,
+    #[serde(default)]
+    base: Option<Value>,
+    #[serde(default)]
+    addition: Option<Value>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -140,9 +146,38 @@ struct SmeltingRecipeData {
     cooking_time: i32,
 }
 
+struct SmithingTransformData {
+    name: String,
+    ident: Ident,
+    template: Option<ParsedIngredient>,
+    base: ParsedIngredient,
+    addition: Option<ParsedIngredient>,
+    result_item_ident: Ident,
+    result_count: i32,
+}
+
+struct SmithingTrimData {
+    name: String,
+    ident: Ident,
+    template: ParsedIngredient,
+    base: ParsedIngredient,
+    addition: ParsedIngredient,
+    pattern: String,
+}
+
 /// Parses a shaped recipe from JSON.
 fn parse_shaped_recipe(recipe_name: &str, recipe: &RecipeJson) -> Option<ShapedRecipeData> {
-    let pattern = recipe.pattern.as_ref()?;
+    let pattern: Vec<String> = recipe
+        .pattern
+        .as_ref()?
+        .as_array()?
+        .iter()
+        .filter_map(|row| row.as_str().map(str::to_string))
+        .collect();
+    if pattern.is_empty() {
+        return None;
+    }
+    let pattern = &pattern;
     let key = recipe.key.as_ref()?;
     let result = recipe.result.as_ref()?;
 
@@ -282,6 +317,50 @@ fn parse_smelting_recipe(recipe_name: &str, recipe: &RecipeJson) -> Option<Smelt
     })
 }
 
+fn parse_optional_ingredient(value: Option<&Value>) -> Option<ParsedIngredient> {
+    value.map(parse_ingredient)
+}
+
+fn parse_smithing_transform(
+    recipe_name: &str,
+    recipe: &RecipeJson,
+) -> Option<SmithingTransformData> {
+    let base = recipe.base.as_ref()?;
+    let result = recipe.result.as_ref()?;
+    let result_item_id = result.id.strip_prefix("minecraft:").unwrap_or(&result.id);
+    let result_item_ident = Ident::new(&result_item_id.to_shouty_snake_case(), Span::call_site());
+    let snake_name = recipe_name.to_snake_case();
+    Some(SmithingTransformData {
+        name: recipe_name.to_string(),
+        ident: Ident::new(&snake_name, Span::call_site()),
+        template: parse_optional_ingredient(recipe.template.as_ref()),
+        base: parse_ingredient(base),
+        addition: parse_optional_ingredient(recipe.addition.as_ref()),
+        result_item_ident,
+        result_count: result.count,
+    })
+}
+
+fn parse_smithing_trim(recipe_name: &str, recipe: &RecipeJson) -> Option<SmithingTrimData> {
+    let template = recipe.template.as_ref()?;
+    let base = recipe.base.as_ref()?;
+    let addition = recipe.addition.as_ref()?;
+    let pattern = recipe.pattern.as_ref()?.as_str()?;
+    let pattern = pattern
+        .strip_prefix("minecraft:")
+        .unwrap_or(pattern)
+        .to_string();
+    let snake_name = recipe_name.to_snake_case();
+    Some(SmithingTrimData {
+        name: recipe_name.to_string(),
+        ident: Ident::new(&snake_name, Span::call_site()),
+        template: parse_ingredient(template),
+        base: parse_ingredient(base),
+        addition: parse_ingredient(addition),
+        pattern,
+    })
+}
+
 /// Generates a `TokenStream` for an ingredient.
 /// For Choice ingredients, uses `Box::leak` to create a static slice.
 fn generate_ingredient_tokens(ingredient: &ParsedIngredient) -> TokenStream {
@@ -317,6 +396,8 @@ pub(crate) fn build() -> TokenStream {
     let mut shaped_recipes: Vec<ShapedRecipeData> = Vec::new();
     let mut shapeless_recipes: Vec<ShapelessRecipeData> = Vec::new();
     let mut smelting_recipes: Vec<SmeltingRecipeData> = Vec::new();
+    let mut smithing_transform_recipes: Vec<SmithingTransformData> = Vec::new();
+    let mut smithing_trim_recipes: Vec<SmithingTrimData> = Vec::new();
 
     // Read all recipe files
     fn read_recipes(
@@ -324,13 +405,22 @@ pub(crate) fn build() -> TokenStream {
         shaped: &mut Vec<ShapedRecipeData>,
         shapeless: &mut Vec<ShapelessRecipeData>,
         smelting: &mut Vec<SmeltingRecipeData>,
+        smithing_transform: &mut Vec<SmithingTransformData>,
+        smithing_trim: &mut Vec<SmithingTrimData>,
     ) {
         for entry in fs::read_dir(dir).unwrap() {
             let entry = entry.unwrap();
             let path = entry.path();
 
             if path.is_dir() {
-                read_recipes(&path, shaped, shapeless, smelting);
+                read_recipes(
+                    &path,
+                    shaped,
+                    shapeless,
+                    smelting,
+                    smithing_transform,
+                    smithing_trim,
+                );
             } else if path.extension().and_then(|s| s.to_str()) == Some("json") {
                 let recipe_name = path
                     .file_stem()
@@ -363,7 +453,16 @@ pub(crate) fn build() -> TokenStream {
                             smelting.push(r);
                         }
                     }
-                    // Skip other recipe types for now (stonecutting, smithing, etc.)
+                    "minecraft:smithing_transform" => {
+                        if let Some(r) = parse_smithing_transform(recipe_name, &recipe) {
+                            smithing_transform.push(r);
+                        }
+                    }
+                    "minecraft:smithing_trim" => {
+                        if let Some(r) = parse_smithing_trim(recipe_name, &recipe) {
+                            smithing_trim.push(r);
+                        }
+                    }
                     _ => {}
                 }
             }
@@ -375,6 +474,8 @@ pub(crate) fn build() -> TokenStream {
         &mut shaped_recipes,
         &mut shapeless_recipes,
         &mut smelting_recipes,
+        &mut smithing_transform_recipes,
+        &mut smithing_trim_recipes,
     );
 
     // Generate individual creator functions for each shaped recipe.
@@ -571,11 +672,134 @@ pub(crate) fn build() -> TokenStream {
         })
         .collect();
 
+    let optional_ingredient = |ingredient: &Option<ParsedIngredient>| match ingredient {
+        None | Some(ParsedIngredient::Empty) => quote! { None },
+        Some(ingredient) => {
+            let tokens = generate_ingredient_tokens(ingredient);
+            quote! { Some(#tokens) }
+        }
+    };
+
+    let smithing_transform_creator_fns: Vec<TokenStream> = smithing_transform_recipes
+        .iter()
+        .map(|r| {
+            let fn_ident = Ident::new(
+                &format!("create_smithing_transform_{}", r.ident),
+                Span::call_site(),
+            );
+            let name = &r.name;
+            let template = optional_ingredient(&r.template);
+            let base = generate_ingredient_tokens(&r.base);
+            let addition = optional_ingredient(&r.addition);
+            let result_item_ident = &r.result_item_ident;
+            let result_count = r.result_count;
+            quote! {
+                #[inline(never)]
+                fn #fn_ident() -> SmithingTransformRecipe {
+                    SmithingTransformRecipe {
+                        id: Identifier::vanilla_static(#name),
+                        template: #template,
+                        base: #base,
+                        addition: #addition,
+                        result: RecipeResult {
+                            item: &*vanilla_items::#result_item_ident,
+                            count: #result_count,
+                        },
+                    }
+                }
+            }
+        })
+        .collect();
+
+    let smithing_trim_creator_fns: Vec<TokenStream> = smithing_trim_recipes
+        .iter()
+        .map(|r| {
+            let fn_ident = Ident::new(
+                &format!("create_smithing_trim_{}", r.ident),
+                Span::call_site(),
+            );
+            let name = &r.name;
+            let template = generate_ingredient_tokens(&r.template);
+            let base = generate_ingredient_tokens(&r.base);
+            let addition = generate_ingredient_tokens(&r.addition);
+            let pattern = &r.pattern;
+            quote! {
+                #[inline(never)]
+                fn #fn_ident() -> SmithingTrimRecipe {
+                    SmithingTrimRecipe {
+                        id: Identifier::vanilla_static(#name),
+                        template: #template,
+                        base: #base,
+                        addition: #addition,
+                        pattern: Identifier::vanilla_static(#pattern),
+                    }
+                }
+            }
+        })
+        .collect();
+
+    let smithing_transform_fields: Vec<TokenStream> = smithing_transform_recipes
+        .iter()
+        .map(|r| {
+            let ident = &r.ident;
+            quote! { pub #ident: SmithingTransformRecipe, }
+        })
+        .collect();
+
+    let smithing_trim_fields: Vec<TokenStream> = smithing_trim_recipes
+        .iter()
+        .map(|r| {
+            let ident = &r.ident;
+            quote! { pub #ident: SmithingTrimRecipe, }
+        })
+        .collect();
+
+    let smithing_transform_field_inits: Vec<TokenStream> = smithing_transform_recipes
+        .iter()
+        .map(|r| {
+            let ident = &r.ident;
+            let fn_ident = Ident::new(
+                &format!("create_smithing_transform_{}", r.ident),
+                Span::call_site(),
+            );
+            quote! { #ident: #fn_ident(), }
+        })
+        .collect();
+
+    let smithing_trim_field_inits: Vec<TokenStream> = smithing_trim_recipes
+        .iter()
+        .map(|r| {
+            let ident = &r.ident;
+            let fn_ident = Ident::new(
+                &format!("create_smithing_trim_{}", r.ident),
+                Span::call_site(),
+            );
+            quote! { #ident: #fn_ident(), }
+        })
+        .collect();
+
+    let smithing_transform_registers: Vec<TokenStream> = smithing_transform_recipes
+        .iter()
+        .map(|r| {
+            let ident = &r.ident;
+            quote! { registry.register_smithing_transform(&RECIPES.smithing_transform.#ident); }
+        })
+        .collect();
+
+    let smithing_trim_registers: Vec<TokenStream> = smithing_trim_recipes
+        .iter()
+        .map(|r| {
+            let ident = &r.ident;
+            quote! { registry.register_smithing_trim(&RECIPES.smithing_trim.#ident); }
+        })
+        .collect();
+
     quote! {
         use crate::{
             recipe::{
                 CraftingCategory, Ingredient, RecipeRegistry, RecipeResult,
                 ShapedRecipe, ShapelessRecipe, SmeltingRecipe,
+                SmithingTransformRecipe, SmithingTrimRecipe,
             },
             vanilla_items,
         };
@@ -601,10 +825,20 @@ pub(crate) fn build() -> TokenStream {
             #(#smelting_fields)*
         }
 
+        pub struct SmithingTransformRecipes {
+            #(#smithing_transform_fields)*
+        }
+
+        pub struct SmithingTrimRecipes {
+            #(#smithing_trim_fields)*
+        }
+
         pub struct Recipes {
             pub shaped: ShapedRecipes,
             pub shapeless: ShapelessRecipes,
             pub smelting: SmeltingRecipes,
+            pub smithing_transform: SmithingTransformRecipes,
+            pub smithing_trim: SmithingTrimRecipes,
         }
 
         // Individual recipe creator functions.
@@ -621,6 +855,8 @@ pub(crate) fn build() -> TokenStream {
         #(#shaped_creator_fns)*
         #(#shapeless_creator_fns)*
         #(#smelting_creator_fns)*
+        #(#smithing_transform_creator_fns)*
+        #(#smithing_trim_creator_fns)*
 
         impl Recipes {
             fn init() -> Self {
@@ -634,6 +870,12 @@ pub(crate) fn build() -> TokenStream {
                     smelting: SmeltingRecipes {
                         #(#smelting_field_inits)*
                     },
+                    smithing_transform: SmithingTransformRecipes {
+                        #(#smithing_transform_field_inits)*
+                    },
+                    smithing_trim: SmithingTrimRecipes {
+                        #(#smithing_trim_field_inits)*
+                    },
                 }
             }
         }
@@ -645,6 +887,8 @@ pub(crate) fn build() -> TokenStream {
             #(#shaped_registers)*
             #(#shapeless_registers)*
             #(#smelting_registers)*
+            #(#smithing_transform_registers)*
+            #(#smithing_trim_registers)*
         }
     }
 }

--- a/steel-registry/src/recipe/mod.rs
+++ b/steel-registry/src/recipe/mod.rs
@@ -7,6 +7,7 @@ mod cooking;
 mod crafting;
 mod ingredient;
 mod registry;
+mod smithing;
 
 pub use cooking::SmeltingRecipe;
 pub use crafting::{
@@ -15,3 +16,4 @@ pub use crafting::{
 };
 pub use ingredient::Ingredient;
 pub use registry::RecipeRegistry;
+pub use smithing::{SmithingRecipe, SmithingTransformRecipe, SmithingTrimRecipe};

--- a/steel-registry/src/recipe/registry.rs
+++ b/steel-registry/src/recipe/registry.rs
@@ -5,7 +5,10 @@ use steel_utils::Identifier;
 
 use super::cooking::SmeltingRecipe;
 use super::crafting::{CraftingInput, CraftingRecipe, ShapedRecipe, ShapelessRecipe};
+use super::ingredient::Ingredient;
+use super::smithing::{SmithingRecipe, SmithingTransformRecipe, SmithingTrimRecipe};
 use crate::item_stack::ItemStack;
+use crate::items::ItemRef;
 
 /// Registry for all recipes.
 pub struct RecipeRegistry {
@@ -19,6 +22,8 @@ pub struct RecipeRegistry {
     shapeless_recipes: Vec<&'static ShapelessRecipe>,
     /// All furnace smelting recipes.
     smelting_recipes: Vec<&'static SmeltingRecipe>,
+    /// All smithing recipes, in registration order.
+    smithing_recipes: Vec<SmithingRecipe>,
     /// Whether registration is still allowed.
     allows_registering: bool,
 }
@@ -39,6 +44,7 @@ impl RecipeRegistry {
             shaped_recipes: Vec::new(),
             shapeless_recipes: Vec::new(),
             smelting_recipes: Vec::new(),
+            smithing_recipes: Vec::new(),
             allows_registering: true,
         }
     }
@@ -76,6 +82,25 @@ impl RecipeRegistry {
             "Cannot register recipes after the registry has been frozen"
         );
         self.smelting_recipes.push(recipe);
+    }
+
+    /// Registers a smithing transform recipe.
+    pub fn register_smithing_transform(&mut self, recipe: &'static SmithingTransformRecipe) {
+        assert!(
+            self.allows_registering,
+            "Cannot register recipes after the registry has been frozen"
+        );
+        self.smithing_recipes
+            .push(SmithingRecipe::Transform(recipe));
+    }
+
+    /// Registers a smithing trim recipe.
+    pub fn register_smithing_trim(&mut self, recipe: &'static SmithingTrimRecipe) {
+        assert!(
+            self.allows_registering,
+            "Cannot register recipes after the registry has been frozen"
+        );
+        self.smithing_recipes.push(SmithingRecipe::Trim(recipe));
     }
 
     /// Finds a matching crafting recipe for the given positioned input.
@@ -177,6 +202,100 @@ impl RecipeRegistry {
     pub fn iter_smelting(&self) -> impl Iterator<Item = &'static SmeltingRecipe> + '_ {
         self.smelting_recipes.iter().copied()
     }
+
+    /// Finds the first matching smithing recipe for the three input slots.
+    #[must_use]
+    pub fn find_smithing_recipe(
+        &self,
+        template: &ItemStack,
+        base: &ItemStack,
+        addition: &ItemStack,
+    ) -> Option<SmithingRecipe> {
+        self.smithing_recipes
+            .iter()
+            .copied()
+            .find(|recipe| recipe.matches(template, base, addition))
+    }
+
+    /// Whether `stack` is a valid smithing template input.
+    #[must_use]
+    pub fn smithing_accepts_template(&self, stack: &ItemStack) -> bool {
+        self.smithing_recipes.iter().any(|recipe| {
+            recipe
+                .template_ingredient()
+                .is_some_and(|ingredient| ingredient.test(stack))
+        })
+    }
+
+    /// Whether `stack` is a valid smithing base input.
+    #[must_use]
+    pub fn smithing_accepts_base(&self, stack: &ItemStack) -> bool {
+        self.smithing_recipes
+            .iter()
+            .any(|recipe| recipe.base_ingredient().test(stack))
+    }
+
+    /// Whether `stack` is a valid smithing addition input.
+    #[must_use]
+    pub fn smithing_accepts_addition(&self, stack: &ItemStack) -> bool {
+        self.smithing_recipes.iter().any(|recipe| {
+            recipe
+                .addition_ingredient()
+                .is_some_and(|ingredient| ingredient.test(stack))
+        })
+    }
+
+    /// Items accepted by smithing template slots, for `RecipePropertySet`.
+    #[must_use]
+    pub fn smithing_template_items(&self) -> Vec<ItemRef> {
+        collect_ingredient_items(
+            self.smithing_recipes
+                .iter()
+                .filter_map(|recipe| recipe.template_ingredient()),
+        )
+    }
+
+    /// Items accepted by smithing base slots, for `RecipePropertySet`.
+    #[must_use]
+    pub fn smithing_base_items(&self) -> Vec<ItemRef> {
+        collect_ingredient_items(
+            self.smithing_recipes
+                .iter()
+                .map(|recipe| recipe.base_ingredient()),
+        )
+    }
+
+    /// Items accepted by smithing addition slots, for `RecipePropertySet`.
+    #[must_use]
+    pub fn smithing_addition_items(&self) -> Vec<ItemRef> {
+        collect_ingredient_items(
+            self.smithing_recipes
+                .iter()
+                .filter_map(|recipe| recipe.addition_ingredient()),
+        )
+    }
+
+    /// Items accepted as furnace inputs, for `RecipePropertySet`.
+    #[must_use]
+    pub fn furnace_input_items(&self) -> Vec<ItemRef> {
+        collect_ingredient_items(
+            self.smelting_recipes
+                .iter()
+                .map(|recipe| &recipe.ingredient),
+        )
+    }
+}
+
+fn collect_ingredient_items<'a>(ingredients: impl Iterator<Item = &'a Ingredient>) -> Vec<ItemRef> {
+    let mut items = Vec::new();
+    for ingredient in ingredients {
+        for item in ingredient.get_items() {
+            if !items.contains(&item) {
+                items.push(item);
+            }
+        }
+    }
+    items
 }
 
 impl crate::RegistryExt for RecipeRegistry {

--- a/steel-registry/src/recipe/smithing.rs
+++ b/steel-registry/src/recipe/smithing.rs
@@ -1,0 +1,163 @@
+//! Smithing recipes.
+
+use steel_utils::Identifier;
+
+use crate::data_components::components::ArmorTrim;
+use crate::data_components::vanilla_components::{PROVIDES_TRIM_MATERIAL, TRIM};
+use crate::item_stack::ItemStack;
+use crate::registry::RegistryHolder;
+use crate::{REGISTRY, RegistryExt};
+
+use super::{Ingredient, RecipeResult};
+
+/// Vanilla `SmithingTransformRecipe`.
+#[derive(Debug)]
+pub struct SmithingTransformRecipe {
+    /// Recipe identifier.
+    pub id: Identifier,
+    /// Optional template ingredient.
+    pub template: Option<Ingredient>,
+    /// Base item ingredient.
+    pub base: Ingredient,
+    /// Optional addition ingredient.
+    pub addition: Option<Ingredient>,
+    /// Result item.
+    pub result: RecipeResult,
+}
+
+/// Vanilla `SmithingTrimRecipe`.
+#[derive(Debug)]
+pub struct SmithingTrimRecipe {
+    /// Recipe identifier.
+    pub id: Identifier,
+    /// Template ingredient.
+    pub template: Ingredient,
+    /// Base item ingredient.
+    pub base: Ingredient,
+    /// Addition ingredient.
+    pub addition: Ingredient,
+    /// Trim pattern applied to the base item.
+    pub pattern: Identifier,
+}
+
+/// A smithing recipe of either vanilla kind.
+#[derive(Debug, Clone, Copy)]
+pub enum SmithingRecipe {
+    /// Netherite-style item upgrade.
+    Transform(&'static SmithingTransformRecipe),
+    /// Armor trim.
+    Trim(&'static SmithingTrimRecipe),
+}
+
+fn optional_ingredient_matches(ingredient: Option<&Ingredient>, stack: &ItemStack) -> bool {
+    match ingredient {
+        Some(ingredient) => ingredient.test(stack),
+        None => stack.is_empty(),
+    }
+}
+
+impl SmithingTransformRecipe {
+    /// Returns whether this recipe accepts the smithing input.
+    #[must_use]
+    pub fn matches(&self, template: &ItemStack, base: &ItemStack, addition: &ItemStack) -> bool {
+        optional_ingredient_matches(self.template.as_ref(), template)
+            && self.base.test(base)
+            && optional_ingredient_matches(self.addition.as_ref(), addition)
+    }
+
+    /// Assembles the upgraded stack, keeping the base item's components.
+    #[must_use]
+    pub fn assemble(&self, base: &ItemStack) -> ItemStack {
+        let mut stack = base.copy_with_count(self.result.count);
+        stack.set_item(&self.result.item.key);
+        stack
+    }
+}
+
+impl SmithingTrimRecipe {
+    /// Returns whether this recipe accepts the smithing input.
+    #[must_use]
+    pub fn matches(&self, template: &ItemStack, base: &ItemStack, addition: &ItemStack) -> bool {
+        self.template.test(template) && self.base.test(base) && self.addition.test(addition)
+    }
+
+    /// Applies this recipe's trim pattern to `base` using `addition`'s material.
+    #[must_use]
+    pub fn assemble(&self, base: &ItemStack, addition: &ItemStack) -> ItemStack {
+        apply_trim(base, addition, &self.pattern)
+    }
+}
+
+/// Vanilla `SmithingTrimRecipe.applyTrim`.
+#[must_use]
+pub fn apply_trim(base: &ItemStack, addition: &ItemStack, pattern_id: &Identifier) -> ItemStack {
+    let Some(provided) = addition.get(PROVIDES_TRIM_MATERIAL) else {
+        return ItemStack::empty();
+    };
+    let Some(pattern) = REGISTRY.trim_patterns.by_key(pattern_id) else {
+        return ItemStack::empty();
+    };
+    let new_trim = ArmorTrim::new(
+        provided.material().clone(),
+        RegistryHolder::reference(pattern),
+    );
+    if base.get(TRIM) == Some(&new_trim) {
+        return ItemStack::empty();
+    }
+    let mut trimmed = base.copy_with_count(1);
+    trimmed.set(TRIM, new_trim);
+    trimmed
+}
+
+impl SmithingRecipe {
+    /// Returns whether this recipe accepts the smithing input.
+    #[must_use]
+    pub fn matches(&self, template: &ItemStack, base: &ItemStack, addition: &ItemStack) -> bool {
+        match self {
+            Self::Transform(recipe) => recipe.matches(template, base, addition),
+            Self::Trim(recipe) => recipe.matches(template, base, addition),
+        }
+    }
+
+    /// Assembles the smithing result.
+    #[must_use]
+    pub fn assemble(
+        &self,
+        template: &ItemStack,
+        base: &ItemStack,
+        addition: &ItemStack,
+    ) -> ItemStack {
+        let _ = template;
+        match self {
+            Self::Transform(recipe) => recipe.assemble(base),
+            Self::Trim(recipe) => recipe.assemble(base, addition),
+        }
+    }
+
+    /// Template ingredient, if the recipe uses one.
+    #[must_use]
+    pub const fn template_ingredient(self) -> Option<&'static Ingredient> {
+        match self {
+            Self::Transform(recipe) => recipe.template.as_ref(),
+            Self::Trim(recipe) => Some(&recipe.template),
+        }
+    }
+
+    /// Base item ingredient.
+    #[must_use]
+    pub const fn base_ingredient(self) -> &'static Ingredient {
+        match self {
+            Self::Transform(recipe) => &recipe.base,
+            Self::Trim(recipe) => &recipe.base,
+        }
+    }
+
+    /// Addition ingredient, if the recipe uses one.
+    #[must_use]
+    pub const fn addition_ingredient(self) -> Option<&'static Ingredient> {
+        match self {
+            Self::Transform(recipe) => recipe.addition.as_ref(),
+            Self::Trim(recipe) => Some(&recipe.addition),
+        }
+    }
+}


### PR DESCRIPTION
<!--
PR template
-->

## Type of change

- [x] Block implementation
- [ ] Item implementation
- [ ] Command implementation
- [ ] Entity implementation
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [ ] Performance improvement
- [ ] Documentation
- [ ] Chore / tooling

## Description

Implements the smithing table. Transform and trim recipes are generated from extracted data. The client gets recipe property sets after login so the input slots filter correctly.

## How this was tested

Minecraft 26.2

- `cargo test -p steel-core --lib smithing`
- `cargo test -p steel-registry --lib recipe`

## Screenshots / logs

<!-- If applicable -->

## Checklist

- [x] Code builds w/o errors or warnings
- [x] Self-reviewed the diff
- [ ] Docs updated (if applicable)
- [x] No leftover debug code / comments

## Additional notes

`CUpdateRecipes` currently sends empty blasting/smoking/campfire property sets and an empty stonecutter list. Those menus are not in this PR.