### PR TITLE
feat: add shovel flattening sound

### DIFF
--- a/steel-core/src/behavior/items/shovel.rs
+++ b/steel-core/src/behavior/items/shovel.rs
@@ -1,11 +1,12 @@
 use steel_macros::item_behavior;
+use steel_protocol::packets::game::SoundSource;
 use steel_registry::{
     blocks::{
         Block,
         block_state_ext::BlockStateExt,
         properties::{BlockStateProperties, BoolProperty},
     },
-    level_events,
+    level_events, sound_events,
     vanilla_block_tags::BlockTag,
     vanilla_blocks, vanilla_game_events,
 };
@@ -50,7 +51,14 @@ impl ItemBehavior for ShovelItem {
             {
                 return InteractionResult::Pass;
             }
-            // TODO: Play SoundEvents.SHOVEL_FLATTEN
+            context.world.play_sound(
+                &sound_events::ITEM_SHOVEL_FLATTEN,
+                SoundSource::Players,
+                context.hit_result.block_pos,
+                1.0,
+                1.0,
+                None,
+            );
             let infinite_materials = context.player.has_infinite_materials();
             context
                 .inv

--- a/steel-core/src/behavior/items/shovel.rs
+++ b/steel-core/src/behavior/items/shovel.rs
@@ -15,6 +15,7 @@ use steel_utils::types::UpdateFlags;
 
 use crate::{
     behavior::{InteractionResult, ItemBehavior, UseOnContext},
+    entity::Entity,
     world::game_event::GameEventContext,
 };
 
@@ -51,13 +52,12 @@ impl ItemBehavior for ShovelItem {
             {
                 return InteractionResult::Pass;
             }
-            context.world.play_sound(
+            context.world.play_block_sound(
                 &sound_events::ITEM_SHOVEL_FLATTEN,
-                SoundSource::Players,
                 context.hit_result.block_pos,
                 1.0,
                 1.0,
-                None,
+                Some(context.player.id()),
             );
             let infinite_materials = context.player.has_infinite_materials();
             context

--- a/steel-core/src/behavior/items/shovel.rs
+++ b/steel-core/src/behavior/items/shovel.rs
@@ -1,5 +1,4 @@
 use steel_macros::item_behavior;
-use steel_protocol::packets::game::SoundSource;
 use steel_registry::{
     blocks::{
         Block,


### PR DESCRIPTION
<!--
PR template
-->

## Type of change

- [ ] Block implementation
- [ ] Item implementation
- [ ] Command implementation
- [ ] Entity implementation
- [x] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [ ] Performance improvement
- [ ] Chore / tooling

## Description
This adds the shovel flattening noise to the server so that other players can hear when someone flattens grass or dirt.
<!-- What this PR does, why. -->

## How this was tested
When I flatten dirt/grass with a shovel, other players in the server can hear it.
<!-- Steps to reproduce/verify. Include env (MC version, OS) if relevant. -->
<!-- For commands please provide example commands -->
<!-- Also if possible link here flint tests, this will help us to review your PR quicker -->

## Screenshots / logs

<!-- If applicable -->

## Checklist

- [X] Code builds w/o errors or warnings
- [X] Self-reviewed the diff
- [ ] Docs updated (if applicable)
- [X] No leftover debug code / comments

## Additional notes
Did I correctly check new feature, or should it have been item implementation?
<!-- Anything else reviewers should know -->
