### PR TITLE
perf: demote audited movement and menu packets to narrower execution lanes

### DIFF
--- a/steel-core/src/player/connection/java.rs
+++ b/steel-core/src/player/connection/java.rs
@@ -194,14 +194,21 @@ impl ScheduledPlayPacket {
                     ScheduledPacketExecution::Exclusive
                 }
             },
-            // Position, world, menu, chat, and domain mutations may overlap player-local work but
-            // retain one global mutation order matching the packet submission order.
+            // Movement handlers mutate only per-player movement/teleport state (SyncMutex)
+            // and route through chunk-map ticket APIs with fine-grained internal locks, so
+            // they may run fully concurrent across players.
+            ScheduledPlayPacketKind::MovePlayer(_) | ScheduledPlayPacketKind::MoveVehicle(_) => {
+                ScheduledPacketExecution::PlayerLocal
+            }
+            // Chat and domain mutations may overlap player-local work but retain one global
+            // mutation order matching the packet submission order. Menu transactions (click,
+            // button, slot state) serialize on the menu lock exactly like ContainerClick.
             ScheduledPlayPacketKind::AcceptTeleportation(_)
             | ScheduledPlayPacketKind::Chat(_)
             | ScheduledPlayPacketKind::ChatAck(_)
-            | ScheduledPlayPacketKind::MovePlayer(_)
-            | ScheduledPlayPacketKind::MoveVehicle(_)
             | ScheduledPlayPacketKind::ContainerClick(_)
+            | ScheduledPlayPacketKind::ContainerButtonClick(_)
+            | ScheduledPlayPacketKind::ContainerSlotStateChanged(_)
             | ScheduledPlayPacketKind::RenameItem(_)
             | ScheduledPlayPacketKind::UseItemOn(_)
             | ScheduledPlayPacketKind::UseItem(_)
@@ -209,15 +216,11 @@ impl ScheduledPlayPacket {
             | ScheduledPlayPacketKind::SpectatorAction(_)
             | ScheduledPlayPacketKind::ChangeGameMode(_)
             | ScheduledPlayPacketKind::ChangeDifficulty(_) => ScheduledPacketExecution::Serialized,
-            // Combat spans source and target state, custom payloads have no constrained resource
-            // contract, and the unimplemented menu handlers have no auditable transaction yet.
+            // Combat spans source and target state, and custom payloads have no constrained
+            // resource contract: full global barriers.
             ScheduledPlayPacketKind::Attack(_)
             | ScheduledPlayPacketKind::Interact(_)
-            | ScheduledPlayPacketKind::CustomPayload(_)
-            | ScheduledPlayPacketKind::ContainerButtonClick(_)
-            | ScheduledPlayPacketKind::ContainerSlotStateChanged(_) => {
-                ScheduledPacketExecution::Exclusive
-            }
+            | ScheduledPlayPacketKind::CustomPayload(_) => ScheduledPacketExecution::Exclusive,
         }
     }
 
@@ -968,6 +971,8 @@ impl NetworkConnection for JavaConnection {
 mod tests {
     use std::array;
 
+    use glam::DVec3;
+
     use crate::{
         entity::{Entity as _, LivingEntity as _},
         test_support::{TestPlayerBuilder, fresh_test_world},
@@ -1117,7 +1122,7 @@ mod tests {
             execution(ScheduledPlayPacketKind::MovePlayer(
                 SMovePlayerStatusOnly { packed_byte: 0 }.into(),
             )),
-            ScheduledPacketExecution::Serialized
+            ScheduledPacketExecution::PlayerLocal
         );
     }
 
@@ -1234,18 +1239,18 @@ mod tests {
     }
 
     #[test]
-    fn cross_player_and_unimplemented_handlers_remain_global_barriers() {
+    fn cross_player_handlers_remain_global_barriers() {
         assert_eq!(
             execution(ScheduledPlayPacketKind::Attack(SAttack { entity_id: 1 })),
             ScheduledPacketExecution::Exclusive
         );
         assert_eq!(
-            execution(ScheduledPlayPacketKind::ContainerButtonClick(
-                SContainerButtonClick {
-                    container_id: 1,
-                    button_id: 0,
-                },
-            )),
+            execution(ScheduledPlayPacketKind::Interact(SInteract {
+                entity_id: 1,
+                hand: InteractionHand::MainHand,
+                location: DVec3::ZERO,
+                using_secondary_action: false,
+            })),
             ScheduledPacketExecution::Exclusive
         );
         assert_eq!(
@@ -1256,6 +1261,42 @@ mod tests {
                 sequence: 0,
             })),
             ScheduledPacketExecution::Exclusive
+        );
+    }
+
+    #[test]
+    fn menu_transactions_share_the_serialized_lane() {
+        let click = SContainerClick {
+            container_id: 0,
+            state_id: 0,
+            slot_num: 0,
+            button_num: 0,
+            click_type: ClickType::Pickup,
+            changed_slots: FxHashMap::default(),
+            carried_item: HashedStack::Empty,
+        };
+        assert_eq!(
+            execution(ScheduledPlayPacketKind::ContainerClick(click)),
+            ScheduledPacketExecution::Serialized
+        );
+        assert_eq!(
+            execution(ScheduledPlayPacketKind::ContainerButtonClick(
+                SContainerButtonClick {
+                    container_id: 1,
+                    button_id: 0,
+                },
+            )),
+            ScheduledPacketExecution::Serialized
+        );
+        assert_eq!(
+            execution(ScheduledPlayPacketKind::ContainerSlotStateChanged(
+                SContainerSlotStateChanged {
+                    slot_id: 0,
+                    container_id: 0,
+                    new_state: true,
+                },
+            )),
+            ScheduledPacketExecution::Serialized
         );
     }
 


### PR DESCRIPTION
## Type of change

- [ ] Block implementation
- [ ] Item implementation
- [ ] Command implementation
- [ ] Entity implementation
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / code cleanup
- [x] Performance improvement

## Description

Concurrency audit of the scheduled packet lanes (see per-handler notes in `ScheduledPlayPacketKind::execution`):

- **MovePlayer / MoveVehicle → PlayerLocal** (was `Serialized`). The handlers mutate only per-player movement and teleport state behind `SyncMutex` and route through chunk-map ticket APIs with fine-grained internal locks; collision lookups are read-only. This takes the hottest packet path off the global serialized lane.
- **ContainerButtonClick / ContainerSlotStateChanged → Serialized** (was `Exclusive`). Menu transactions serialize on the menu lock exactly like `ContainerClick`, so the full global barrier was unnecessarily wide.
- **Attack, Interact, CustomPayload, PlayerAction::ReleaseUseItem remain Exclusive**: combat spans independently locked source and target state; custom payloads have no constrained resource contract.

The `ScheduledPacketExecution` doc comment documents the per-lane safety invariants.

## How this was tested

- Classification tests updated: `packet_execution_classification_separates_local_and_serialized_work` now asserts MovePlayer = PlayerLocal; new `menu_transactions_share_the_serialized_lane` asserts Click/ButtonClick/SlotStateChanged = Serialized; `cross_player_handlers_remain_global_barriers` (renamed) asserts Attack/Interact/ReleaseUseItem = Exclusive.
- `cargo test -p steel-core --lib` (2423 tests) pass; `cargo clippy -r --all-targets` clean.

## Screenshots / logs

N/A.

## Checklist

- [x] Code builds w/o errors or warnings
- [x] Self-reviewed the diff
- [ ] Docs updated (if applicable) — N/A
- [x] No leftover debug code / comments

## Additional notes

- Contingency from the audit plan: if profiling surfaces unexpected contention on chunk-map tickets under MovePlayer concurrency, MovePlayer can fall back to `Serialized` while keeping the menu demotions.
- Env: Linux, Rust nightly, Minecraft protocol 776 (0.15.2+mc26.2).
