### PR TITLE
fix: Correct dispenser and dropper placement orientation

### DIFF
--- a/steel-core/src/behavior/blocks/container/dispenser_block.rs
+++ b/steel-core/src/behavior/blocks/container/dispenser_block.rs
@@ -1,0 +1,35 @@
+//! Dispenser block placement behavior.
+
+use steel_macros::block_behavior;
+use steel_registry::blocks::BlockRef;
+use steel_registry::blocks::block_state_ext::BlockStateExt as _;
+use steel_registry::blocks::properties::{BlockStateProperties, Direction, EnumProperty};
+use steel_utils::BlockStateId;
+
+use crate::behavior::{BlockBehavior, BlockPlaceContext};
+
+const FACING: &EnumProperty<Direction> = &BlockStateProperties::FACING;
+
+/// Vanilla dispenser placement behavior.
+#[block_behavior]
+pub struct DispenserBlock {
+    block: BlockRef,
+}
+
+impl DispenserBlock {
+    /// Creates dispenser behavior for `block`.
+    #[must_use]
+    pub const fn new(block: BlockRef) -> Self {
+        Self { block }
+    }
+}
+
+impl BlockBehavior for DispenserBlock {
+    fn get_state_for_placement(&self, context: &BlockPlaceContext<'_>) -> Option<BlockStateId> {
+        Some(
+            self.block
+                .default_state()
+                .set_value(FACING, context.get_nearest_looking_direction().opposite()),
+        )
+    }
+}

--- a/steel-core/src/behavior/blocks/container/dropper_block.rs
+++ b/steel-core/src/behavior/blocks/container/dropper_block.rs
@@ -1,0 +1,35 @@
+//! Dropper block placement behavior.
+
+use steel_macros::block_behavior;
+use steel_registry::blocks::BlockRef;
+use steel_registry::blocks::block_state_ext::BlockStateExt as _;
+use steel_registry::blocks::properties::{BlockStateProperties, Direction, EnumProperty};
+use steel_utils::BlockStateId;
+
+use crate::behavior::{BlockBehavior, BlockPlaceContext};
+
+const FACING: &EnumProperty<Direction> = &BlockStateProperties::FACING;
+
+/// Vanilla dropper placement behavior.
+#[block_behavior]
+pub struct DropperBlock {
+    block: BlockRef,
+}
+
+impl DropperBlock {
+    /// Creates dropper behavior for `block`.
+    #[must_use]
+    pub const fn new(block: BlockRef) -> Self {
+        Self { block }
+    }
+}
+
+impl BlockBehavior for DropperBlock {
+    fn get_state_for_placement(&self, context: &BlockPlaceContext<'_>) -> Option<BlockStateId> {
+        Some(
+            self.block
+                .default_state()
+                .set_value(FACING, context.get_nearest_looking_direction().opposite()),
+        )
+    }
+}

--- a/steel-core/src/behavior/blocks/container/mod.rs
+++ b/steel-core/src/behavior/blocks/container/mod.rs
@@ -3,9 +3,16 @@ mod barrel_block;
 mod beehive_block;
 mod chiseled_bookshelf_block;
 mod crafting_table_block;
+mod dispenser_block;
+mod dropper_block;
+
+#[cfg(test)]
+mod placement_tests;
 
 pub use anvil_block::AnvilBlock;
 pub use barrel_block::BarrelBlock;
 pub use beehive_block::BeehiveBlock;
 pub use chiseled_bookshelf_block::ChiseledBookShelfBlock;
 pub use crafting_table_block::CraftingTableBlock;
+pub use dispenser_block::DispenserBlock;
+pub use dropper_block::DropperBlock;

--- a/steel-core/src/behavior/blocks/container/placement_tests.rs
+++ b/steel-core/src/behavior/blocks/container/placement_tests.rs
@@ -1,0 +1,64 @@
+use glam::DVec3;
+use steel_registry::blocks::BlockRef;
+use steel_registry::blocks::block_state_ext::BlockStateExt as _;
+use steel_registry::blocks::properties::{BlockStateProperties, Direction, EnumProperty};
+use steel_registry::item_stack::ItemStack;
+use steel_registry::{init_vanilla_registry, vanilla_blocks, vanilla_items};
+use steel_utils::BlockPos;
+use steel_utils::types::InteractionHand;
+
+use crate::behavior::{
+    BLOCK_BEHAVIORS, BlockHitResult, BlockPlaceContext, PlacementOrientation, PlacementSource,
+    init_behaviors,
+};
+use crate::test_support::test_world;
+
+const FACING: &EnumProperty<Direction> = &BlockStateProperties::FACING;
+
+fn assert_faces_away_from_player_look(block: BlockRef) {
+    let behavior = BLOCK_BEHAVIORS.get_behavior(block);
+
+    for look_direction in Direction::ALL {
+        let rotation = look_direction.to_yaw();
+        let pitch = match look_direction {
+            Direction::Down => 90.0,
+            Direction::Up => -90.0,
+            _ => 0.0,
+        };
+        let mut stack = ItemStack::new(&vanilla_items::STONE);
+        let source = PlacementSource::direct(
+            None,
+            InteractionHand::MainHand,
+            &mut stack,
+            PlacementOrientation::Player { rotation, pitch },
+            false,
+        );
+        let context = BlockPlaceContext::new(
+            test_world(),
+            source,
+            &BlockHitResult {
+                location: DVec3::ZERO,
+                direction: Direction::East,
+                block_pos: BlockPos::ZERO,
+                miss: false,
+                inside: false,
+                world_border_hit: false,
+            },
+        );
+        let state = behavior
+            .get_state_for_placement(&context)
+            .expect("dispenser-family placement should produce a state");
+
+        assert_eq!(state.get_block(), block);
+        assert_eq!(state.get_value(FACING), look_direction.opposite());
+    }
+}
+
+#[test]
+fn dispenser_and_dropper_face_away_from_player_look() {
+    init_vanilla_registry();
+    init_behaviors();
+
+    assert_faces_away_from_player_look(&vanilla_blocks::DISPENSER);
+    assert_faces_away_from_player_look(&vanilla_blocks::DROPPER);
+}

--- a/steel-core/src/behavior/blocks/mod.rs
+++ b/steel-core/src/behavior/blocks/mod.rs
@@ -29,6 +29,7 @@ pub use building::{
 pub use colored::StainedGlassPaneBlock;
 pub use container::{
     AnvilBlock, BarrelBlock, BeehiveBlock, ChiseledBookShelfBlock, CraftingTableBlock,
+    DispenserBlock, DropperBlock,
 };
 pub use decoration::{
     BannerBlock, CakeBlock, CandleBlock, CandleCakeBlock, CeilingHangingSignBlock, ChainBlock,


### PR DESCRIPTION
## Type of change

- [x] Block implementation
- [x] Bug fix

## Description

Dispenser and dropper placement used `DefaultBlockBehavior`, leaving both blocks facing north regardless of player orientation.

This adds exact-class behaviors matching Minecraft 26.2. Placed dispensers and droppers now face opposite the player's nearest look direction.

## How this was tested

- Compared against generated Minecraft 26.2 source.
- Tested both blocks across all six look directions.
- Fabric client GameTest passed all 12 placements using real client look/use input.

## Screenshots / logs

Fabric client GameTest completed with `BUILD SUCCESSFUL`.

## Checklist

- [x] Code builds w/o errors or warnings
- [x] Self-reviewed the diff
- [x] Docs updated (if applicable)
- [x] No leftover debug code / comments

## Classes modified:

- DispenserBlock
- DropperBlock

## Additional notes

This change is unaffected by the planned loot-table overhaul. It only selects the block state used during placement and does not touch loot generation, inventories, block entities, redstone activation, or dispensing behavior.

Steel registers behaviors by exact Java class name, so `DropperBlock` needs its own Rust behavior even though vanilla inherits placement behavior from `DispenserBlock`.
