### PR TITLE
fix: Pick the correct item when block and item IDs differ

### DIFF
--- a/steel-core/src/behavior/block/mod.rs
+++ b/steel-core/src/behavior/block/mod.rs
@@ -571,9 +571,9 @@ pub trait BlockBehavior: Send + Sync {
 
     /// Returns the item stack to give when a player picks this block (middle click).
     ///
-    /// The default implementation looks up an item with the same key as the block.
-    /// Override this for blocks where the pick item differs from the block key
-    /// (e.g., crops → seeds, redstone wire → redstone dust, wall torch → torch).
+    /// The default implementation uses the block's registered item association.
+    /// Blocks without an associated item return an empty stack. Override this when
+    /// Vanilla selects the clone item from block state, block entity data, or another rule.
     ///
     /// # Arguments
     /// * `block` - The block being picked
@@ -589,8 +589,7 @@ pub trait BlockBehavior: Send + Sync {
         state: BlockStateId,
         include_data: bool,
     ) -> Option<ItemStack> {
-        // Default: look up item by block's key
-        REGISTRY.items.by_key(&block.key).map(ItemStack::new)
+        Some(ItemStack::new(REGISTRY.items.by_block(block)))
     }
 
     /// Returns whether this block state is pathfindable for the supplied vanilla path computation.

--- a/steel-core/src/behavior/block/tests.rs
+++ b/steel-core/src/behavior/block/tests.rs
@@ -7,6 +7,40 @@ use steel_registry::blocks::properties::{BlockStateProperties, SlabType};
 use steel_registry::init_vanilla_registry;
 use steel_registry::sound_events;
 use steel_registry::vanilla_blocks;
+use steel_registry::vanilla_items;
+
+use crate::behavior::init_behaviors;
+
+#[test]
+fn clone_item_stack_uses_registered_block_item_association() {
+    init_vanilla_registry();
+    init_behaviors();
+
+    for (block, expected_item) in [
+        (&vanilla_blocks::REDSTONE_WIRE, &*vanilla_items::REDSTONE),
+        (&vanilla_blocks::WALL_TORCH, &*vanilla_items::TORCH),
+        (
+            &vanilla_blocks::BIG_DRIPLEAF_STEM,
+            &*vanilla_items::BIG_DRIPLEAF,
+        ),
+    ] {
+        let clone_item = BLOCK_BEHAVIORS
+            .get_behavior(block)
+            .get_clone_item_stack(block, block.default_state(), false)
+            .map(|stack| stack.item());
+
+        assert_eq!(clone_item, Some(expected_item));
+    }
+
+    let block = &vanilla_blocks::FIRE;
+    let clone_item = BLOCK_BEHAVIORS.get_behavior(block).get_clone_item_stack(
+        block,
+        block.default_state(),
+        false,
+    );
+
+    assert!(clone_item.is_some_and(|stack| stack.is_empty()));
+}
 
 #[test]
 fn drained_waterlogged_state_clears_waterlogged_property() {


### PR DESCRIPTION
## Type of change

- [x] Bug fix

## Description

Fixes #501.

The default pick-block behavior looked for an item with the same registry key as the block. This failed for mappings such as redstone wire to redstone and wall torch to torch.

Use the registered block-to-item association instead, matching Minecraft 26.2 behavior. Blocks without an associated item still produce an empty stack. Existing block-specific overrides remain unchanged.

Regression coverage includes redstone wire, wall torch, big dripleaf stem, and fire.

## How this was tested

Manually ran the Fabric client GameTest against a local Steel 26.2 server. Redstone wire, wall torch, big dripleaf stem, repeater, and fire all behaved as expected.

## Screenshots / logs

```text
Fabric client GameTest: BUILD SUCCESSFUL

redstone_wire      -> redstone
wall_torch         -> torch
big_dripleaf_stem  -> big_dripleaf
repeater           -> repeater
fire               -> no inventory change
```

## Checklist

- [x] Code builds w/o errors or warnings
- [x] Self-reviewed the diff
- [x] Docs updated (if applicable)
- [x] No leftover debug code / comments

## Classes modified:

N/A. This changes shared block behavior rather than a tracked block class.

## Additional notes

Regenerated `minecraft-src` with `update-minecraft-src.sh` and verified the clean Minecraft 26.2 source checkout at `55bb6f05`.
