### PR TITLE
perf(worldgen): position-batched SIMD lane selection for density corner fill

### DIFF
--- a/steel-worldgen/build/density/functions.rs
+++ b/steel-worldgen/build/density/functions.rs
@@ -1,7 +1,9 @@
 use proc_macro2::TokenStream;
+use quote::format_ident;
 use quote::quote;
 use serde::Deserialize;
 use std::collections::BTreeMap;
+use std::env;
 use std::path::Path;
 use std::string::String;
 use std::sync::Arc;
@@ -685,6 +687,7 @@ fn transpile_dimension(
     dimension: &str,
     prefix: &str,
     registry: &BTreeMap<String, DensityFunction>,
+    simd_lanes: usize,
 ) -> TokenStream {
     let settings = read_noise_settings(dimension);
     let router_entries = router_to_entries(&settings.noise_router);
@@ -696,9 +699,10 @@ fn transpile_dimension(
         prefix: prefix.to_string(),
         cell_width,
         legacy_random_source: settings.legacy_random_source,
+        simd_lanes,
     };
 
-    transpile(&input)
+    transpile(&input, simd_lanes)
 }
 
 /// Generate noise settings constants and trait impls for a dimension.
@@ -706,7 +710,7 @@ fn transpile_dimension(
     clippy::too_many_lines,
     reason = "generated noise settings include all trait glue in one quoted block"
 )]
-fn generate_noise_settings(dimension: &str, prefix: &str) -> TokenStream {
+fn generate_noise_settings(dimension: &str, prefix: &str, simd_lanes: usize) -> TokenStream {
     let mut settings = read_noise_settings(dimension);
 
     let settings_struct = Ident::new(&format!("{prefix}NoiseSettings"), Span::call_site());
@@ -815,6 +819,38 @@ fn generate_noise_settings(dimension: &str, prefix: &str) -> TokenStream {
 
     let default_block_ident = Ident::new(&default_block_upper, Span::call_site());
     let default_fluid_ident = Ident::new(&default_fluid_upper, Span::call_site());
+
+    let fill_corner_overrides: TokenStream = if simd_lanes == 8 {
+        quote! {
+            #[inline]
+            fn fill_cell_corner_densities_8x(
+                &self,
+                cache: &mut Self::ColumnCache,
+                x: i32,
+                ys: std::simd::f64x8,
+                z: i32,
+                blended_noise_values: std::simd::f64x8,
+                out: &mut [f64],
+            ) {
+                fill_cell_corner_densities_8x(self, cache, x, ys, z, blended_noise_values, out)
+            }
+        }
+    } else {
+        quote! {
+            #[inline]
+            fn fill_cell_corner_densities_4x(
+                &self,
+                cache: &mut Self::ColumnCache,
+                x: i32,
+                ys: std::simd::f64x4,
+                z: i32,
+                blended_noise_values: std::simd::f64x4,
+                out: &mut [f64],
+            ) {
+                fill_cell_corner_densities_4x(self, cache, x, ys, z, blended_noise_values, out)
+            }
+        }
+    };
 
     quote! {
         /// Noise settings for this dimension, parsed from the datapack.
@@ -988,6 +1024,10 @@ fn generate_noise_settings(dimension: &str, prefix: &str) -> TokenStream {
                 VEIN_INTERP_ENABLED
             }
 
+            fn simd_lanes() -> usize {
+                SIMD_LANES
+            }
+
             #[inline]
             fn compute_noise_column(&self, x: i32, block_ys: &[i32], z: i32, out: &mut [f64]) {
                 self.blended_noise.compute_column(x, block_ys, z, out);
@@ -998,18 +1038,7 @@ fn generate_noise_settings(dimension: &str, prefix: &str) -> TokenStream {
                 fill_cell_corner_densities(self, cache, x, y, z, blended_noise_value, out)
             }
 
-            #[inline]
-            fn fill_cell_corner_densities_4x(
-                &self,
-                cache: &mut Self::ColumnCache,
-                x: i32,
-                ys: std::simd::f64x4,
-                z: i32,
-                blended_noise_values: std::simd::f64x4,
-                out: &mut [f64],
-            ) {
-                fill_cell_corner_densities_4x(self, cache, x, ys, z, blended_noise_values, out)
-            }
+            #fill_corner_overrides
 
             #[inline]
             fn combine_interpolated(&self, cache: &mut Self::ColumnCache, interpolated: &[f64], x: i32, y: i32, z: i32) -> f64 {
@@ -1084,6 +1113,12 @@ pub(crate) struct DensityFunctionFiles {
 
 /// Generate density function code for all dimensions, split into one file per dimension.
 pub(crate) fn build() -> DensityFunctionFiles {
+    let simd_lanes: usize = env::var("STEEL_DENSITY_LANES")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .map_or(4, |l| if l == 8 { 8 } else { 4 });
+    println!("cargo:rerun-if-env-changed=STEEL_DENSITY_LANES");
+
     let registry_json = read_density_function_registry();
 
     // Convert JSON registry to DensityFunction values (shared across dimensions)
@@ -1092,34 +1127,40 @@ pub(crate) fn build() -> DensityFunctionFiles {
         .map(|(id, json)| (id.clone(), json_to_df(json)))
         .collect();
 
-    let overworld_df = transpile_dimension("overworld", "Overworld", &registry);
-    let overworld_settings = generate_noise_settings("overworld", "Overworld");
-    let nether_df = transpile_dimension("nether", "Nether", &registry);
-    let nether_settings = generate_noise_settings("nether", "Nether");
-    let end_df = transpile_dimension("end", "End", &registry);
-    let end_settings = generate_noise_settings("end", "End");
+    let overworld_df = transpile_dimension("overworld", "Overworld", &registry, simd_lanes);
+    let overworld_settings = generate_noise_settings("overworld", "Overworld", simd_lanes);
+    let nether_df = transpile_dimension("nether", "Nether", &registry, simd_lanes);
+    let nether_settings = generate_noise_settings("nether", "Nether", simd_lanes);
+    let end_df = transpile_dimension("end", "End", &registry, simd_lanes);
+    let end_settings = generate_noise_settings("end", "End", simd_lanes);
 
     // Note: the transpiler already emits `use` imports in #overworld_df / #nether_df / #end_df.
+    let lane_alias_overworld = format_ident!("f64x{}", simd_lanes);
     let overworld = quote! {
         use steel_registry::RegistryExt;
         use steel_registry::blocks::block_state_ext::BlockStateExt;
-
+        use std::simd;
+        use simd::#lane_alias_overworld as __LaneV;
         #overworld_df
         #overworld_settings
     };
 
+    let lane_alias_nether = format_ident!("f64x{}", simd_lanes);
     let nether = quote! {
         use steel_registry::RegistryExt;
         use steel_registry::blocks::block_state_ext::BlockStateExt;
-
+        use std::simd;
+        use simd::#lane_alias_nether as __LaneV;
         #nether_df
         #nether_settings
     };
 
+    let lane_alias_end = format_ident!("f64x{}", simd_lanes);
     let end = quote! {
         use steel_registry::RegistryExt;
         use steel_registry::blocks::block_state_ext::BlockStateExt;
-
+        use std::simd;
+        use simd::#lane_alias_end as __LaneV;
         #end_df
         #end_settings
     };

--- a/steel-worldgen/build/density/transpiler/codegen_expr.rs
+++ b/steel-worldgen/build/density/transpiler/codegen_expr.rs
@@ -21,7 +21,9 @@ use super::TranspilerInput;
 use super::bounds::compute_bounds;
 use super::context::TranspileContext;
 use super::fingerprint::{collect_expensive_subexprs, fingerprint, is_cse_candidate};
-use super::naming::{named_fn_field_ident, named_fn_ident, named_fn_ident_4x, noise_field_ident};
+use super::naming::{
+    named_fn_field_ident, named_fn_ident, named_fn_ident_lanes, noise_field_ident,
+};
 
 impl TranspileContext {
     #[expect(
@@ -587,8 +589,8 @@ impl TranspileContext {
         fn_name
     }
 
-    /// Generate a `TokenStream` expression that computes `df` as `f64x4`
-    /// across 4 cell-corner Y values (`ys: f64x4`).
+    /// Generate a `TokenStream` expression that computes `df` as `__LaneV`
+    /// across 4 cell-corner Y values (`ys: __LaneV`).
     ///
     /// Variants migrated to true SIMD (`Constant`, `Noise`, `BlendAlpha/Offset`,
     /// `BlendDensity`, `Marker`, `Reference`, `BlendedNoise` in fill mode) emit
@@ -608,7 +610,7 @@ impl TranspileContext {
         is_flat: bool,
     ) -> TokenStream {
         // Unified CSE (SIMD): if this node was hoisted by an enclosing scope,
-        // emit the `f64x4` variable instead of recomputing the subtree.
+        // emit the `__LaneV` variable instead of recomputing the subtree.
         if is_cse_candidate(df) {
             let fp = fingerprint(df);
             if let Some(var) = self.cse_bindings_simd.get(&fp) {
@@ -621,7 +623,7 @@ impl TranspileContext {
         // bindings and lets LLVM see the simpler form.
         if is_flat {
             let scalar = self.gen_expr(df, input, true);
-            return quote! { f64x4::splat(#scalar) };
+            return quote! { __LaneV::splat(#scalar) };
         }
 
         // Splines whose entire structure is Y-independent (e.g. driven by a
@@ -634,13 +636,13 @@ impl TranspileContext {
             && self.is_spline_y_independent(&s.spline)
         {
             let scalar = self.gen_expr(df, input, true);
-            return quote! { f64x4::splat(#scalar) };
+            return quote! { __LaneV::splat(#scalar) };
         }
 
         match df {
             DensityFunction::Constant(c) => {
                 let val = Literal::f64_unsuffixed(c.value);
-                quote! { f64x4::splat(#val) }
+                quote! { __LaneV::splat(#val) }
             }
 
             DensityFunction::Noise(n) => {
@@ -650,7 +652,7 @@ impl TranspileContext {
                     let fp = fingerprint(df);
                     if let Some((idx, _, _)) = self.inline_flat_noises.get(&fp) {
                         let cache_field = format_ident!("inline_noise_{}", idx);
-                        return quote! { f64x4::splat(cache.#cache_field) };
+                        return quote! { __LaneV::splat(cache.#cache_field) };
                     }
                 }
                 let field = noise_field_ident(&n.noise_id);
@@ -658,7 +660,7 @@ impl TranspileContext {
                 let y_scale = Literal::f64_unsuffixed(n.y_scale);
                 if n.y_scale == 0.0 {
                     quote! {
-                        f64x4::splat(noises.#field.get_value_xz(
+                        __LaneV::splat(noises.#field.get_value_xz(
                             x * #xz_scale, z * #xz_scale,
                         ))
                     }
@@ -666,15 +668,15 @@ impl TranspileContext {
                     quote! {
                         noises.#field.get_value_y_simd(
                             x * #xz_scale,
-                            ys * f64x4::splat(#y_scale),
+                            ys * __LaneV::splat(#y_scale),
                             z * #xz_scale,
                         )
                     }
                 }
             }
 
-            DensityFunction::BlendAlpha(_) => quote! { f64x4::splat(1.0) },
-            DensityFunction::BlendOffset(_) => quote! { f64x4::splat(0.0) },
+            DensityFunction::BlendAlpha(_) => quote! { __LaneV::splat(1.0) },
+            DensityFunction::BlendOffset(_) => quote! { __LaneV::splat(0.0) },
 
             DensityFunction::BlendDensity(bd) => self.gen_expr_simd(&bd.input, input, is_flat),
 
@@ -704,13 +706,13 @@ impl TranspileContext {
                     if let Some(ref_df) = input.registry.get(&r.id) {
                         self.gen_expr_simd(ref_df, input, is_flat)
                     } else {
-                        quote! { f64x4::splat(0.0) }
+                        quote! { __LaneV::splat(0.0) }
                     }
                 } else if self.flat_cached.contains(&r.id) {
                     let field = named_fn_field_ident(&r.id);
-                    quote! { f64x4::splat(cache.#field) }
+                    quote! { __LaneV::splat(cache.#field) }
                 } else {
-                    let fn_name = named_fn_ident_4x(&r.id);
+                    let fn_name = named_fn_ident_lanes(&r.id, self.simd_lanes);
                     quote! { #fn_name(noises, cache, x, ys, z) }
                 }
             }
@@ -725,13 +727,13 @@ impl TranspileContext {
                 let from_val = Literal::f64_unsuffixed(g.from_value);
                 let to_val = Literal::f64_unsuffixed(g.to_value);
                 quote! {{
-                    let __t = (ys - f64x4::splat(#from_y))
-                        / f64x4::splat(#to_y - #from_y);
-                    let __min = f64x4::splat(#from_val);
-                    let __max = f64x4::splat(#to_val);
+                    let __t = (ys - __LaneV::splat(#from_y))
+                        / __LaneV::splat(#to_y - #from_y);
+                    let __min = __LaneV::splat(#from_val);
+                    let __max = __LaneV::splat(#to_val);
                     let __lerped = __min + __t * (__max - __min);
-                    let __below = __t.simd_lt(f64x4::splat(0.0));
-                    let __above = __t.simd_gt(f64x4::splat(1.0));
+                    let __below = __t.simd_lt(__LaneV::splat(0.0));
+                    let __above = __t.simd_gt(__LaneV::splat(1.0));
                     let __r = __above.select(__max, __lerped);
                     __below.select(__min, __r)
                 }}
@@ -740,7 +742,7 @@ impl TranspileContext {
             DensityFunction::ShiftA(s) => {
                 let field = noise_field_ident(&s.noise_id);
                 quote! {
-                    f64x4::splat(noises.#field.get_value_xz(
+                    __LaneV::splat(noises.#field.get_value_xz(
                         x * 0.25, z * 0.25,
                     ) * 4.0)
                 }
@@ -749,7 +751,7 @@ impl TranspileContext {
             DensityFunction::ShiftB(s) => {
                 let field = noise_field_ident(&s.noise_id);
                 quote! {
-                    f64x4::splat(noises.#field.get_value_xy(
+                    __LaneV::splat(noises.#field.get_value_xy(
                         z * 0.25, x * 0.25,
                     ) * 4.0)
                 }
@@ -760,9 +762,9 @@ impl TranspileContext {
                 quote! {
                     noises.#field.get_value_y_simd(
                         x * 0.25,
-                        ys * f64x4::splat(0.25),
+                        ys * __LaneV::splat(0.25),
                         z * 0.25,
-                    ) * f64x4::splat(4.0)
+                    ) * __LaneV::splat(4.0)
                 }
             }
 
@@ -787,7 +789,7 @@ impl TranspileContext {
                         quote! {{
                             let dx = #dx;
                             let dz = #dz;
-                            f64x4::splat(noises.#field.get_value_xz(
+                            __LaneV::splat(noises.#field.get_value_xz(
                                 x * #xz_scale + dx,
                                 z * #xz_scale + dz,
                             ))
@@ -799,7 +801,7 @@ impl TranspileContext {
                             let dz = #dz;
                             noises.#field.get_value_y_simd(
                                 x * #xz_scale + dx,
-                                ys * f64x4::splat(#y_scale) + f64x4::splat(dy),
+                                ys * __LaneV::splat(#y_scale) + __LaneV::splat(dy),
                                 z * #xz_scale + dz,
                             )
                         }}
@@ -820,27 +822,27 @@ impl TranspileContext {
                         // Mask form: gt(0) ? v : v * 0.5
                         quote! {{
                             let __v = #v;
-                            let __mask = __v.simd_gt(f64x4::splat(0.0));
-                            __mask.select(__v, __v * f64x4::splat(0.5))
+                            let __mask = __v.simd_gt(__LaneV::splat(0.0));
+                            __mask.select(__v, __v * __LaneV::splat(0.5))
                         }}
                     }
                     MappedType::QuarterNegative => {
                         quote! {{
                             let __v = #v;
-                            let __mask = __v.simd_gt(f64x4::splat(0.0));
-                            __mask.select(__v, __v * f64x4::splat(0.25))
+                            let __mask = __v.simd_gt(__LaneV::splat(0.0));
+                            __mask.select(__v, __v * __LaneV::splat(0.25))
                         }}
                     }
-                    MappedType::Invert => quote! { f64x4::splat(1.0) / (#v) },
+                    MappedType::Invert => quote! { __LaneV::splat(1.0) / (#v) },
                     MappedType::Squeeze => {
                         // Scalar: c = clamp(v, -1, 1); c / 2 - c * c * c / 24.
                         quote! {{
                             let __v = #v;
                             let __c = __v
-                                .simd_max(f64x4::splat(-1.0))
-                                .simd_min(f64x4::splat(1.0));
-                            __c / f64x4::splat(2.0)
-                                - __c * __c * __c / f64x4::splat(24.0)
+                                .simd_max(__LaneV::splat(-1.0))
+                                .simd_min(__LaneV::splat(1.0));
+                            __c / __LaneV::splat(2.0)
+                                - __c * __c * __c / __LaneV::splat(24.0)
                         }}
                     }
                 }
@@ -855,8 +857,8 @@ impl TranspileContext {
                 // by lane for finite values (no NaN in density values).
                 quote! {
                     (#inner)
-                        .simd_max(f64x4::splat(#min))
-                        .simd_min(f64x4::splat(#max))
+                        .simd_max(__LaneV::splat(#min))
+                        .simd_min(__LaneV::splat(#max))
                 }
             }
 
@@ -889,15 +891,12 @@ impl TranspileContext {
                         ).abs()
                     }}
                 };
-                let r0 = lane(0);
-                let r1 = lane(1);
-                let r2 = lane(2);
-                let r3 = lane(3);
+                let lane_exprs: Vec<TokenStream> = (0..self.simd_lanes).map(lane).collect();
                 quote! {{
                     let __rarity_v = #input_simd;
                     let __rarity_arr = __rarity_v.to_array();
                     let __ys_arr = ys.to_array();
-                    f64x4::from_array([#r0, #r1, #r2, #r3])
+                    __LaneV::from_array([#(#lane_exprs),*])
                 }}
             }
 
@@ -934,7 +933,7 @@ impl TranspileContext {
                             let b_lo_lit = Literal::f64_unsuffixed(b_lo);
                             quote! {{
                                 let __sc_a = #a;
-                                if __sc_a.simd_le(f64x4::splat(#b_lo_lit)).all() {
+                                if __sc_a.simd_le(__LaneV::splat(#b_lo_lit)).all() {
                                     __sc_a
                                 } else {
                                     __sc_a.simd_min(#b)
@@ -952,7 +951,7 @@ impl TranspileContext {
                             let b_hi_lit = Literal::f64_unsuffixed(b_hi);
                             quote! {{
                                 let __sc_a = #a;
-                                if __sc_a.simd_ge(f64x4::splat(#b_hi_lit)).all() {
+                                if __sc_a.simd_ge(__LaneV::splat(#b_hi_lit)).all() {
                                     __sc_a
                                 } else {
                                     __sc_a.simd_max(#b)
@@ -983,7 +982,7 @@ impl TranspileContext {
                 // only on (block_x, block_z). All 4 lanes get the same value, so
                 // we evaluate scalar once and splat. This skips the 25×25
                 // simplex-noise neighborhood scan three out of four times.
-                quote! { f64x4::splat(noises.end_islands.sample(x, 0.0, z)) }
+                quote! { __LaneV::splat(noises.end_islands.sample(x, 0.0, z)) }
             }
 
             DensityFunction::RangeChoice(rc) => {
@@ -1033,8 +1032,8 @@ impl TranspileContext {
                 quote! {{
                     let __v = #input_simd;
                     #(#hoisted)*
-                    let __in_mask = __v.simd_ge(f64x4::splat(#min))
-                        & __v.simd_lt(f64x4::splat(#max));
+                    let __in_mask = __v.simd_ge(__LaneV::splat(#min))
+                        & __v.simd_lt(__LaneV::splat(#max));
                     if __in_mask.all() {
                         #in_range
                     } else if !__in_mask.any() {
@@ -1089,19 +1088,14 @@ impl TranspileContext {
             }}
         };
 
-        let r0 = lane_block(0, &scalar);
-        let r1 = lane_block(1, &scalar);
-        let r2 = lane_block(2, &scalar);
-        let r3 = lane_block(3, &scalar);
+        let lane_blocks: Vec<TokenStream> = (0..self.simd_lanes)
+            .map(|i| lane_block(i, &scalar))
+            .collect();
 
         quote! {{
             let __ys_arr = ys.to_array();
             #bv_arr_decl
-            let __r0 = #r0;
-            let __r1 = #r1;
-            let __r2 = #r2;
-            let __r3 = #r3;
-            f64x4::from_array([__r0, __r1, __r2, __r3])
+            __LaneV::from_array([#(#lane_blocks),*])
         }}
     }
 
@@ -1237,7 +1231,7 @@ impl TranspileContext {
     }
 
     /// SIMD counterpart of [`Self::hoist_common_subexprs`]. Identical
-    /// fingerprint/commonality logic, but emits `f64x4` bindings (values via
+    /// fingerprint/commonality logic, but emits `__LaneV` bindings (values via
     /// `gen_expr_simd`) into the disjoint `cse_bindings_simd` map. The scalar
     /// CSE pass was historically never ported here, so the `_4x` fill path
     /// recomputed shared cave subtrees per operand/branch.

--- a/steel-worldgen/build/density/transpiler/codegen_functions.rs
+++ b/steel-worldgen/build/density/transpiler/codegen_functions.rs
@@ -16,7 +16,7 @@ use super::TranspilerInput;
 use super::context::TranspileContext;
 use super::graph::{collect_interpolated_inners, is_flat_cached, unwrap_markers};
 use super::naming::{
-    named_fn_ident, named_fn_ident_4x, router_cache_field_ident, router_compute_fn_ident,
+    named_fn_ident, named_fn_ident_lanes, router_cache_field_ident, router_compute_fn_ident,
     sanitize_name,
 };
 
@@ -62,18 +62,21 @@ impl TranspileContext {
                 continue;
             };
             let inner = unwrap_markers(df).clone();
-            let fn_name_4x = named_fn_ident_4x(&name);
+            let fn_name_lanes = named_fn_ident_lanes(&name, self.simd_lanes);
 
             let body = self.gen_expr_simd(&inner, input, false);
 
             let params = self.fn_params_4x();
 
-            let doc = Literal::string(&format!("`{name}` (SIMD form, batches 4 Y values)"));
+            let doc = Literal::string(&format!(
+                "`{name}` (SIMD form, batches {} Y values)",
+                self.simd_lanes
+            ));
             fns_4x.push(quote! {
                 #[doc = #doc]
                 #[allow(dead_code)]
                 #[inline]
-                fn #fn_name_4x(#params) -> f64x4 {
+                fn #fn_name_lanes(#params) -> __LaneV {
                     #body
                 }
             });
@@ -206,6 +209,8 @@ impl TranspileContext {
 
         let total_count = all_inners.len();
         let total_count_lit = Literal::usize_unsuffixed(total_count);
+        let lanes_lit = Literal::usize_unsuffixed(self.simd_lanes);
+        let fill_lanes_ident = format_ident!("fill_cell_corner_densities_{}x", self.simd_lanes);
 
         // Phase 2: Generate fill_cell_corner_densities with ALL channels
         self.fill_mode = true;
@@ -229,13 +234,18 @@ impl TranspileContext {
             let idx = Literal::usize_unsuffixed(i);
             let inner = unwrap_markers(inner_df);
             let expr_simd = self.gen_expr_simd(inner, input, false);
+            // Lane indices are compile-time constants inside the generated
+            // module (SIMD_LANES), so `__r[l]` compiles to a plain extract.
+            let lane_writes: Vec<TokenStream> = (0..self.simd_lanes)
+                .map(|l| {
+                    let l_lit = Literal::usize_unsuffixed(l);
+                    quote! { out[#idx + #l_lit * INTERPOLATED_COUNT] = __r[#l_lit]; }
+                })
+                .collect();
             inner_stmts_4x.push(quote! {
                 {
                     let __r = #expr_simd;
-                    out[#idx] = __r[0];
-                    out[#idx + INTERPOLATED_COUNT] = __r[1];
-                    out[#idx + 2 * INTERPOLATED_COUNT] = __r[2];
-                    out[#idx + 3 * INTERPOLATED_COUNT] = __r[3];
+                    #(#lane_writes)*
                 }
             });
         }
@@ -291,6 +301,7 @@ impl TranspileContext {
             /// Total number of independently interpolated channels across all
             /// router entries (final_density + vein_toggle + vein_ridged).
             pub const INTERPOLATED_COUNT: usize = #total_count_lit;
+            pub const SIMD_LANES: usize = #lanes_lit;
 
             /// Whether vein functions have interpolation channels.
             pub const VEIN_INTERP_ENABLED: bool = #has_vein_interp_tok;
@@ -314,23 +325,23 @@ impl TranspileContext {
                 #(#inner_stmts)*
             }
 
-            /// SIMD form of [`fill_cell_corner_densities`] that batches 4
-            /// cell-corner Y values at fixed `(x, z)`.
+            /// SIMD form of [`fill_cell_corner_densities`] that batches
+            /// SIMD_LANES cell-corner Y values at fixed `(x, z)`.
             ///
             /// `out` layout: lane-major SoA. Lane `i`'s `INTERPOLATED_COUNT`
-            /// channels live at `out[i * INTERPOLATED_COUNT..(i + 1) * INTERPOLATED_COUNT]`.
-            /// `out` must have length `4 * INTERPOLATED_COUNT`.
+            /// channels live at
+            /// `out[i * INTERPOLATED_COUNT..(i + 1) * INTERPOLATED_COUNT]`.
             ///
-            /// Per-lane semantics are bit-identical to four scalar
+            /// Per-lane semantics are bit-identical to scalar
             /// [`fill_cell_corner_densities`] calls at the same Y values.
             #[expect(unused_variables, reason = "generated function has a fixed signature; not all dimensions use every parameter")]
-            pub fn fill_cell_corner_densities_4x(
+            pub fn #fill_lanes_ident(
                 noises: &#noises,
                 cache: &#cache,
                 x: i32,
-                ys: f64x4,
+                ys: __LaneV,
                 z: i32,
-                blended_noise_value_v: f64x4,
+                blended_noise_value_v: __LaneV,
                 out: &mut [f64],
             ) {
                 let x = cache.x as f64;

--- a/steel-worldgen/build/density/transpiler/codegen_structs.rs
+++ b/steel-worldgen/build/density/transpiler/codegen_structs.rs
@@ -559,7 +559,7 @@ impl TranspileContext {
     pub(super) fn fn_params_4x(&self) -> TokenStream {
         let noises = &self.noises_ident;
         let cache = &self.cache_ident;
-        quote! { noises: &#noises, cache: &#cache, x: f64, ys: f64x4, z: f64 }
+        quote! { noises: &#noises, cache: &#cache, x: f64, ys: __LaneV, z: f64 }
     }
 
     /// Generate the function parameter list for a router entry point.

--- a/steel-worldgen/build/density/transpiler/context.rs
+++ b/steel-worldgen/build/density/transpiler/context.rs
@@ -68,6 +68,10 @@ pub(super) struct TranspileContext {
     pub(super) cse_bindings_simd: FxHashMap<u64, Ident>,
     /// Counter for generating unique CSE variable names.
     pub(super) cse_counter: usize,
+    /// SIMD lane width the emitted `__LaneV` alias and corner-fill functions
+    /// are generated for (4 or 8). Chosen at build time via
+    /// `STEEL_DENSITY_LANES`.
+    pub(super) simd_lanes: usize,
     /// Inline `Noise` nodes with `y_scale == 0.0` found inside non-flat
     /// functions. These are Y-independent but get recomputed per Y corner;
     /// caching them in the column cache avoids ~48 redundant evaluations per
@@ -76,7 +80,7 @@ pub(super) struct TranspileContext {
 }
 
 impl TranspileContext {
-    pub(super) fn new(prefix: &str) -> Self {
+    pub(super) fn new(prefix: &str, lanes: usize) -> Self {
         Self {
             noise_ids: BTreeSet::new(),
             flat_cached: BTreeSet::new(),
@@ -98,6 +102,7 @@ impl TranspileContext {
             cse_bindings: FxHashMap::default(),
             cse_bindings_simd: FxHashMap::default(),
             cse_counter: 0,
+            simd_lanes: lanes,
             inline_flat_noises: BTreeMap::new(),
         }
     }

--- a/steel-worldgen/build/density/transpiler/mod.rs
+++ b/steel-worldgen/build/density/transpiler/mod.rs
@@ -64,6 +64,8 @@ pub struct TranspilerInput {
     ///   hardcoded params `(-7, [1.0, 1.0])` and direct `LegacyRandom(seed)`.
     /// - `BlendedNoise` uses `LegacyRandom(seed)` instead of the positional splitter.
     pub legacy_random_source: bool,
+    /// Build-time SIMD lane width for the corner-fill backend (4 or 8).
+    pub simd_lanes: usize,
 }
 
 /// Compile density function trees into a `TokenStream` of Rust code.
@@ -74,8 +76,8 @@ pub struct TranspilerInput {
 /// - Private `compute_*` functions for each named density function
 /// - Public `router_*` functions for each noise router entry point
 #[must_use]
-pub fn transpile(input: &TranspilerInput) -> TokenStream {
-    let mut ctx = context::TranspileContext::new(&input.prefix);
+pub fn transpile(input: &TranspilerInput, simd_lanes: usize) -> TokenStream {
+    let mut ctx = context::TranspileContext::new(&input.prefix, simd_lanes);
     ctx.legacy_random_source = input.legacy_random_source;
 
     // Phase 1: Analyze the graph

--- a/steel-worldgen/build/density/transpiler/naming.rs
+++ b/steel-worldgen/build/density/transpiler/naming.rs
@@ -22,6 +22,10 @@ pub(super) fn named_fn_ident_4x(name: &str) -> Ident {
     format_ident!("compute_{}_4x", sanitize_name(name))
 }
 
+pub(super) fn named_fn_ident_lanes(name: &str, lanes: usize) -> Ident {
+    format_ident!("compute_{}_{}x", sanitize_name(name), lanes)
+}
+
 pub(super) fn grid_field_ident(name: &str) -> Ident {
     format_ident!("grid_df_{}", sanitize_name(name))
 }

--- a/steel-worldgen/src/density/traits.rs
+++ b/steel-worldgen/src/density/traits.rs
@@ -5,6 +5,7 @@
 //! density functions.
 
 use std::simd::f64x4;
+use std::simd::f64x8;
 
 use crate::BlockStateId;
 use crate::random::RandomSplitter;
@@ -160,6 +161,15 @@ pub trait DimensionNoises: Sized + Send + Sync {
     /// Whether vein functions have interpolation channels.
     fn vein_interp_enabled() -> bool;
 
+    /// Lane width the dimension's transpiled SIMD corner fill is emitted for.
+    /// The driver in `NoiseChunk` batches cell-corner Y values accordingly.
+    /// Dimensions default to the 4-lane form; a build-time setting may emit
+    /// an 8-lane override instead (see `fill_cell_corner_densities_8x`).
+    #[must_use]
+    fn simd_lanes() -> usize {
+        4
+    }
+
     /// Compute blended noise for an entire column of Y values.
     ///
     /// Called by `NoiseChunk::fill_slice` before iterating over Y corners.
@@ -211,6 +221,37 @@ pub trait DimensionNoises: Sized + Send + Sync {
         let ys_arr = ys.to_array();
         let blended_arr = blended_noise_values.to_array();
         for lane in 0..4 {
+            let dst = &mut out[lane * interp_count..(lane + 1) * interp_count];
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "block Y values are integer-valued f64s in cell-corner range"
+            )]
+            let y = ys_arr[lane] as i32;
+            self.fill_cell_corner_densities(cache, x, y, z, blended_arr[lane], dst);
+        }
+    }
+
+    /// SIMD form of [`fill_cell_corner_densities`] that batches 8 cell-corner
+    /// Y values at fixed `(x, z)`. Same lane-major `SoA` `out` layout as the
+    /// 4-lane form with `out.len() == 8 * interpolated_count()`.
+    ///
+    /// Default: scalar loop. Dimensions compiled with `SIMD_DENSITY_LANES=8`
+    /// override this with the transpiled 8-lane chain.
+    ///
+    /// [`fill_cell_corner_densities`]: Self::fill_cell_corner_densities
+    fn fill_cell_corner_densities_8x(
+        &self,
+        cache: &mut Self::ColumnCache,
+        x: i32,
+        ys: f64x8,
+        z: i32,
+        blended_noise_values: f64x8,
+        out: &mut [f64],
+    ) {
+        let interp_count = Self::interpolated_count();
+        let ys_arr = ys.to_array();
+        let blended_arr = blended_noise_values.to_array();
+        for lane in 0..8 {
             let dst = &mut out[lane * interp_count..(lane + 1) * interp_count];
             #[expect(
                 clippy::cast_possible_truncation,

--- a/steel-worldgen/src/noise/noise_chunk.rs
+++ b/steel-worldgen/src/noise/noise_chunk.rs
@@ -11,6 +11,7 @@
 
 use std::marker::PhantomData;
 use std::simd::f64x4;
+use std::simd::f64x8;
 
 use steel_math::lerp;
 use steel_worldgen::density::{ColumnCache, DimensionNoises, NoiseSettings};
@@ -163,9 +164,10 @@ impl<N: DimensionNoises> NoiseChunk<N> {
 
         let mut values = [0.0f64; MAX_INTERP];
 
-        // Scratch buffer for the 4-Y SIMD batch. Lane-major SoA: lane `i`'s
-        // `interp_count` channels live at `values_4x[i * interp_count..]`.
+        // Scratch buffers for the SIMD batches. Lane-major SoA: lane `i`'s
+        // `interp_count` channels live at `values_Nx[i * interp_count..]`.
         let mut values_4x = [0.0f64; 4 * MAX_INTERP];
+        let mut values_8x = [0.0f64; 8 * MAX_INTERP];
 
         for cz in 0..=cell_count_xz {
             let cell_z = first_cell_z + cz as i32;
@@ -180,6 +182,49 @@ impl<N: DimensionNoises> NoiseChunk<N> {
             // 4-Y SIMD-batched corner fill. Tail is handled by the scalar
             // loop below for any remaining `corners_y % 4` corners.
             let mut cy = 0;
+            if N::simd_lanes() == 8 {
+                while cy + 8 <= corners_y {
+                    let ys_v = f64x8::from_array([
+                        f64::from(block_ys[cy]),
+                        f64::from(block_ys[cy + 1]),
+                        f64::from(block_ys[cy + 2]),
+                        f64::from(block_ys[cy + 3]),
+                        f64::from(block_ys[cy + 4]),
+                        f64::from(block_ys[cy + 5]),
+                        f64::from(block_ys[cy + 6]),
+                        f64::from(block_ys[cy + 7]),
+                    ]);
+                    let blended_v = f64x8::from_array([
+                        blended_column[cy],
+                        blended_column[cy + 1],
+                        blended_column[cy + 2],
+                        blended_column[cy + 3],
+                        blended_column[cy + 4],
+                        blended_column[cy + 5],
+                        blended_column[cy + 6],
+                        blended_column[cy + 7],
+                    ]);
+
+                    noises.fill_cell_corner_densities_8x(
+                        cache,
+                        block_x,
+                        ys_v,
+                        block_z,
+                        blended_v,
+                        &mut values_8x[..8 * interp_count],
+                    );
+
+                    for lane in 0..8 {
+                        let lane_cy = cy + lane;
+                        let src = &values_8x[lane * interp_count..(lane + 1) * interp_count];
+                        let corner_idx = cz * corners_y + lane_cy;
+                        let base = corner_idx * MAX_INTERP;
+                        slice[base..base + interp_count].copy_from_slice(src);
+                    }
+
+                    cy += 8;
+                }
+            }
             while cy + 4 <= corners_y {
                 let ys_v = f64x4::from_array([
                     f64::from(block_ys[cy]),


### PR DESCRIPTION
# NEED HELP WITH THIS ONE IF YOU HAVE AN AVX-512 CAPABLE CPU
## Type of change

- [x] Performance improvement

## Description

The transpiled density-function corner-fill backend was hardcoded to 4-lane
`f64x4`. This PR makes the lane width a **build-time setting**
(`STEEL_DENSITY_LANES`, default `4`) so the transpiler can emit 8-lane
(`f64x8`) corner evaluation where the target CPU favours it:

- `codegen_expr` emits a `__LaneV` alias instead of literal `f64x4`; all node
  forms (splat, select, `from_array`, scalar-fallback lanes, rarity mapper)
  become width-agnostic.
- Named `compute_*` helpers get width-suffixed idents; the dimension impl
  overrides `fill_cell_corner_densities_8x` or `_4x` to match the setting and
  exposes `simd_lanes()`.
- `NoiseChunk::fill_slice_into` dispatches on `simd_lanes()` and batches
  cell-corner Y values accordingly (8-lane path halves per-column call count).

**Status: draft.** Bit-parity is proven for both widths, but on the test
machine (Lunar Lake, 4P+4E) the measured throughput is flat-to-slightly-negative
at 8 lanes — see the benchmark table below. Opening as draft so CI/maintainers
can evaluate on wider CPUs (AVX-512) and advise whether to keep the
infrastructure with default 4, tune per-target, or drop it.

## How this was tested

### Bit-parity (both widths)
Full-chunk block checksums after `create_biomes` + `fill_from_noise` are
**identical to master** at `STEEL_DENSITY_LANES=4` and `=8`:

| Seed | Checksum |
|---|---|
| `0x0` | `0x9cdaed00b4c40375` |
| `0x5eed1234abcd` | `0xcda05a50b795f863` |

### Test suite
```bash
cargo test --workspace          # all green at STEEL_DENSITY_LANES=4
cargo fmt --all --check
cargo clippy --workspace --all-targets --all-features   # 0 warnings
```

### Benchmark reproduction (pinned seed, 4,225 chunks, interleaved runs)
```bash
cargo build --profile profiling                      # LANES=4 default
STEEL_DENSITY_LANES=8 cargo build --profile profiling
env PREGEN_SIZE=65 target/profiling/steel
```

## Screenshots / logs

Median chunks/s over 5 interleaved runs per variant (Lunar Lake 4P+4E):

| Variant | Median cps | Δ vs master |
|---|---|---|
| `master` | 444.8 | baseline |
| This PR, `LANES=4` | 445.4 | +0.1% (noise) |
| This PR, `LANES=8` | 441.5 | -0.7% |

## Checklist

- [x] Code builds w/o errors or warnings
- [x] Self-reviewed the diff
- [x] Docs updated (if applicable)
- [x] No leftover debug code / comments

## Additional notes

- The 8-lane regression is consistent with register-pressure spills in deep
  tree nodes on 256-bit targets; AVX-512 hosts may flip the result, which is
  why the knob exists rather than a hard-coded choice.
- Zero gameplay/worldgen determinism change (checksums above).