### PR TITLE
fix: prevent swords from breaking blocks in creative (#534)

### DIFF
--- a/steel-core/src/player/game_mode/block_breaking.rs
+++ b/steel-core/src/player/game_mode/block_breaking.rs
@@ -342,8 +342,10 @@ impl BlockBreakingManager {
     fn destroy_block(&self, player: &Player, world: &Arc<World>, pos: BlockPos) -> bool {
         let state = world.get_block_state(pos);
 
-        // Check if player's tool can destroy this block
-        // TODO: Implement canDestroyBlock check for adventure mode
+        // Vanilla `ServerPlayerGameMode.destroyBlock` / `Item.canDestroyBlock`.
+        if !held_item_can_destroy_block(player) {
+            return false;
+        }
 
         // Get block info
         let Some(_block) = REGISTRY.blocks.by_state_id(state) else {
@@ -470,6 +472,20 @@ pub enum BlockBreakAction {
     Stop,
     /// Player aborted breaking a block.
     Abort,
+}
+
+/// Vanilla `Item.canDestroyBlock` default implementation.
+///
+/// Tools with `can_destroy_blocks_in_creative = false` cannot destroy blocks
+/// while the player has instabuild (creative).
+fn held_item_can_destroy_block(player: &Player) -> bool {
+    let can_destroy_in_creative = {
+        let inventory = player.inventory.lock();
+        inventory
+            .get_item_in_hand(InteractionHand::MainHand)
+            .can_destroy_blocks_in_creative()
+    };
+    can_destroy_in_creative || !player.abilities.lock().instabuild
 }
 
 /// Checks if a block state is air.

--- a/steel-core/src/player/tests.rs
+++ b/steel-core/src/player/tests.rs
@@ -1367,3 +1367,57 @@ fn block_action_restriction_precedes_redstone_ore_attack() {
             .get_value(&BlockStateProperties::LIT)
     );
 }
+
+#[test]
+fn creative_sword_does_not_destroy_blocks() {
+    init_vanilla_registry();
+    init_behaviors();
+    let world = fresh_test_world("creative_sword_block_break");
+    let pos = BlockPos::new(1, 64, 0);
+    insert_ready_full_chunk(&world, ChunkPos::from_block_pos(pos));
+    let stone = vanilla_blocks::STONE.default_state();
+    assert!(world.set_block(pos, stone, UpdateFlags::UPDATE_ALL));
+
+    let player = test_player(Arc::clone(&world));
+    player.base.set_position_local(DVec3::new(1.0, 64.0, 0.0));
+    player.restore_game_modes(GameType::Creative, None);
+    player
+        .abilities
+        .lock()
+        .update_for_game_mode(GameType::Creative);
+    player
+        .inventory
+        .lock()
+        .set_selected_item(ItemStack::new(&vanilla_items::WOODEN_SWORD));
+
+    player.block_breaking.lock().handle_block_break_action(
+        &player,
+        &world,
+        pos,
+        BlockBreakAction::Start,
+        Direction::Up,
+    );
+
+    assert_eq!(
+        world.get_block_state(pos),
+        stone,
+        "swords must not destroy blocks in creative"
+    );
+
+    player
+        .inventory
+        .lock()
+        .set_selected_item(ItemStack::new(&vanilla_items::DIAMOND_PICKAXE));
+    player.block_breaking.lock().handle_block_break_action(
+        &player,
+        &world,
+        pos,
+        BlockBreakAction::Start,
+        Direction::Up,
+    );
+
+    assert!(
+        world.get_block_state(pos).is_air(),
+        "creative mining with a pickaxe must still destroy the block"
+    );
+}


### PR DESCRIPTION
## Type of change

- [ ] Block implementation
- [ ] Item implementation
- [ ] Command implementation
- [ ] Entity implementation
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [ ] Performance improvement
- [ ] Chore / tooling

## Description

Fixes #534.

Vanilla `ServerPlayerGameMode.destroyBlock` rejects creative-mode destruction when the held item's tool component has `can_destroy_blocks_in_creative = false` (swords, maces). Steel already had `ItemStack::can_destroy_blocks_in_creative()`, but `destroy_block` never checked it, so a single creative click with any sword removed the block.

This applies the vanilla `Item.canDestroyBlock` default: if the held tool forbids creative destruction and the player has instabuild, return false and resync the client. Pickaxes and other tools that allow creative mining still insta-break.

## How this was tested

- `cargo test -p steel-core --lib player::tests::creative_sword_does_not_destroy_blocks -- --exact`
- `cargo test -p steel-core --lib player::tests::block_action_restriction_precedes_redstone_ore_attack -- --exact`

The new test places stone, switches to creative, holds a wooden sword, and asserts the block remains after `StartDestroyBlock`. It then switches to a diamond pickaxe and asserts the block is destroyed.

## Screenshots / logs

N/A

## Checklist

- [x] Code builds w/o errors or warnings
- [x] Self-reviewed the diff
- [x] Docs updated (if applicable)
- [x] No leftover debug code / comments

## Classes modified:

- `ServerPlayerGameMode`

## Additional notes

Item-specific `canDestroyBlock` overrides (debug stick) are still unimplemented; this only covers the default tool-component check.